### PR TITLE
Namespace redis pub/sub channels by ledgerNodeId.

### DIFF
--- a/lib/agents/consensus-agent.js
+++ b/lib/agents/consensus-agent.js
@@ -34,7 +34,7 @@ module.exports = class ConsensusAgent extends ContinuityAgent {
     async.auto({
       // subscribing, but not adding an event handler
       subscribe: callback => this.subscriber.subscribe(
-        'continuity2017.event', callback)
+        `continuity2017|event|${this.ledgerNode.id}`, callback)
     }, err => {
       if(err) {
         return this._quit(err);
@@ -46,8 +46,7 @@ module.exports = class ConsensusAgent extends ContinuityAgent {
   }
 
   _onMessage(channel, message) {
-    if(channel === 'continuity2017.event' && message === 'merge' &&
-      !this.working && !this.halt) {
+    if(message === 'merge' && !(this.working || this.halt)) {
       this.working = true;
       this.subscriber.removeListener('message', this.messageListener);
       setTimeout(() => this._work(), this.debounce);

--- a/lib/agents/event-writer-agent.js
+++ b/lib/agents/event-writer-agent.js
@@ -180,7 +180,7 @@ module.exports = class EventWriter extends ContinuityAgent {
           if(newHeads.length !== 0) {
             multi.sadd(this.childlessKey, newHeads);
             // new heads, publish to inform ConsensusAgent and other listeners
-            multi.publish('continuity2017.event', 'merge');
+            multi.publish(`continuity2017|event|${ledgerNodeId}`, 'merge');
           }
         }
         // remove head keys so they will not be removed from the cache
@@ -213,7 +213,7 @@ module.exports = class EventWriter extends ContinuityAgent {
     async.auto({
       // subscribing, but not adding an event handler
       subscribe: callback => this.subscriber.subscribe(
-        'continuity2017.peerEvent', callback)
+        `continuity2017|peerEvent|${this.ledgerNode.id}`, callback)
     }, err => {
       if(err) {
         return this._quit(err);
@@ -224,9 +224,8 @@ module.exports = class EventWriter extends ContinuityAgent {
     });
   }
 
-  // ignore message
-  _onMessage(channel /*, message */) {
-    if(channel === 'continuity2017.peerEvent' && !this.working && !this.halt) {
+  _onMessage() {
+    if(!(this.working || this.halt)) {
       this.working = true;
       this.subscriber.removeListener('message', this.messageListener);
       // debounce

--- a/lib/agents/merge-agent.js
+++ b/lib/agents/merge-agent.js
@@ -76,18 +76,18 @@ module.exports = class MergeAgent extends ContinuityAgent {
 
   _workLoop() {
     this.messageListener = this._onMessage.bind(this);
+    const ledgerNodeId = this.ledgerNode.id;
     async.auto({
-      creator: callback => _voters.get(
-        {ledgerNodeId: this.ledgerNode.id}, (err, result) => {
-          if(err) {
-            return callback(err);
-          }
-          this.creatorId = result.id;
-          callback();
-        }),
+      creator: callback => _voters.get({ledgerNodeId}, (err, result) => {
+        if(err) {
+          return callback(err);
+        }
+        this.creatorId = result.id;
+        callback();
+      }),
       // subscribing, but not adding an event handler
       subscribe: ['creator', (results, callback) => this.subscriber.subscribe(
-        'continuity2017.event', callback)]
+        `continuity2017|event|${ledgerNodeId}`, callback)]
     }, err => {
       if(err) {
         return this._quit(err);
@@ -98,10 +98,9 @@ module.exports = class MergeAgent extends ContinuityAgent {
     });
   }
 
-  // ignore message
-  _onMessage(channel /*, message */) {
+  _onMessage() {
     // this node should merge on both local regular and remote merge events
-    if(channel === 'continuity2017.event' && !this.working && !this.halt) {
+    if(!(this.working || this.halt)) {
       this.working = true;
       this.subscriber.removeListener('message', this.messageListener);
 

--- a/lib/agents/operation-agent.js
+++ b/lib/agents/operation-agent.js
@@ -27,18 +27,18 @@ module.exports = class OperationAgent extends ContinuityAgent {
 
   _workLoop() {
     this.messageListener = this._onMessage.bind(this);
+    const ledgerNodeId = this.ledgerNode.id;
     async.auto({
-      creator: callback => _voters.get(
-        {ledgerNodeId: this.ledgerNode.id}, (err, result) => {
-          if(err) {
-            return callback(err);
-          }
-          this.creatorId = result.id;
-          callback();
-        }),
+      creator: callback => _voters.get({ledgerNodeId}, (err, result) => {
+        if(err) {
+          return callback(err);
+        }
+        this.creatorId = result.id;
+        callback();
+      }),
       // subscribing, but not adding an event handler
       subscribe: ['creator', (results, callback) => this.subscriber.subscribe(
-        'continuity2017.operation', callback)]
+        `continuity2017|operation|${ledgerNodeId}`, callback)]
     }, err => {
       if(err) {
         return this._quit(err);
@@ -49,9 +49,8 @@ module.exports = class OperationAgent extends ContinuityAgent {
     });
   }
 
-  // ignore message
-  _onMessage(channel /*, message */) {
-    if(channel === 'continuity2017.operation' && !this.working && !this.halt) {
+  _onMessage() {
+    if(!(this.working || this.halt)) {
       this.working = true;
       this.subscriber.removeListener('message', this.messageListener);
       setTimeout(() => this._work(), this.debounce);

--- a/lib/events.js
+++ b/lib/events.js
@@ -1476,7 +1476,7 @@ function _queueEvent({event, ledgerNodeId, meta}, callback) {
   multi.set(eventKey, eventJson);
   // push to the list that is handled in the event-writer
   multi.rpush(eventQueueKey, eventKey);
-  multi.publish('continuity2017.peerEvent', 'new');
+  multi.publish(`continuity2017|peerEvent|${ledgerNodeId}`, 'new');
   multi.exec(callback);
 }
 
@@ -1510,7 +1510,7 @@ function _updateCache({eventRecord, ledgerNodeId}, callback) {
     .set(eventKey, cacheEvent)
     .sadd(outstandingMergeKey, eventKey)
     .hmset(headKey, 'h', eventHash, 'g', generation)
-    .publish('continuity2017.event', 'merge')
+    .publish(`continuity2017|event|${ledgerNodeId}`, 'merge')
     .exec((err, result) => {
       if(err) {
         // FIXME: fail gracefully
@@ -1649,7 +1649,7 @@ function _writeEvent(
         .incr(eventCountKey)
         .expire(eventCountKey, eventsConfig.counter.ttl)
         // inform ConsensusAgent and other listeners about new regular events
-        .publish('continuity2017.event', 'regular')
+        .publish(`continuity2017|event|${ledgerNodeId}`, 'regular')
         .exec(callback);
     }]
   }, (err, results) => {

--- a/lib/operations.js
+++ b/lib/operations.js
@@ -45,7 +45,7 @@ api.add = ({operation, ledgerNode}, callback) => {
         .set(opKey, JSON.stringify(
           {operation, meta: {operationHash}, recordId}))
         .rpush(opListKey, opKey)
-        .publish('continuity2017.operation', 'add')
+        .publish(`continuity2017|operation|${ledgerNodeId}`, 'add')
         .exec(callback);
     }]
   }, callback);


### PR DESCRIPTION
Fixes #84.
Remove unnecessary conditionals involving channel names. The channel is
always the subscribed channel.