### PR TITLE
Prevent duplicates in `descendants`.

### DIFF
--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -190,7 +190,7 @@ function _getElectorBranches({history, electors}) {
 function _getAncestorHashes({allXs, ledgerNodeId}) {
   // get all ancestor hashes from every consensus X
   const hashes = new Set();
-  const descendants = new Set();
+  const descendants = [];
   const parentHashes = new Set();
   for(const x of allXs) {
     // TODO: anything missed or different here with byzantine forks?
@@ -199,10 +199,10 @@ function _getAncestorHashes({allXs, ledgerNodeId}) {
       const current = next;
       next = [];
       for(const event of current) {
-        if(descendants.has(event)) {
+        if(hashes.has(event.eventHash)) {
           continue;
         }
-        descendants.add(event);
+        descendants.push(event);
         hashes.add(event.eventHash);
         const parents = event._parents || [];
         next.push(...parents);
@@ -211,9 +211,10 @@ function _getAncestorHashes({allXs, ledgerNodeId}) {
           if(!hashes.has(parentHash) &&
             !event._parents.some(p => p.eventHash === parentHash)) {
             parentHashes.add(parentHash);
+            hashes.add(parentHash);
             // synthesize regular event with enough properties to check
             // ancestry below during sort
-            descendants.add({
+            descendants.push({
               eventHash: parentHash,
               meta: {
                 continuity2017: {
@@ -240,7 +241,7 @@ function _getAncestorHashes({allXs, ledgerNodeId}) {
   //   on hashes w/baseHash mixin, etc.
 
   // find total ordering of events
-  const order = [...descendants];
+  const order = descendants;
   order.sort((a, b) => {
     let diff = 0;
 
@@ -706,7 +707,7 @@ function _findConsensusMergeEventProof({
   logger.debug('Start sync _findConsensusMergeEventProof: _tallyBranches');
   //console.log('Start sync _findConsensusMergeEventProof: _tallyBranches');
   // go through each Y's branch looking for consensus
-  let consensus = _tallyBranches(
+  const consensus = _tallyBranches(
     {ledgerNodeId, yByElector, blockHeight, electors, logger});
   /*console.log('End sync _findConsensusMergeEventProof: (Branches', {
     duration: Date.now() - startTime
@@ -1582,7 +1583,7 @@ function _hasAncestors(
     candidateAncestryMaps, found}) {
   const candidateSet = new Set(candidates);
   let next = target._parents;
-  let difference = [...candidateSet].filter(x => !found.has(x));
+  const difference = [...candidateSet].filter(x => !found.has(x));
   // include `checked` as an optimization to avoid double checking ancestors
   const checked = new Set();
   while(next.length > 0) {

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -202,7 +202,9 @@ function _getAncestorHashes({allXs, ledgerNodeId}) {
         if(hashes.has(event.eventHash)) {
           continue;
         }
-        descendants.push(event);
+        if(!parentHashes.has(event.eventHash)) {
+          descendants.push(event);
+        }
         hashes.add(event.eventHash);
         const parents = event._parents || [];
         next.push(...parents);
@@ -211,7 +213,6 @@ function _getAncestorHashes({allXs, ledgerNodeId}) {
           if(!hashes.has(parentHash) &&
             !event._parents.some(p => p.eventHash === parentHash)) {
             parentHashes.add(parentHash);
-            hashes.add(parentHash);
             // synthesize regular event with enough properties to check
             // ancestry below during sort
             descendants.push({


### PR DESCRIPTION
Unfortunately set.add does not do a deep compare to prevent duplicates.

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set/has
https://stackoverflow.com/a/29759699/3272112

And since the set wasn't doing anything useful, array.push blows the doors off set.add
https://jsperf.com/set-add-vs-array-push/2