### PR TITLE
Send votes to peer.

### DIFF
--- a/lib/client.js
+++ b/lib/client.js
@@ -3,8 +3,10 @@
  *
  * Copyright (c) 2017 Digital Bazaar, Inc. All rights reserved.
  */
+const async = require('async');
 const bedrock = require('bedrock');
 const config = bedrock.config;
+const election = require('./election');
 // NOTE: request.defaults not used here so that request can be stubbed
 const request = require('request');
 const validate = require('bedrock-validation').validate;
@@ -56,25 +58,45 @@ api.getBlockStatus = (blockHeight, peer, callback) => {
 api.getManifest = (manifestHash, peer, callback) => {
   const url = peer + '/manifests?id=' +
     encodeURIComponent(manifestHash);
-  request.get({url, strictSSL, json: true}, (err, res) => {
-    if(err) {
-      return callback(new BedrockError(
-        'Could not get manifest.', 'NetworkError', {manifestHash, peer}, err));
-    }
-    if(res.statusCode !== 200) {
-      return callback(new BedrockError(
-        'Could not get manifest.',
-        res.statusCode === 404 ? 'NotFoundError' : 'NetworkError', {
-          httpStatusCode: res.statusCode,
-          public: true,
-          manifestHash,
-          peer,
-          error: res.body,
-        }));
-    }
-    // TODO: validate manifest
-    callback(null, res.body);
-  });
+  async.auto({
+    get: callback => request.get({url, strictSSL, json: true}, (err, res) => {
+      if(err) {
+        return callback(new BedrockError(
+          'Could not get manifest.', 'NetworkError',
+          {manifestHash, peer}, err));
+      }
+      if(res.statusCode !== 200) {
+        return callback(new BedrockError(
+          'Could not get manifest.',
+          res.statusCode === 404 ? 'NotFoundError' : 'NetworkError', {
+            httpStatusCode: res.statusCode,
+            public: true,
+            manifestHash,
+            peer,
+            error: res.body,
+          }));
+      }
+      callback(null, res.body);
+    }),
+    validate: ['get', (results, callback) =>
+      validate('continuity.manifest', results.get, callback)],
+    validateHash: ['validate', (results, callback) => {
+      const manifest = results.get;
+      const expectedHash = election.createManifestHash(manifest.item);
+      if(manifest.id !== manifestHash) {
+        return callback(new BedrockError(
+          'The hash contained in the manifest is invalid.',
+          'ValidationError', {
+            httpStatusCode: 400,
+            public: true,
+            expectedHash,
+            manifest,
+            peer,
+          }));
+      }
+      callback();
+    }]
+  }, (err, results) => err ? callback(err) : callback(err, results.get));
 };
 
 api.sendEvent = (event, peer, callback) => {
@@ -96,6 +118,28 @@ api.sendEvent = (event, peer, callback) => {
         }));
     }
     callback(null, res.headers.location);
+  });
+};
+
+api.sendManifest = (manifest, peer, callback) => {
+  const url = peer + '/manifests';
+  request.post({url, strictSSL, json: manifest}, (err, res) => {
+    if(err) {
+      return callback(new BedrockError(
+        'Could not send manifest.', 'NetworkError', {manifest, peer}, err));
+    }
+    if(res.statusCode !== 200) {
+      return callback(new BedrockError(
+        'Could not send manifest.',
+        'NetworkError', {
+          httpStatusCode: res.statusCode,
+          public: true,
+          manifest,
+          peer,
+          error: res.body,
+        }));
+    }
+    callback();
   });
 };
 

--- a/lib/client.js
+++ b/lib/client.js
@@ -106,14 +106,16 @@ api.sendVote = (vote, peer, callback) => {
       return callback(new BedrockError(
         'Could not send vote.', 'NetworkError', {vote, peer}, err));
     }
+    // TODO: should the server return success or 409 on duplicate?
     if(res.statusCode !== 201) {
       return callback(new BedrockError(
         'Could not send vote.',
         'NetworkError', {
           httpStatusCode: res.statusCode,
           vote,
-          peer
-        }, typeof res.body === 'object' || new Error(res.body)));
+          peer,
+          error: res.body,
+        }));
     }
     callback(null, res.headers.location);
   });

--- a/lib/client.js
+++ b/lib/client.js
@@ -99,6 +99,26 @@ api.sendEvent = (event, peer, callback) => {
   });
 };
 
+api.sendVote = (vote, peer, callback) => {
+  const url = peer + '/votes';
+  request.post({url, strictSSL, json: vote}, (err, res) => {
+    if(err) {
+      return callback(new BedrockError(
+        'Could not send vote.', 'NetworkError', {vote, peer}, err));
+    }
+    if(res.statusCode !== 201) {
+      return callback(new BedrockError(
+        'Could not send vote.',
+        'NetworkError', {
+          httpStatusCode: res.statusCode,
+          vote,
+          peer
+        }, typeof res.body === 'object' || new Error(res.body)));
+    }
+    callback(null, res.headers.location);
+  });
+};
+
 api.getEvent = (eventHash, peer, callback) => {
   const url = peer + '/events?id=' +
     encodeURIComponent(eventHash);

--- a/lib/client.js
+++ b/lib/client.js
@@ -99,25 +99,24 @@ api.sendEvent = (event, peer, callback) => {
   });
 };
 
-api.sendVote = (vote, peer, callback) => {
-  const url = peer + '/votes';
-  request.post({url, strictSSL, json: vote}, (err, res) => {
+api.sendVote = (voteRecord, peer, callback) => {
+  const url = peer + '/votes/' + voteRecord.topic;
+  request.post({url, strictSSL, json: voteRecord.vote}, (err, res) => {
     if(err) {
       return callback(new BedrockError(
-        'Could not send vote.', 'NetworkError', {vote, peer}, err));
+        'Could not send vote.', 'NetworkError', {voteRecord, peer}, err));
     }
-    // TODO: should the server return success or 409 on duplicate?
-    if(res.statusCode !== 201) {
+    if(res.statusCode !== 200) {
       return callback(new BedrockError(
         'Could not send vote.',
         'NetworkError', {
           httpStatusCode: res.statusCode,
-          vote,
+          voteRecord,
           peer,
           error: res.body,
         }));
     }
-    callback(null, res.headers.location);
+    callback();
   });
 };
 

--- a/lib/config.js
+++ b/lib/config.js
@@ -11,7 +11,7 @@ cfg.routes.root = '/consensus/continuity2017/voters/:voterId';
 cfg.routes.blockStatus = cfg.routes.root + '/blocks/:blockHeight/status';
 cfg.routes.events = cfg.routes.root + '/events';
 cfg.routes.manifests = cfg.routes.root + '/manifests';
-cfg.routes.votes = cfg.routes.root + '/votes';
+cfg.routes.votes = cfg.routes.root + '/votes/:voteTopic';
 
 cfg.keyParameters = {
   RSA: {

--- a/lib/config.js
+++ b/lib/config.js
@@ -11,6 +11,7 @@ cfg.routes.root = '/consensus/continuity2017/voters/:voterId';
 cfg.routes.blockStatus = cfg.routes.root + '/blocks/:blockHeight/status';
 cfg.routes.events = cfg.routes.root + '/events';
 cfg.routes.manifests = cfg.routes.root + '/manifests';
+cfg.routes.votes = cfg.routes.root + '/votes';
 
 cfg.keyParameters = {
   RSA: {

--- a/lib/election.js
+++ b/lib/election.js
@@ -777,7 +777,7 @@ function _selectInstantRunoffRollCallManifest(
 
       if(tallies.length > 0) {
         // still no single tally has won, select by manifest hash
-        tallies.sort((a, b) => a.localeCompare(b));
+        tallies.sort((a, b) => a.manifestHash.localeCompare(b.manifestHash));
       }
 
       callback(null, tallies[0].manifestHash);

--- a/lib/election.js
+++ b/lib/election.js
@@ -256,17 +256,20 @@ api.certify = (ledgerNode, electionTopic, votes, callback) => {
   async.auto({
     config: callback => _getLatestConfig(ledgerNode, callback),
     certify: ['config', (results, callback) => {
-      const maxElectorCount = results.config.electorCount || MAX_ELECTOR_COUNT;
-      if(votes.length > maxElectorCount) {
-        return callback(new BedrockError(
-          'The vote count exceeds the maximum number of electors.',
-          'ValidationError', {
-            electionTopic,
-            votes,
-            voteCount: votes.length,
-            maxElectorCount,
-          }));
-      }
+
+      // FIXME: it appears to be normal for votes from all `voteRound` to be
+      // included here, so this check needs to be done somewhere else.
+      // const maxElectorCount = results.config.electorCount || MAX_ELECTOR_COUNT;
+      // if(votes.length > maxElectorCount) {
+      //   return callback(new BedrockError(
+      //     'The vote count exceeds the maximum number of electors.',
+      //     'ValidationError', {
+      //       electionTopic,
+      //       votes,
+      //       voteCount: votes.length,
+      //       maxElectorCount,
+      //     }));
+      // }
       async.each(votes, (voteRecord, callback) => {
         async.auto({
           voteExists: callback => api._storage.votes.exists(

--- a/lib/election.js
+++ b/lib/election.js
@@ -47,13 +47,13 @@ api.createManifestHash = items =>
   niUri.digest('sha-256', items.join('\n'), true);
 
 /**
- * Check if a manifest has the required majority vote.
+ * Check if a  RollCall manifest has the required number of votes.
  *
  * @param manifest the manifest to check.
  * @param ledgerNode the ledgerNode that is tracking the manifest.
  * @param callback(err) called once the operation is complete.
  */
-api.checkMajority = (manifest, ledgerNode, callback) => {
+api.validateRollCallManifest = (manifest, ledgerNode, callback) => {
   const blockHeight = manifest.blockHeight;
   const manifestItemCount = manifest.item.length;
 
@@ -851,8 +851,14 @@ function _getManifestFromPeer(
     },
     manifest: callback => api._client.getManifest(
       manifestHash, peerId, callback),
-    checkMajority: ['manifest', (results, callback) =>
-      api.checkMajority(results.manifest, ledgerNode, callback)],
+    checkMajority: ['manifest', (results, callback) => {
+      const manifest = results.manifest;
+      if(manifest.type !== 'RollCall') {
+        return callback();
+      }
+      // ensure that RollCall manifest contains the required number of votes
+      api.validateRollCallManifest(manifest, ledgerNode, callback);
+    }],
     sync: ['hashes', 'checkMajority', (results, callback) => {
       if(type === 'Events') {
         const peerEvents = results.manifest.item;

--- a/lib/election.js
+++ b/lib/election.js
@@ -222,24 +222,22 @@ api.certify = (ledgerNode, electionTopic, votes, callback) => {
       }
       async.each(votes, (vote, callback) => {
         async.auto({
-          voteHash: callback => api._hasher(vote, callback),
-          voteExists: ['voteHash', (results, callback) =>
-            api._storage.votes.exists(ledgerNode.id, results.voteHash, callback)
-          ],
+          voteExists: callback => api._storage.votes.exists(
+            ledgerNode.id, vote.meta.voteHash, callback),
           verify: ['voteExists', (results, callback) => {
             if(results.voteExists === true) {
               // vote already exists, do not need to verify or store again
               return callback();
             }
-            _verifyVote(ledgerNode, vote, electionTopic, err => {
+            _verifyVote(ledgerNode, vote.vote, electionTopic, err => {
               if(err) {
                 // ignore failed votes, do not store them
                 logger.verbose('Non-critical error in _verifyVote.', err);
                 return callback();
               }
               api._storage.votes.add(
-                ledgerNode.id, electionTopic, vote, {
-                  meta: {voteHash: results.voteHash}
+                ledgerNode.id, electionTopic, vote.vote, {
+                  meta: {voteHash: vote.meta.voteHash}
                 }, err => {
                   if(err && err.name === 'DuplicateError') {
                     // this vote has already been added, via another process,

--- a/lib/election.js
+++ b/lib/election.js
@@ -895,17 +895,24 @@ function _getManifestFromPeer(
       // type === 'RollCall', we already have the events votes from the peer
       // in the database, so we just have to make sure that those listed in the
       // manifest also exist in our database or else the manifest is bogus
-      api._storage.votes.exists(ledgerNode.id, manifest.item, (err, result) => {
-        if(err) {
-          return callback(err);
-        }
-        if(result === false) {
-          return callback(new BedrockError(
-            'Some votes in the manifest could not be validated.',
-            'ValidationError', {manifest}));
-        }
-        callback();
-      });
+
+      // FIXME: this check is getting called as votes are being stored by way:
+      // election.js#L282 `api.certify`
+      // election.js#L823 `_verifyVote`
+      // and because the votes have not been saved yet, the `exists` check fails
+
+      // api._storage.votes.exists(ledgerNode.id, manifest.item, (err, result) => {
+      //   if(err) {
+      //     return callback(err);
+      //   }
+      //   if(result === false) {
+      //     return callback(new BedrockError(
+      //       'Some votes in the manifest could not be validated.',
+      //       'ValidationError', {manifest}));
+      //   }
+      //   callback();
+      // });
+      callback();
     }],
     store: ['validate', (results, callback) => {
       if(type === 'Events' &&

--- a/lib/election.js
+++ b/lib/election.js
@@ -37,11 +37,22 @@ api._createEventManifest = _createEventManifest;
 api._getManifest = _getManifest;
 api._recommendElectors = _recommendElectors;
 
-// TODO: add documentation
+/**
+ * Create a hash of a manifest.
+ *
+ * @param items the items in the manifest.
+ * @returns hash the hash of the items.
+ */
 api.createManifestHash = items =>
   niUri.digest('sha-256', items.join('\n'), true);
 
-// TODO: add documentation
+/**
+ * Check if a manifest has the required majority vote.
+ *
+ * @param manifest the manifest to check.
+ * @param ledgerNode the ledgerNode that is tracking the manifest.
+ * @param callback(err) called once the operation is complete.
+ */
 api.checkMajority = (manifest, ledgerNode, callback) => {
   const blockHeight = manifest.blockHeight;
   const manifestItemCount = manifest.item.length;

--- a/lib/election.js
+++ b/lib/election.js
@@ -37,6 +37,30 @@ api._createEventManifest = _createEventManifest;
 api._getManifest = _getManifest;
 api._recommendElectors = _recommendElectors;
 
+// TODO: add documentation
+api.createManifestHash = items =>
+  niUri.digest('sha-256', items.join('\n'), true);
+
+// TODO: add documentation
+api.checkMajority = (manifest, ledgerNode, callback) => {
+  const blockHeight = manifest.blockHeight;
+  const manifestItemCount = manifest.item.length;
+
+  // TODO: consider passing electors through to optimize away this look up
+  api.getBlockElectors(ledgerNode, blockHeight, (err, result) => {
+    if(err) {
+      return callback(err);
+    }
+    const twoThirds = _twoThirdsMajority(result.length);
+    if(manifestItemCount < twoThirds) {
+      return callback(new BedrockError(
+        'The manifest does not contain the required two-thirds majority.',
+        'ValidationError', {manifest, manifestItemCount, twoThirds}));
+    }
+    callback();
+  });
+};
+
 /**
  * Get the voter population for the given ledger node and block height.
  *
@@ -816,25 +840,8 @@ function _getManifestFromPeer(
     },
     manifest: callback => api._client.getManifest(
       manifestHash, peerId, callback),
-    checkMajority: ['manifest', (results, callback) => {
-      const manifest = results.manifest;
-      const blockHeight = manifest.blockHeight;
-      const manifestItemCount = manifest.item.length;
-
-      // TODO: consider passing electors through to optimize away this look up
-      api.getBlockElectors(ledgerNode, blockHeight, (err, result) => {
-        if(err) {
-          return callback(err);
-        }
-        const twoThirds = _twoThirdsMajority(result.length);
-        if(manifestItemCount < twoThirds) {
-          return callback(new BedrockError(
-            'The manifest does not contain the required two-thirds majority.',
-            'ValidationError', {manifest, manifestItemCount, twoThirds}));
-        }
-        callback();
-      });
-    }],
+    checkMajority: ['manifest', (results, callback) =>
+      api.checkMajority(results.manifest, ledgerNode, callback)],
     sync: ['hashes', 'checkMajority', (results, callback) => {
       if(type === 'Events') {
         const peerEvents = results.manifest.item;
@@ -909,9 +916,8 @@ function _getEventFromPeer(ledgerNode, peerId, eventHash, callback) {
 
 function _createManifest(ledgerNodeId, blockHeight, type, items, callback) {
   // create manifest hash (EOL delimited) and store manifest
-  const hash = niUri.digest('sha-256', items.join('\n'), true);
   const manifest = {
-    id: hash,
+    id: api.createManifestHash(items),
     type: type,
     blockHeight: blockHeight,
     item: items

--- a/lib/election.js
+++ b/lib/election.js
@@ -57,11 +57,7 @@ api.validateRollCallManifest = (manifest, ledgerNode, callback) => {
   if(manifest.type !== 'RollCall') {
     return callback(new BedrockError(
       'The manifest `type` must be `RollCall`',
-      'DataError', {
-        httpStatusCode: 400,
-        public: true,
-        manifest,
-      }));
+      'DataError', {httpStatusCode: 400, public: true, manifest}));
   }
 
   const blockHeight = manifest.blockHeight;

--- a/lib/election.js
+++ b/lib/election.js
@@ -54,6 +54,16 @@ api.createManifestHash = items =>
  * @param callback(err) called once the operation is complete.
  */
 api.validateRollCallManifest = (manifest, ledgerNode, callback) => {
+  if(manifest.type !== 'RollCall') {
+    return callback(new BedrockError(
+      'The manifest `type` must be `RollCall`',
+      'DataError', {
+        httpStatusCode: 400,
+        public: true,
+        manifest,
+      }));
+  }
+
   const blockHeight = manifest.blockHeight;
   const manifestItemCount = manifest.item.length;
 
@@ -66,7 +76,13 @@ api.validateRollCallManifest = (manifest, ledgerNode, callback) => {
     if(manifestItemCount < twoThirds) {
       return callback(new BedrockError(
         'The manifest does not contain the required two-thirds majority.',
-        'ValidationError', {manifest, manifestItemCount, twoThirds}));
+        'ValidationError', {
+          httpStatusCode: 400,
+          public: true,
+          manifest,
+          manifestItemCount,
+          twoThirds,
+        }));
     }
     callback();
   });

--- a/lib/election.js
+++ b/lib/election.js
@@ -220,24 +220,24 @@ api.certify = (ledgerNode, electionTopic, votes, callback) => {
             maxElectorCount,
           }));
       }
-      async.each(votes, (vote, callback) => {
+      async.each(votes, (voteRecord, callback) => {
         async.auto({
           voteExists: callback => api._storage.votes.exists(
-            ledgerNode.id, vote.meta.voteHash, callback),
+            ledgerNode.id, voteRecord.meta.voteHash, callback),
           verify: ['voteExists', (results, callback) => {
             if(results.voteExists === true) {
               // vote already exists, do not need to verify or store again
               return callback();
             }
-            _verifyVote(ledgerNode, vote.vote, electionTopic, err => {
+            _verifyVote(ledgerNode, voteRecord.vote, electionTopic, err => {
               if(err) {
                 // ignore failed votes, do not store them
                 logger.verbose('Non-critical error in _verifyVote.', err);
                 return callback();
               }
               api._storage.votes.add(
-                ledgerNode.id, electionTopic, vote.vote, {
-                  meta: {voteHash: vote.meta.voteHash}
+                ledgerNode.id, electionTopic, voteRecord.vote, {
+                  meta: {voteHash: voteRecord.meta.voteHash}
                 }, err => {
                   if(err && err.name === 'DuplicateError') {
                     // this vote has already been added, via another process,

--- a/lib/manifestStorage.js
+++ b/lib/manifestStorage.js
@@ -81,6 +81,22 @@ api.add = (ledgerNodeId, manifest, callback) => {
   });
 };
 
+// TODO: add documentation
+api.exists = (ledgerNodeId, manifestHash, callback) => {
+  const query = {
+    ledgerNodeId: database.hash(ledgerNodeId),
+    'manifest.id': manifestHash,
+    'meta.deleted': {$exists: false},
+  };
+  const collection = database.collections.continuity2017_manifest;
+  collection.find(query).count((err, result) => {
+    if(err) {
+      return callback(err);
+    }
+    return callback(null, !!result);
+  });
+};
+
 /**
  * Gets a manifest by the given manifest ID (hash).
  *

--- a/lib/manifestStorage.js
+++ b/lib/manifestStorage.js
@@ -81,7 +81,13 @@ api.add = (ledgerNodeId, manifest, callback) => {
   });
 };
 
-// TODO: add documentation
+/**
+ * Check if a manifest with the given hash exists.
+ *
+ * @param ledgerNodeId the ID of the ledgerNode that is tracking the manifest.
+ * @param manifestHash the hash of the manifest to check.
+ * @param callback(err, result) called once the operation is complete.
+ */
 api.exists = (ledgerNodeId, manifestHash, callback) => {
   const query = {
     ledgerNodeId: database.hash(ledgerNodeId),

--- a/lib/server.js
+++ b/lib/server.js
@@ -316,8 +316,14 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
               }
               callback();
             })],
-        checkMajority: ['checkExists', (results, callback) =>
-          election.checkMajority(manifest, results.ledgerNode, callback)],
+        checkMajority: ['checkExists', (results, callback) => {
+          if(manifest.type !== 'RollCall') {
+            return callback();
+          }
+          // ensure that RollCall manifest contains the required number of votes
+          election.validateRollCallManifest(
+            manifest, results.ledgerNode, callback);
+        }],
         checkItems: ['checkMajority', (results, callback) => {
           // FIXME: is it necessary to check items if the type is `Events`?
           if(manifest.type === 'RollCall') {
@@ -329,7 +335,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
                 if(!result) {
                   return callback(new BedrockError(
                     'Unknown votes enumerated in the manifest.',
-                    'DataError', {manifest, httpStatus: 404, public: true}));
+                    'DataError', {manifest, httpStatus: 400, public: true}));
                 }
                 return callback();
               });

--- a/lib/server.js
+++ b/lib/server.js
@@ -290,6 +290,8 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
   });
 
   // Add a new manifest
+  let success = 0;
+  let duplicate = 0;
   app.post(
     routes.manifests, brRest.when.prefers.ld, validate('continuity.manifest'),
     (req, res, next) => {
@@ -298,7 +300,8 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       const manifest = req.body;
       // it is safe to assume we have all the events, just store manifest
       // TODO: do a quick existence check on manifest?
-      console.log('ZZZZZZZZ receiving posted manifest', manifest.id);
+      const voterSlug = req.params.voterId.substring(24);
+      console.log(`${voterSlug} receiving posted manifest: ${manifest.id}`);
       return async.auto({
         validateHash: callback => _validateManifestHash(manifest, callback),
         voter: ['validateHash', (results, callback) =>
@@ -327,9 +330,11 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
         }],
         store: ['checkItems', (results, callback) =>
           storage.manifests.add(results.ledgerNode.id, manifest, err => {
-            console.log(
-              results.ledgerNode.id, ' storing POSTED manifest, error:', err.name);
+            if(!err) {
+              console.log(`${voterSlug} Manifest store no error: ${success++}`);
+            }
             if(err && err.name === 'DuplicateError') {
+              console.log(`${voterSlug} Duplicate Manifest ${duplicate++}`);
               // ignore duplicate manifest entries; they only mean that
               // another process has already added the same manifest
               err = null;

--- a/lib/server.js
+++ b/lib/server.js
@@ -10,13 +10,12 @@ const bedrock = require('bedrock');
 const brRest = require('bedrock-rest');
 const config = require('bedrock').config;
 const brLedger = require('bedrock-ledger-node');
-const cors = require('cors');
+// const cors = require('cors');
 const database = require('bedrock-mongodb');
 const docs = require('bedrock-docs');
 const election = require('./election');
 const url = require('url');
 const validate = require('bedrock-validation').validate;
-
 const BedrockError = bedrock.util.BedrockError;
 
 require('bedrock-express');
@@ -25,9 +24,6 @@ require('bedrock-permission');
 require('./config');
 
 const storage = require('./storage');
-
-let success = 0;
-let fail = 0;
 
 // module API
 const api = {};
@@ -177,7 +173,6 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       const voterId = config.server.baseUri +
         '/consensus/continuity2017/voters/' + req.params.voterId;
       const eventHash = req.query.id;
-
       async.auto({
         getVoter: callback => storage.voters.get({voterId}, callback),
         getLedgerNode: ['getVoter', (results, callback) =>
@@ -209,32 +204,32 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
   app.post(
     routes.events, brRest.when.prefers.ld, validate('continuity.event'),
     (req, res, next) => {
-    const voterId = config.server.baseUri +
-      '/consensus/continuity2017/voters/' + req.params.voterId;
-    async.auto({
-      getVoter: callback => storage.voters.get({voterId}, callback),
-      getLedgerNode: ['getVoter', (results, callback) =>
-        brLedger.get(null, results.getVoter.ledgerNodeId, callback)],
-      addEvent: ['getLedgerNode', (results, callback) =>
-        results.getLedgerNode.events.add(req.body, {
-          continuity2017: {peer: true}
-        }, callback)]
-    }, (err, results) => {
-      if(err) {
-        return next(err);
-      }
-      const eventUrl = url.format({
-        protocol: 'https',
-        host: config.server.host,
-        pathname: url.parse(req.url).pathname,
-        query: {
-          id: results.addEvent.meta.eventHash
+      const voterId = config.server.baseUri +
+        '/consensus/continuity2017/voters/' + req.params.voterId;
+      async.auto({
+        getVoter: callback => storage.voters.get({voterId}, callback),
+        getLedgerNode: ['getVoter', (results, callback) =>
+          brLedger.get(null, results.getVoter.ledgerNodeId, callback)],
+        addEvent: ['getLedgerNode', (results, callback) =>
+          results.getLedgerNode.events.add(req.body, {
+            continuity2017: {peer: true}
+          }, callback)]
+      }, (err, results) => {
+        if(err) {
+          return next(err);
         }
+        const eventUrl = url.format({
+          protocol: 'https',
+          host: config.server.host,
+          pathname: url.parse(req.url).pathname,
+          query: {
+            id: results.addEvent.meta.eventHash
+          }
+        });
+        res.location(eventUrl);
+        res.status(201).end();
       });
-      res.location(eventUrl);
-      res.status(201).end();
     });
-  });
   docs.annotate.post(routes.events, {
     description: 'Request that a Ledger Agent append a new event to a ledger',
     schema: 'services.ledger.postLedgerEvent',
@@ -250,55 +245,48 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
 
   // Add a new vote
   // TODO: validate event
-  app.post(routes.votes, brRest.when.prefers.ld, (req, res, next) => {
-    const voterId = config.server.baseUri +
-      '/consensus/continuity2017/voters/' + req.params.voterId;
-    // console.log('*************', JSON.stringify(req.body, null, 2));
-    async.auto({
-      voteHash: callback => brLedger.consensus._hasher(req.body.vote, callback),
-      voter: callback => storage.voters.get({voterId}, callback),
-      ledgerNode: ['voter', (results, callback) =>
-        brLedger.get(null, results.voter.ledgerNodeId, callback)],
-      addVote: ['voteHash', 'ledgerNode', (results, callback) =>
-        storage.votes.add(
-          results.ledgerNode.id, req.body.topic, req.body.vote, {
+  app.post(
+    routes.votes, brRest.when.prefers.ld, validate('continuity.vote'),
+    (req, res, next) => {
+      const voterId = config.server.baseUri +
+        '/consensus/continuity2017/voters/' + req.params.voterId;
+      const supportedVoteTopics = ['Events', 'RollCall'];
+      const voteTopic = req.params.voteTopic;
+      if(!supportedVoteTopics.includes(voteTopic)) {
+        return next(new BedrockError(
+          'Unsupported vote topic.', 'NotSupportedError', {
+            httpStatusCode: 400,
+            public: true,
+            voteTopic,
+            supportedVoteTopics,
+          }));
+      }
+      async.auto({
+        voteHash: callback =>
+          brLedger.consensus._hasher(req.body, callback),
+        voter: callback => storage.voters.get({voterId}, callback),
+        ledgerNode: ['voter', (results, callback) =>
+          brLedger.get(null, results.voter.ledgerNodeId, callback)],
+        addVote: ['voteHash', 'ledgerNode', (results, callback) =>
+          storage.votes.add(results.ledgerNode.id, voteTopic, req.body, {
             meta: {voteHash: results.voteHash}
           }, callback)]
-    }, (err, results) => {
-      if(err && !(database.isDuplicateError(err) ||
-        err.name === 'DuplicateError')) {
-        return next(err);
-      }
-      // TODO: report success or status 409 duplicate?
-      // FIXME remove, logging purposes only
-      // if(err && err && (database.isDuplicateError(err) ||
-      //   err.name === 'DuplicateError')) {
-      //   console.log('DuplicateError', fail++);
-      // } else {
-      //   console.log('Success', success++);
-      // }
-      // const eventUrl = url.format({
-      //   protocol: 'https',
-      //   host: config.server.host,
-      //   pathname: url.parse(req.url).pathname,
-      //   query: {
-      //     id: results.addEvent.meta.eventHash
-      //   }
-      // });
-      // res.location(eventUrl);
-      res.status(201).end();
+      }, err => {
+        if(err && !(database.isDuplicateError(err) ||
+          err.name === 'DuplicateError')) {
+          return next(err);
+        }
+        res.status(200).end();
+      });
     });
-  });
   docs.annotate.post(routes.votes, {
     description: 'Add a new vote',
     schema: 'services.ledger.postLedgerVote',
     securedBy: ['null'],
     responses: {
-      201: 'Event was accepted for writing. HTTP Location header ' +
+      200: 'Vote was accepted for writing. HTTP Location header ' +
         'contains URL of accepted event.',
       400: 'Request failed due to malformed request.',
-      403: 'Request failed due to invalid digital signature',
-      409: 'Request failed due to duplicate information.'
     }
   });
 });

--- a/lib/server.js
+++ b/lib/server.js
@@ -325,7 +325,20 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
             manifest, results.ledgerNode, callback);
         }],
         checkItems: ['checkMajority', (results, callback) => {
-          // FIXME: is it necessary to check items if the type is `Events`?
+          if(manifest.type === 'Events') {
+            return results.ledgerNode.storage.events.exists(
+              manifest.item, (err, result) => {
+                if(err) {
+                  return callback(err);
+                }
+                if(!result) {
+                  return callback(new BedrockError(
+                    'Unknown events enumerated in the manifest.',
+                    'DataError', {manifest, httpStatus: 400, public: true}));
+                }
+                return callback();
+              });
+          }
           if(manifest.type === 'RollCall') {
             return storage.votes.exists(
               results.ledgerNode.id, manifest.item, (err, result) => {

--- a/lib/server.js
+++ b/lib/server.js
@@ -308,7 +308,21 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
           storage.voters.get({voterId}, callback)],
         ledgerNode: ['voter', (results, callback) =>
           brLedger.get(null, results.voter.ledgerNodeId, callback)],
-        checkMajority: ['ledgerNode', (results, callback) =>
+        checkExists: ['ledgerNode', (results, callback) =>
+          storage.manifests.exists(
+            results.ledgerNode.id, manifest.id, (err, result) => {
+              if(err) {
+                return callback(err);
+              }
+              if(result) {
+                return callback(new BedrockError(
+                  'The manifest already exists.', 'DuplicateError', {
+                    manifest: manifest.id
+                  }, err));
+              }
+              callback();
+            })],
+        checkMajority: ['checkExists', (results, callback) =>
           election.checkMajority(manifest, results.ledgerNode, callback)],
         checkItems: ['checkMajority', (results, callback) => {
           // FIXME: is it necessary to check items if the type is `Events`?
@@ -329,19 +343,17 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
           callback();
         }],
         store: ['checkItems', (results, callback) =>
-          storage.manifests.add(results.ledgerNode.id, manifest, err => {
-            if(!err) {
-              console.log(`${voterSlug} Manifest store no error: ${success++}`);
-            }
-            if(err && err.name === 'DuplicateError') {
-              console.log(`${voterSlug} Duplicate Manifest ${duplicate++}`);
-              // ignore duplicate manifest entries; they only mean that
-              // another process has already added the same manifest
-              err = null;
-            }
-            callback(err);
-          })]
+          storage.manifests.add(results.ledgerNode.id, manifest, callback)]
       }, err => {
+        if(!err) {
+          console.log(`${voterSlug} Manifest store no error: ${success++}`);
+        }
+        if(err && err.name === 'DuplicateError') {
+          console.log(`${voterSlug} Duplicate Manifest ${duplicate++}`);
+          // ignore duplicate manifest entries; they only mean that
+          // another process has already added the same manifest
+          err = null;
+        }
         if(err) {
           console.log('ERROR IN POST', err);
           return next(err);

--- a/lib/server.js
+++ b/lib/server.js
@@ -298,7 +298,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       const manifest = req.body;
       // it is safe to assume we have all the events, just store manifest
       // TODO: do a quick existence check on manifest?
-      console.log('ZZZZZZZZ receiving posted manifest', manifest);
+      console.log('ZZZZZZZZ receiving posted manifest', manifest.id);
       return async.auto({
         validateHash: callback => _validateManifestHash(manifest, callback),
         voter: ['validateHash', (results, callback) =>
@@ -327,16 +327,18 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
         }],
         store: ['checkItems', (results, callback) =>
           storage.manifests.add(results.ledgerNode.id, manifest, err => {
+            console.log(
+              results.ledgerNode.id, ' storing POSTED manifest, error:', err.name);
             if(err && err.name === 'DuplicateError') {
               // ignore duplicate manifest entries; they only mean that
               // another process has already added the same manifest
               err = null;
             }
-            console.log('stored POSTED manifest, error', err);
             callback(err);
           })]
       }, err => {
         if(err) {
+          console.log('ERROR IN POST', err);
           return next(err);
         }
         res.status(200).end();

--- a/lib/server.js
+++ b/lib/server.js
@@ -232,7 +232,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
     });
   docs.annotate.post(routes.events, {
     description: 'Request that a Ledger Agent append a new event to a ledger',
-    schema: 'services.ledger.postLedgerEvent',
+    schema: 'continuity.event',
     securedBy: ['null'],
     responses: {
       201: 'Event was accepted for writing. HTTP Location header ' +
@@ -280,7 +280,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
     });
   docs.annotate.post(routes.votes, {
     description: 'Add a new vote',
-    schema: 'services.ledger.postLedgerVote',
+    schema: 'continuity.vote',
     securedBy: ['null'],
     responses: {
       200: 'Vote was accepted for writing. HTTP Location header ' +
@@ -290,15 +290,12 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
   });
 
   // Add a new manifest
-  let success = 0;
-  let duplicate = 0;
   app.post(
     routes.manifests, brRest.when.prefers.ld, validate('continuity.manifest'),
     (req, res, next) => {
       const voterId = config.server.baseUri +
         '/consensus/continuity2017/voters/' + req.params.voterId;
       const manifest = req.body;
-      // it is safe to assume we have all the events, just store manifest
       return async.auto({
         validateHash: callback => _validateManifestHash(manifest, callback),
         voter: ['validateHash', (results, callback) =>
@@ -354,12 +351,11 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       });
     });
   docs.annotate.post(routes.votes, {
-    description: 'Add a new vote',
-    schema: 'services.ledger.postLedgerVote',
+    description: 'Add a new manifest',
+    schema: 'continuity.manifest',
     securedBy: ['null'],
     responses: {
-      200: 'Vote was accepted for writing. HTTP Location header ' +
-        'contains URL of accepted event.',
+      200: 'Manifest was accepted.',
       400: 'Request failed due to malformed request.',
     }
   });

--- a/lib/server.js
+++ b/lib/server.js
@@ -25,6 +25,9 @@ require('./config');
 
 const storage = require('./storage');
 
+let success = 0;
+let fail = 0;
+
 // module API
 const api = {};
 module.exports = api;
@@ -234,6 +237,53 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
   docs.annotate.post(routes.events, {
     description: 'Request that a Ledger Agent append a new event to a ledger',
     schema: 'services.ledger.postLedgerEvent',
+    securedBy: ['null'],
+    responses: {
+      201: 'Event was accepted for writing. HTTP Location header ' +
+        'contains URL of accepted event.',
+      400: 'Request failed due to malformed request.',
+      403: 'Request failed due to invalid digital signature',
+      409: 'Request failed due to duplicate information.'
+    }
+  });
+
+  // Add a new vote
+  // TODO: validate event
+  app.post(routes.votes, brRest.when.prefers.ld, (req, res, next) => {
+    const voterId = config.server.baseUri +
+      '/consensus/continuity2017/voters/' + req.params.voterId;
+    // console.log('*************', JSON.stringify(req.body, null, 2));
+    async.auto({
+      voteHash: callback => brLedger.consensus._hasher(req.body.vote, callback),
+      voter: callback => storage.voters.get({voterId}, callback),
+      ledgerNode: ['voter', (results, callback) =>
+        brLedger.get(null, results.voter.ledgerNodeId, callback)],
+      addVote: ['voteHash', 'ledgerNode', (results, callback) =>
+        storage.votes.add(
+          results.ledgerNode.id, req.body.topic, req.body.vote, {
+            meta: {voteHash: results.voteHash}
+          }, callback)]
+    }, (err, results) => {
+      if(err) {
+        console.log('Fail', fail++);
+        return next(err);
+      }
+      console.log('Success', success++);
+      // const eventUrl = url.format({
+      //   protocol: 'https',
+      //   host: config.server.host,
+      //   pathname: url.parse(req.url).pathname,
+      //   query: {
+      //     id: results.addEvent.meta.eventHash
+      //   }
+      // });
+      // res.location(eventUrl);
+      res.status(201).end();
+    });
+  });
+  docs.annotate.post(routes.votes, {
+    description: 'Add a new vote',
+    schema: 'services.ledger.postLedgerVote',
     securedBy: ['null'],
     responses: {
       201: 'Event was accepted for writing. HTTP Location header ' +

--- a/lib/server.js
+++ b/lib/server.js
@@ -11,6 +11,7 @@ const brRest = require('bedrock-rest');
 const config = require('bedrock').config;
 const brLedger = require('bedrock-ledger-node');
 const cors = require('cors');
+const database = require('bedrock-mongodb');
 const docs = require('bedrock-docs');
 const election = require('./election');
 const url = require('url');
@@ -264,11 +265,18 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
             meta: {voteHash: results.voteHash}
           }, callback)]
     }, (err, results) => {
-      if(err) {
-        console.log('Fail', fail++);
+      if(err && !(database.isDuplicateError(err) ||
+        err.name === 'DuplicateError')) {
         return next(err);
       }
-      console.log('Success', success++);
+      // TODO: report success or status 409 duplicate?
+      // FIXME remove, logging purposes only
+      // if(err && err && (database.isDuplicateError(err) ||
+      //   err.name === 'DuplicateError')) {
+      //   console.log('DuplicateError', fail++);
+      // } else {
+      //   console.log('Success', success++);
+      // }
       // const eventUrl = url.format({
       //   protocol: 'https',
       //   host: config.server.host,

--- a/lib/server.js
+++ b/lib/server.js
@@ -299,9 +299,6 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
         '/consensus/continuity2017/voters/' + req.params.voterId;
       const manifest = req.body;
       // it is safe to assume we have all the events, just store manifest
-      // TODO: do a quick existence check on manifest?
-      const voterSlug = req.params.voterId.substring(24);
-      console.log(`${voterSlug} receiving posted manifest: ${manifest.id}`);
       return async.auto({
         validateHash: callback => _validateManifestHash(manifest, callback),
         voter: ['validateHash', (results, callback) =>
@@ -345,17 +342,12 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
         store: ['checkItems', (results, callback) =>
           storage.manifests.add(results.ledgerNode.id, manifest, callback)]
       }, err => {
-        if(!err) {
-          console.log(`${voterSlug} Manifest store no error: ${success++}`);
-        }
         if(err && err.name === 'DuplicateError') {
-          console.log(`${voterSlug} Duplicate Manifest ${duplicate++}`);
           // ignore duplicate manifest entries; they only mean that
           // another process has already added the same manifest
           err = null;
         }
         if(err) {
-          console.log('ERROR IN POST', err);
           return next(err);
         }
         res.status(200).end();

--- a/lib/server.js
+++ b/lib/server.js
@@ -244,7 +244,6 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
   });
 
   // Add a new vote
-  // TODO: validate event
   app.post(
     routes.votes, brRest.when.prefers.ld, validate('continuity.vote'),
     (req, res, next) => {
@@ -274,6 +273,70 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       }, err => {
         if(err && !(database.isDuplicateError(err) ||
           err.name === 'DuplicateError')) {
+          return next(err);
+        }
+        res.status(200).end();
+      });
+    });
+  docs.annotate.post(routes.votes, {
+    description: 'Add a new vote',
+    schema: 'services.ledger.postLedgerVote',
+    securedBy: ['null'],
+    responses: {
+      200: 'Vote was accepted for writing. HTTP Location header ' +
+        'contains URL of accepted event.',
+      400: 'Request failed due to malformed request.',
+    }
+  });
+
+  // Add a new manifest
+  app.post(
+    routes.manifests, brRest.when.prefers.ld, validate('continuity.manifest'),
+    (req, res, next) => {
+      const voterId = config.server.baseUri +
+        '/consensus/continuity2017/voters/' + req.params.voterId;
+      const manifest = req.body;
+      // it is safe to assume we have all the events, just store manifest
+      // TODO: do a quick existence check on manifest?
+      console.log('ZZZZZZZZ receiving posted manifest', manifest);
+      return async.auto({
+        validateHash: callback => _validateManifestHash(manifest, callback),
+        voter: ['validateHash', (results, callback) =>
+          storage.voters.get({voterId}, callback)],
+        ledgerNode: ['voter', (results, callback) =>
+          brLedger.get(null, results.voter.ledgerNodeId, callback)],
+        checkMajority: ['ledgerNode', (results, callback) =>
+          election.checkMajority(manifest, results.ledgerNode, callback)],
+        checkItems: ['checkMajority', (results, callback) => {
+          // FIXME: is it necessary to check items if the type is `Events`?
+          if(manifest.type === 'RollCall') {
+            return storage.votes.exists(
+              results.ledgerNode.id, manifest.item, (err, result) => {
+                if(err) {
+                  return callback(err);
+                }
+                if(!result) {
+                  return callback(new BedrockError(
+                    'Unknown votes enumerated in the manifest.',
+                    'DataError', {manifest, httpStatus: 404, public: true}));
+                }
+                return callback();
+              });
+          }
+          callback();
+        }],
+        store: ['checkItems', (results, callback) =>
+          storage.manifests.add(results.ledgerNode.id, manifest, err => {
+            if(err && err.name === 'DuplicateError') {
+              // ignore duplicate manifest entries; they only mean that
+              // another process has already added the same manifest
+              err = null;
+            }
+            console.log('stored POSTED manifest, error', err);
+            callback(err);
+          })]
+      }, err => {
+        if(err) {
           return next(err);
         }
         res.status(200).end();
@@ -408,4 +471,19 @@ function _createBlockStatus(blockHeight, ledgerNode, voter, callback) {
 
 function _hasVoted(voter, votes) {
   return votes.some(v => v.voter === voter.id);
+}
+
+function _validateManifestHash(manifest, callback) {
+  const expectedHash = election.createManifestHash(manifest.item);
+  if(manifest.id !== expectedHash) {
+    return callback(new BedrockError(
+      'The hash contained in the manifest is invalid.',
+      'ValidationError', {
+        httpStatusCode: 400,
+        public: true,
+        expectedHash,
+        manifest,
+      }));
+  }
+  callback();
 }

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -370,16 +370,25 @@ function _rebuildVote(vote, callback) {
 function _syncVotes(options, callback) {
   // process vote topic serially: Events then RollCall
   async.eachSeries(options.election, (e, callback) => {
-    const voteHashes = e.electionResults.map(vote => vote.meta.voteHash);
+    const voteHashes = e.electionResults.map(v => v.meta.voteHash);
+    const manifestHashes = _.uniq(e.electionResults.map(v =>
+      v.vote.manifestHash));
     async.auto({
       votes: callback => api._votes.get(
         options.ledgerNodeId, options.blockHeight, e.topic, callback),
-      send: ['votes', (results, callback) => {
+      sendVotes: ['votes', (results, callback) => {
         const toSend = results.votes
           .filter(v => !voteHashes.includes(v.meta.voteHash))
           .map(v => ({topic: e.topic, vote: v.vote}));
         async.each(toSend, (vote, callback) =>
           api._client.sendVote(vote, options.peerId, callback), callback);
+      }],
+      sendManifests: ['votes', (results, callback) => {
+        const toSend = results.votes
+          .filter(v => !manifestHashes.includes(v.vote.manifestHash))
+          .map(v => ({topic: e.topic, manifestHash: v.vote.manifestHash}));
+        // TODO: send manifest
+        callback();
       }]
     }, callback);
   }, callback);

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -315,23 +315,24 @@ function _gossipWith(ledgerNode, voter, blockHeight, peer, callback) {
 
       // election results should be in the proper order: Events, RollCall
       status.election.sort((a, b) => a.topic.localeCompare(b.topic));
-      return async.parallel([
-        callback => _syncVotes({
+      return async.auto({
+        validate: callback =>
+          validate('continuity.election', status.election, callback),
+        rebuildVotes: ['validate', (results, callback) =>
+          async.each(status.election, (e, callback) =>
+            async.each(e.electionResults, _rebuildVote, callback), callback)],
+        sync: ['rebuildVotes', (results, callback) => _syncVotes({
           election: status.election,
           ledgerNodeId: ledgerNode.id,
           peerId: peer.id,
           blockHeight,
-        }, callback),
-        callback => async.series([
-          callback =>
-            validate('continuity.election', status.election, callback),
-          callback =>
-            async.eachSeries(status.election, (election, callback) => {
-              api._election.certify(
-                ledgerNode, election.topic, election.electionResults, callback);
-            }, callback)
-        ], callback)
-      ], callback);
+        }, callback)],
+        certify: ['rebuildVotes', (results, callback) =>
+          async.eachSeries(status.election, (election, callback) =>
+            api._election.certify(
+              ledgerNode, election.topic, election.electionResults, callback)
+          , callback)]
+      }, err => callback(err));
     }
 
     return callback(new BedrockError(
@@ -341,18 +342,36 @@ function _gossipWith(ledgerNode, voter, blockHeight, peer, callback) {
   });
 }
 
+// NOTE: mutates vote
+// FIXME: is there a better way? Simply adding `vote.meta` to store the hash
+// seems inappropriate because the vote is signed.
+function _rebuildVote(vote, callback) {
+  api._hasher(vote, (err, voteHash) => {
+    if(err) {
+      return callback(err);
+    }
+    const newVote = {};
+    Object.keys(vote).forEach(k => {
+      newVote[k] = vote[k];
+      delete vote[k];
+    });
+    vote.vote = newVote;
+    vote.meta = {voteHash},
+    callback();
+  });
+}
+
 function _syncVotes(options, callback) {
   async.each(options.election, (e, callback) => {
+    const voteHashes = e.electionResults.map(vote => vote.meta.voteHash);
     async.auto({
-      hashes: callback => async.map(e.electionResults, api._hasher, callback),
       votes: callback => api._votes.get(
         options.ledgerNodeId, options.blockHeight, e.topic, callback),
-      send: ['hashes', 'votes', (results, callback) => {
+      send: ['votes', (results, callback) => {
         const toSend = results.votes
-          .filter(v => !results.hashes.includes(v.meta.voteHash))
-          // FIXME: add context
+          .filter(v => !voteHashes.includes(v.meta.voteHash))
+          // FIXME: add context?
           .map(v => ({topic: e.topic, vote: v.vote}));
-        // console.log('VVVVVVVVVVVV', toSend);
         async.each(toSend, (vote, callback) =>
           api._client.sendVote(vote, options.peerId, callback), callback);
       }]

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -172,7 +172,6 @@ function _runElection(
       if(condition()) {
         return nextElector();
       }
-
       async.auto({
         // 2. Gossip with a single elector.
         gossip: callback => _gossipWith(

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -312,16 +312,25 @@ function _gossipWith(ledgerNode, voter, blockHeight, peer, callback) {
     //   'consensus' phases.
     if(['decideEvents', 'decideRollCall', 'consensus'].includes(
       status.consensusPhase)) {
-      // TODO: send votes we know about to peer to optimize
 
       // election results should be in the proper order: Events, RollCall
       status.election.sort((a, b) => a.topic.localeCompare(b.topic));
-      return async.series([
-        callback => validate('continuity.election', status.election, callback),
-        callback => async.eachSeries(status.election, (election, callback) => {
-          api._election.certify(
-            ledgerNode, election.topic, election.electionResults, callback);
-        }, callback)
+      return async.parallel([
+        callback => _syncVotes({
+          election: status.election,
+          ledgerNodeId: ledgerNode.id,
+          peerId: peer.id,
+          blockHeight,
+        }, callback),
+        callback => async.series([
+          callback =>
+            validate('continuity.election', status.election, callback),
+          callback =>
+            async.eachSeries(status.election, (election, callback) => {
+              api._election.certify(
+                ledgerNode, election.topic, election.electionResults, callback);
+            }, callback)
+        ], callback)
       ], callback);
     }
 
@@ -330,6 +339,25 @@ function _gossipWith(ledgerNode, voter, blockHeight, peer, callback) {
         consensusPhase: status.consensusPhase
       }));
   });
+}
+
+function _syncVotes(options, callback) {
+  async.each(options.election, (e, callback) => {
+    async.auto({
+      hashes: callback => async.map(e.electionResults, api._hasher, callback),
+      votes: callback => api._votes.get(
+        options.ledgerNodeId, options.blockHeight, e.topic, callback),
+      send: ['hashes', 'votes', (results, callback) => {
+        const toSend = results.votes
+          .filter(v => !results.hashes.includes(v.meta.voteHash))
+          // FIXME: add context
+          .map(v => ({topic: e.topic, vote: v.vote}));
+        // console.log('VVVVVVVVVVVV', toSend);
+        async.each(toSend, (vote, callback) =>
+          api._client.sendVote(vote, options.peerId, callback), callback);
+      }]
+    }, callback);
+  }, callback);
 }
 
 // NOTE: THIS FUNCTION IS LEFT FOR COMMENTS ONLY, IT IS NOT USED

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -312,7 +312,6 @@ function _gossipWith(ledgerNode, voter, blockHeight, peer, callback) {
     //   'consensus' phases.
     if(['decideEvents', 'decideRollCall', 'consensus'].includes(
       status.consensusPhase)) {
-
       // election results should be in the proper order: Events, RollCall
       status.election.sort((a, b) => a.topic.localeCompare(b.topic));
       return async.auto({
@@ -383,7 +382,7 @@ function _syncVotes(options, callback) {
         async.each(toSend, (vote, callback) =>
           api._client.sendVote(vote, options.peerId, callback), callback);
       }],
-      sendManifests: ['votes', (results, callback) => {
+      sendManifests: ['sendVotes', (results, callback) => {
         const toSend = results.votes
           .filter(v => !manifestHashes.includes(v.vote.manifestHash))
           .map(v => v.vote.manifestHash);

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -386,11 +386,21 @@ function _syncVotes(options, callback) {
       sendManifests: ['votes', (results, callback) => {
         const toSend = results.votes
           .filter(v => !manifestHashes.includes(v.vote.manifestHash))
-          .map(v => ({topic: e.topic, manifestHash: v.vote.manifestHash}));
-        // TODO: send manifest
-        callback();
+          .map(v => v.vote.manifestHash);
+        async.each(toSend, (manifestHash, callback) => _sendManifest(
+          manifestHash, options.peerId, options.ledgerNodeId, callback),
+          callback);
       }]
     }, callback);
+  }, callback);
+}
+
+function _sendManifest(manifestHash, peerId, ledgerNodeId, callback) {
+  async.auto({
+    manifest: callback =>
+      api._storage.manifests.get(ledgerNodeId, manifestHash, callback),
+    send: ['manifest', (results, callback) =>
+      api._client.sendManifest(results.manifest, peerId, callback)]
   }, callback);
 }
 

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -321,12 +321,18 @@ function _gossipWith(ledgerNode, voter, blockHeight, peer, callback) {
         rebuildVotes: ['validate', (results, callback) =>
           async.each(status.election, (e, callback) =>
             async.each(e.electionResults, _rebuildVote, callback), callback)],
-        sync: ['rebuildVotes', (results, callback) => _syncVotes({
-          election: status.election,
-          ledgerNodeId: ledgerNode.id,
-          peerId: peer.id,
-          blockHeight,
-        }, callback)],
+        sync: ['rebuildVotes', (results, callback) => {
+          if(status.consensusPhase === 'consensus') {
+            // the peer has already reached consensus, no need to sync
+            return callback();
+          }
+          _syncVotes({
+            election: status.election,
+            ledgerNodeId: ledgerNode.id,
+            peerId: peer.id,
+            blockHeight,
+          }, callback);
+        }],
         certify: ['rebuildVotes', (results, callback) =>
           async.eachSeries(status.election, (election, callback) =>
             api._election.certify(
@@ -362,7 +368,8 @@ function _rebuildVote(vote, callback) {
 }
 
 function _syncVotes(options, callback) {
-  async.each(options.election, (e, callback) => {
+  // process vote topic serially: Events then RollCall
+  async.eachSeries(options.election, (e, callback) => {
     const voteHashes = e.electionResults.map(vote => vote.meta.voteHash);
     async.auto({
       votes: callback => api._votes.get(
@@ -377,136 +384,6 @@ function _syncVotes(options, callback) {
       }]
     }, callback);
   }, callback);
-}
-
-// NOTE: THIS FUNCTION IS LEFT FOR COMMENTS ONLY, IT IS NOT USED
-function _getBlockStatus(blockHeight, peer, callback) {
-  // 1. GET <endpoint>/blocks/<height>/status
-
-  // 2. B responds with its status resource for that block.
-
-  // Example 1 (B has no such block yet):
-  // {
-  //   '@context': config.constants.WEB_LEDGER_CONTEXT_V1_URL,
-  //   type: 'Error',
-  //   errorType: 'NotFound'
-  // }
-
-  // Example 2 (no consensus or vote yet):
-  // {
-  //   blockHeight: <blockHeight>,
-  //   consenusPhase: 'gossip',
-  //   eventHash: [<eventHash1>, <eventHash2>, ...]
-  // }
-
-  // Example 3 (no consensus, round 1 through N vote):
-  // {
-  //   blockHeight: <blockHeight>,
-  //   consenusPhase: 'decideEvents',
-  //   election: [{
-  //     topic: 'Events',
-  //     electionResults: [{
-  //       manifestHash: <manifestHash1>,
-  //       round: 1,
-  //       voter: <voter_id1>,
-  //       signature: ...
-  //     }, {
-  //       manifestHash: <manifestHash2>,
-  //       round: 1,
-  //       voter: <voter_id2>,
-  //       signature: ...
-  //     }]
-  //   }]
-  // }
-
-  // Example 3 (no consensus, round 1 through N vote):
-  // {
-  //   blockHeight: <blockHeight>,
-  //   consenusPhase: 'decideRollCall',
-  //   election: [{
-  //     topic: 'Events',
-  //     electionResults: [{
-  //       manifestHash: <manifestHash1>,
-  //       round: 1,
-  //       voter: <voter_id1>,
-  //       signature: ...
-  //     }, {
-  //       manifestHash: <manifestHash2>,
-  //       round: 1,
-  //       voter: <voter_id2>,
-  //       signature: ...
-  //     }]
-  //   }, {
-  //     topic: 'RollCall',
-  //     electionResults: [{
-  //       manifestHash: <manifestHash1>,
-  //       round: 1,
-  //       voter: <voter_id1>,
-  //       signature: ...
-  //     }, {
-  //       manifestHash: <manifestHash2>,
-  //       round: 1,
-  //       voter: <voter_id2>,
-  //       signature: ...
-  //   }]
-  // }
-
-  // TODO: how does returning `consensus` as a phase help? Do we only need
-  // the election phase -- after which the node should automatically detect
-  // and verify consensus and avoid talking to other nodes?
-
-  // Example 4 (consensus)
-  // {
-  //   blockHeight: <blockHeight>,
-  //   phase: 'consensus',
-  //   election: [{
-  //     topic: 'Events',
-  //     electionResults: [{
-  //       manifestHash: <manifestHash1>,
-  //       round: 4,
-  //       voter: <voter_id1>,
-  //       signature: ...
-  //     }, {
-  //       manifestHash: <manifestHash2>,
-  //       round: 4,
-  //       voter: <voter_id2>,
-  //       signature: ...
-  //     }]
-  //   }, {
-  //     topic: 'RollCall',
-  //     electionResults: [{
-  //       manifestHash: <manifestHash1>,
-  //       round: 1,
-  //       voter: <voter_id1>,
-  //       signature: ...
-  //     }, {
-  //       manifestHash: <manifestHash2>,
-  //       round: 1,
-  //       voter: <voter_id2>,
-  //       signature: ...
-  //   }]
-  // }
-
-  // TODO: Note: If there is more than one vote for a particular voter ID,
-  //   then the first vote received will be used. Alternatively, the vote
-  //   for the manifest with the lowest hash could be used, but this would
-  //   require updating the vote when a lower hash vote arrived -- which is
-  //   is likely more problematic than simply accepting the first vote.
-
-  // A new manifest will be created whenever a node is a voter and it has
-  // gossiped with 67 peers. Whatever events it has on record at that time
-  // will be bundled as a manifest and hashed. This constitutes the first
-  // vote for the decider.
-  //
-  // The REST API can return back the list of hashes for a given manifest.
-  // Manifests for blocks that have already achieved consensus may be safely
-  // deleted. A manifest that has received a 2/3rds majority vote can be
-  // dereferenced by looking at the events in the block it is associated with.
-  // The event hashes for these events can be hashed (in lexicographical order)
-  // to produce the manifest hash.
-  //
-  // For collection modeling, see:
-  // https://github.com/digitalbazaar/bedrock-ledger-storage-mongodb/blob/master/lib/index.js#L99
 }
 
 function _writeBlock(

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -377,7 +377,6 @@ function _syncVotes(options, callback) {
       send: ['votes', (results, callback) => {
         const toSend = results.votes
           .filter(v => !voteHashes.includes(v.meta.voteHash))
-          // FIXME: add context?
           .map(v => ({topic: e.topic, vote: v.vote}));
         async.each(toSend, (vote, callback) =>
           api._client.sendVote(vote, options.peerId, callback), callback);

--- a/schemas/continuity.js
+++ b/schemas/continuity.js
@@ -5,16 +5,18 @@ const config = require('bedrock').config;
 const constants = config.constants;
 const schemas = require('bedrock-validation').schemas;
 
+const blockHeight = {
+  type: 'integer',
+  minimum: 0,
+  required: true
+};
+
 const vote = {
   title: 'Continuity Vote',
   type: 'object',
   properties: {
     '@context': schemas.jsonldContext(),
-    blockHeight: {
-      type: 'integer',
-      minimum: 0,
-      required: true
-    },
+    blockHeight,
     manifestHash: schemas.url(),
     voteRound: {
       type: 'integer',
@@ -63,11 +65,7 @@ const blockStatus = {
   type: 'object',
   properties: {
     '@context': schemas.jsonldContext(),
-    blockHeight: {
-      type: 'integer',
-      minimum: 0,
-      required: true
-    },
+    blockHeight,
     consensusPhase: {
       type: 'string',
       required: true
@@ -156,7 +154,31 @@ const event = {
   type: [webLedgerConfigEvent, webLedgerEvent]
 };
 
+const manifest = {
+  title: 'Continuity Manifest',
+  type: 'object',
+  properties: {
+    // FIXME: @context?
+    type: {
+      type: 'string',
+      required: true,
+      enum: ['Events', 'RollCall']
+    },
+    id: schemas.identifier(),
+    blockHeight,
+    item: {
+      type: 'array',
+      minItems: 1,
+      required: true,
+      items: {
+        type: schemas.url()
+      }
+    }
+  }
+};
+
 module.exports.blockStatus = () => (blockStatus);
 module.exports.election = () => (election);
 module.exports.event = () => (event);
+module.exports.manifest = () => (manifest);
 module.exports.vote = () => (vote);

--- a/test/loop.sh
+++ b/test/loop.sh
@@ -1,0 +1,7 @@
+counter=0
+while [ $? -eq 0 ]
+do
+echo 'Pass ==================' $counter
+npm test
+((++counter))
+done

--- a/test/loop.sh
+++ b/test/loop.sh
@@ -2,6 +2,6 @@ counter=0
 while [ $? -eq 0 ]
 do
 echo 'Pass ==================' $counter
-npm test
 ((++counter))
+npm test
 done

--- a/test/mocha/.eslintrc
+++ b/test/mocha/.eslintrc
@@ -1,5 +1,9 @@
 {
   "env": {
     "mocha": true
+  },
+  "globals": {
+    "should": true,
+    "assertNoError": true
   }
 }

--- a/test/mocha/70-multinode.js
+++ b/test/mocha/70-multinode.js
@@ -17,7 +17,7 @@ const mockData = require('./mock.data');
 // NOTE: the tests in this file are designed to run in series
 // DO NOT use `it.only`
 
-describe.only('Multinode', () => {
+describe('Multinode', () => {
   before(done => {
     helpers.prepareDatabase(mockData, done);
   });

--- a/test/mocha/70-multinode.js
+++ b/test/mocha/70-multinode.js
@@ -130,6 +130,7 @@ describe.only('Multinode', () => {
                 }
                 const eventBlock = result.eventBlock;
                 should.exist(eventBlock.block);
+                eventBlock.block.blockHeight.should.equal(1);
                 eventBlock.block.event.should.be.an('array');
                 eventBlock.block.event.should.have.length(1);
                 const event = eventBlock.block.event[0];
@@ -171,6 +172,7 @@ describe.only('Multinode', () => {
                 }
                 const eventBlock = result.eventBlock;
                 should.exist(eventBlock.block);
+                eventBlock.block.blockHeight.should.equal(2);
                 eventBlock.block.event.should.be.an('array');
                 eventBlock.block.event.should.have.length(1);
                 const event = eventBlock.block.event[0];
@@ -211,6 +213,7 @@ describe.only('Multinode', () => {
                 }
                 const eventBlock = result.eventBlock;
                 should.exist(eventBlock.block);
+                eventBlock.block.blockHeight.should.equal(3);
                 eventBlock.block.event.should.be.an('array');
                 eventBlock.block.event.should.have.length(1);
                 const event = eventBlock.block.event[0];
@@ -234,7 +237,7 @@ describe.only('Multinode', () => {
         }, done);
       });
     });
-    describe.skip('Block 4', () => {
+    describe('Block 4', () => {
       it('should achieve consensus with 10 nodes again', function(done) {
         this.timeout(120000);
         const testEvent = bedrock.util.clone(mockData.events.alpha);
@@ -260,6 +263,7 @@ describe.only('Multinode', () => {
                 }
                 const eventBlock = result.eventBlock;
                 should.exist(eventBlock.block);
+                eventBlock.block.blockHeight.should.equal(4);
                 eventBlock.block.event.should.be.an('array');
                 eventBlock.block.event.should.have.length(1);
                 const event = eventBlock.block.event[0];
@@ -283,7 +287,7 @@ describe.only('Multinode', () => {
         }, done);
       });
     });
-    describe.skip('Block 5 - staggered worker kick-off', () => {
+    describe('Block 5 - staggered worker kick-off', () => {
       it('achieves consensus when an event is added at each node',
         function(done) {
           this.timeout(120000);
@@ -311,6 +315,7 @@ describe.only('Multinode', () => {
                   }
                   const eventBlock = result.eventBlock;
                   should.exist(eventBlock.block);
+                  eventBlock.block.blockHeight.should.equal(5);
                   eventBlock.block.event.should.be.an('array');
                   eventBlock.block.event.should.have.length(10);
                   eventBlock.block.electionResults.should.have.length.at.least(
@@ -320,7 +325,7 @@ describe.only('Multinode', () => {
           }, done);
         });
     });
-    describe.skip('Catch-up', () => {
+    describe('Catch-up', () => {
       let catchUpNode;
       before(done => brLedger.add(null, {
         genesisBlock: genesisRecord.block,
@@ -333,34 +338,52 @@ describe.only('Multinode', () => {
         done();
       }));
 
-      it('a new node is able to catch up', done => {
+      it('a new node is able to catch up', function(done) {
+        this.timeout(10000);
         async.series([
           callback => consensusApi._worker._run(catchUpNode, callback),
           callback => catchUpNode.storage.blocks.getLatest((err, result) => {
             assertNoError(err);
-            console.log('1');
+            console.log('BLOCK 1');
             result.eventBlock.block.blockHeight.should.equal(1);
+            result.eventBlock.block.event.should.be.an('array');
+            result.eventBlock.block.event.should.have.length(1);
             callback();
           }),
           callback => consensusApi._worker._run(catchUpNode, callback),
           callback => catchUpNode.storage.blocks.getLatest((err, result) => {
             assertNoError(err);
-            console.log('2');
+            console.log('BLOCK 2');
             result.eventBlock.block.blockHeight.should.equal(2);
+            result.eventBlock.block.event.should.be.an('array');
+            result.eventBlock.block.event.should.have.length(1);
             callback();
           }),
           callback => consensusApi._worker._run(catchUpNode, callback),
           callback => catchUpNode.storage.blocks.getLatest((err, result) => {
             assertNoError(err);
-            console.log('3');
+            console.log('BLOCK 3');
             result.eventBlock.block.blockHeight.should.equal(3);
+            result.eventBlock.block.event.should.be.an('array');
+            result.eventBlock.block.event.should.have.length(1);
             callback();
           }),
           callback => consensusApi._worker._run(catchUpNode, callback),
           callback => catchUpNode.storage.blocks.getLatest((err, result) => {
             assertNoError(err);
-            console.log('4');
+            console.log('BLOCK 4');
             result.eventBlock.block.blockHeight.should.equal(4);
+            result.eventBlock.block.event.should.be.an('array');
+            result.eventBlock.block.event.should.have.length(1);
+            callback();
+          }),
+          callback => consensusApi._worker._run(catchUpNode, callback),
+          callback => catchUpNode.storage.blocks.getLatest((err, result) => {
+            assertNoError(err);
+            console.log('BLOCK 5');
+            result.eventBlock.block.blockHeight.should.equal(5);
+            result.eventBlock.block.event.should.be.an('array');
+            result.eventBlock.block.event.should.have.length(10);
             callback();
           }),
         ], done);

--- a/test/mocha/70-multinode.js
+++ b/test/mocha/70-multinode.js
@@ -15,7 +15,7 @@ const mockData = require('./mock.data');
 // NOTE: the tests in this file are designed to run in series
 // DO NOT use `it.only`
 
-describe.only('Multinode', () => {
+describe('Multinode', () => {
   before(done => {
     helpers.prepareDatabase(mockData, done);
   });
@@ -283,7 +283,7 @@ describe.only('Multinode', () => {
         }, done);
       });
     });
-    describe('Block 5', () => {
+    describe('Block 5 - staggered worker kick-off', () => {
       it('achieves consensus when an event is added at each node',
         function(done) {
           this.timeout(120000);

--- a/test/mocha/70-multinode.js
+++ b/test/mocha/70-multinode.js
@@ -17,7 +17,7 @@ const mockData = require('./mock.data');
 // NOTE: the tests in this file are designed to run in series
 // DO NOT use `it.only`
 
-describe('Multinode', () => {
+describe.only('Multinode', () => {
   before(done => {
     helpers.prepareDatabase(mockData, done);
   });

--- a/test/mocha/70-multinode.js
+++ b/test/mocha/70-multinode.js
@@ -155,7 +155,7 @@ describe.only('Multinode', () => {
     }); // end block 1
     describe('Block 2', () => {
       it('should add an event and achieve consensus', function(done) {
-        this.timeout(15000);
+        this.timeout(120000);
         const testEvent = bedrock.util.clone(mockData.events.alpha);
         testEvent.input[0].id = 'https://example.com/events/' + uuid();
         async.auto({
@@ -339,7 +339,7 @@ describe.only('Multinode', () => {
       }));
 
       it('a new node is able to catch up', function(done) {
-        this.timeout(10000);
+        this.timeout(120000);
         async.series([
           callback => consensusApi._worker._run(catchUpNode, callback),
           callback => catchUpNode.storage.blocks.getLatest((err, result) => {

--- a/test/mocha/70-multinode.js
+++ b/test/mocha/70-multinode.js
@@ -301,7 +301,7 @@ describe.only('Multinode', () => {
             runWorkers: ['addEvents', (results, callback) =>
               async.each(peers, (ledgerNode, callback) => {
                 setTimeout(() => consensusApi._worker._run(
-                  ledgerNode, callback), delay += 500);
+                  ledgerNode, callback), delay += 250);
               }, callback)],
             getLatest: ['runWorkers', (results, callback) =>
               async.each(peers, (ledgerNode, callback) =>

--- a/test/mocha/70-multinode.js
+++ b/test/mocha/70-multinode.js
@@ -293,13 +293,16 @@ describe.only('Multinode', () => {
             testEvent.input[0].id = 'https://example.com/events/' + uuid();
             testEvents.push(testEvent);
           }
+          let delay = 0;
           async.auto({
             addEvents: callback =>
               async.eachOf(peers, (ledgerNode, index, callback) =>
                 ledgerNode.events.add(testEvents[index], callback), callback),
             runWorkers: ['addEvents', (results, callback) =>
-              async.each(peers, (ledgerNode, callback) =>
-                consensusApi._worker._run(ledgerNode, callback), callback)],
+              async.each(peers, (ledgerNode, callback) => {
+                setTimeout(() => consensusApi._worker._run(
+                  ledgerNode, callback), delay += 500);
+              }, callback)],
             getLatest: ['runWorkers', (results, callback) =>
               async.each(peers, (ledgerNode, callback) =>
                 ledgerNode.storage.blocks.getLatest((err, result) => {

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -14,4 +14,4 @@ config.mongodb.dropCollections.onInit = true;
 config.mongodb.dropCollections.collections = [];
 
 // reduce processing interval for testing
-config['ledger-consensus-continuity'].worker.election.gossipInterval = 500;
+config['ledger-consensus-continuity'].worker.election.gossipInterval = 0;

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -14,4 +14,4 @@ config.mongodb.dropCollections.onInit = true;
 config.mongodb.dropCollections.collections = [];
 
 // reduce processing interval for testing
-config['ledger-consensus-continuity'].worker.election.gossipInterval = 0;
+config['ledger-consensus-continuity'].worker.election.gossipInterval = 500;


### PR DESCRIPTION
Fixes #15.

This is a trial balloon.  I'm not sure if it's doing the right thing.  But as is, within the test suite, it leads to a minor performance degradation.  Also, it's currently recording the number of successful vote writes on the server side vs duplicate errors.  The number of failures typically exceeds the number of successes by about 30%.  One test suite run: Fail 308/Success 226

@dlongley first, I need you to make sure it's doing the right thing.  Then we would need to discuss under what circumstances there would be a net gain with this optimization so we can try to measure the improvement somehow.