### PR TITLE
Fix eviction

### DIFF
--- a/lib/storage-keys.js
+++ b/lib/storage-keys.js
@@ -162,8 +162,6 @@ api.updatePublicKey = (ledgerNodeId, publicKey, callback) => {
   const publicKeyCacheKey = _cacheKey.publicKey(
     {ledgerNodeId, publicKeyId: publicKey.id});
   async.auto({
-    // evict the key from the cache
-    evict: callback => cache.client.del(publicKeyCacheKey, callback),
     // exclude restricted fields
     update: callback => database.collections['continuity2017_key'].update(
       {id: database.hash(publicKey.id), ledgerNodeId},
@@ -181,6 +179,9 @@ api.updatePublicKey = (ledgerNodeId, publicKey, callback) => {
         ));
       }
       callback();
-    }]
+    }],
+    // evict the key from the cache
+    evict: ['checkUpdate', (results, callback) => cache.client.del(
+      publicKeyCacheKey, callback)],
   }, callback);
 };

--- a/test/mocha/92-xblock-multinode.js
+++ b/test/mocha/92-xblock-multinode.js
@@ -37,7 +37,8 @@ describe('X Block Test', () => {
     let consensusApi;
     const mockIdentity = mockData.identities.regularUser;
     const ledgerConfiguration = mockData.ledgerConfiguration;
-    before(done => {
+    before(function(done) {
+      this.timeout(120000);
       async.auto({
         clean: callback => cache.client.flushall(callback),
         actor: ['clean', (results, callback) => brIdentity.get(


### PR DESCRIPTION
This addresses a race condition whereby the cache is evicted and repopulated via a `getPublicKey` operation before the database is updated resulting in a stale cache entry which is resulting in inaccurate publicKey information being put into blocks.  The inaccuracy is that the `seeAlso` shorthand is not being used when it should be which results in a `blockHash` mismatch.