### PR TITLE
Add latest voters to list of recommended electors.

### DIFF
--- a/lib/election.js
+++ b/lib/election.js
@@ -21,6 +21,9 @@ require('./config');
 
 jsigs.use('jsonld', brDidClient.jsonld);
 
+// maximum number of electors if not specified in the ledger configuration
+const MAX_ELECTOR_COUNT = 10;
+
 // module API
 const api = {};
 module.exports = api;
@@ -48,20 +51,7 @@ api._recommendElectors = _recommendElectors;
  */
 api.getBlockElectors = (ledgerNode, blockHeight, callback) => {
   async.auto({
-    config: callback =>
-      ledgerNode.storage.events.getLatestConfig((err, result) => {
-      if(err) {
-        return callback(err);
-      }
-      const config = result.event.input[0];
-      if(config.consensusMethod !== 'Continuity2017') {
-        return callback(new BedrockError(
-          'Consensus method must be "Continuity2017".', 'InvalidStateError', {
-            consensusMethod: config.consensusMethod
-          }));
-      }
-      callback(null, config);
-    }),
+    config: callback => _getLatestConfig(ledgerNode, callback),
     latestBlock: callback =>
       ledgerNode.storage.blocks.getLatest((err, result) => {
         if(err) {
@@ -105,9 +95,10 @@ api.getBlockElectors = (ledgerNode, blockHeight, callback) => {
       });
       electors = Object.keys(aggregate).map(k => aggregate[k]);
 
-      // get elector count, defaulting to 10 if not set (hardcoded, all nodes
-      // must do the same thing -- but ideally this would *always* be set)
-      const electorCount = results.config.electorCount || 10;
+      // get elector count, defaulting to MAX_ELECTOR_COUNT if not set
+      // (hardcoded, all nodes must do the same thing -- but ideally this would
+      // *always* be set)
+      const electorCount = results.config.electorCount || MAX_ELECTOR_COUNT;
 
       // compute super majority requirement
       const twoThirds = _twoThirdsMajority(previousVotes.length);
@@ -421,32 +412,51 @@ function _createEventManifest(ledgerNode, blockHeight, callback) {
  *          completes.
  */
 function _recommendElectors(ledgerNode, voter, electors, manifest, callback) {
-  // TODO: use given parameters and blockchain to determine a set of
-  // electors to recommend for the next block
+  // TODO: determine if a better deterministic algorithm (better == more secure,
+  // performant) could be used here that uses given parameters and blockchain
+  // data to recommend electors for the next block
 
-  // FIXME: include all current electors (should filter this by those
-  //   that voted in the last election so we don't recommend those that
-  //   aren't participating)
-  let recommendedElectors = electors.map(elector => ({id: elector.id}));
+  let recommendedElectors = [];
 
   // TODO: implement option to add all nodes that sent in events to the
   // previous block to the elector pool that can be contacted
 
   async.auto({
+    config: callback => _getLatestConfig(ledgerNode, callback),
     latestBlock: callback => ledgerNode.storage.blocks.getLatest(callback),
-    getEventPeers: ['latestBlock', (results, callback) => {
+    latestVoters: ['latestBlock', (results, callback) => {
+      // there may not be an event block yet
+      const voters =
+        _.get(results, 'latestBlock.eventBlock.block.electionResults', [])
+          .map(v => v.voter);
+      recommendedElectors.push(...voters);
+      callback();
+    }],
+    eventPeers: ['latestVoters', (results, callback) => {
       if(!results.latestBlock.eventBlock.block) {
         return callback(null, []);
       }
       const events = results.latestBlock.eventBlock.block.event || [];
-      // TODO: _getEventPeers returns an array...
       async.map(events, _getEventPeers.bind(null, ledgerNode), callback);
     }],
-    addEventPeers: ['getEventPeers', (results, callback) => {
-      const eventPeers = [].concat(...results.getEventPeers);
+    addElectors: ['config', 'eventPeers', (results, callback) => {
+      // add event peers
+      const eventPeers = [].concat(...results.eventPeers);
       recommendedElectors.push(...eventPeers);
+
+      // add previous electors
+      recommendedElectors.push(...electors.map(elector => ({id: elector.id})));
+
+      // remove duplicates from the list of electors
       recommendedElectors = _.uniqWith(
         recommendedElectors, (a, b) => a.id === b.id);
+
+      // restrict the number of electors
+      // get elector count, defaulting to MAX_ELECTOR_COUNT if not set
+      // (hardcoded, all nodes must do the same thing -- but ideally this would
+      // *always* be set)
+      const electorCount = results.config.electorCount || MAX_ELECTOR_COUNT;
+      recommendedElectors.splice(electorCount - 1);
       callback();
     }]
   }, err => callback(err, recommendedElectors));
@@ -875,6 +885,26 @@ function _createVote(ledgerNode, electionTopic, vote, voter, callback) {
       callback(err, results.sign);
     })]
   }, (err, results) => err ? callback(err) : callback(null, results.store));
+}
+
+function _getLatestConfig(ledgerNode, callback) {
+  ledgerNode.storage.events.getLatestConfig((err, result) => {
+    if(err) {
+      return callback(err);
+    }
+    // `getLatestConfig` returns an empty object before genesis block is written
+    if(_.isEmpty(result)) {
+      return callback(null, {});
+    }
+    const config = result.event.input[0];
+    if(config.consensusMethod !== 'Continuity2017') {
+      return callback(new BedrockError(
+        'Consensus method must be "Continuity2017".', 'InvalidStateError', {
+          consensusMethod: config.consensusMethod
+        }));
+    }
+    callback(null, config);
+  });
 }
 
 function _unique(array) {


### PR DESCRIPTION
Fixes #23.

Note, that the `_recommendElectors` function is used in the basic API tests, but it is overridden in the multiNode test.