### PR TITLE
Fix test helpers

### DIFF
--- a/test/mocha/60-worker-gossip-with.js
+++ b/test/mocha/60-worker-gossip-with.js
@@ -555,8 +555,8 @@ describe('Worker - _gossipWith', () => {
   }); // end cycle delta
 
   function _commitCache(ledgerNode, callback) {
+    // ledgerNode.eventWriter is in immediate mode and stops itself
+    // as soon as the event queue is cleared
     ledgerNode.eventWriter.start(callback);
-    // need a minimal amount of time for write to kick off
-    setTimeout(() => ledgerNode.eventWriter.stop(), 250);
   }
 });

--- a/test/mocha/history-alpha.js
+++ b/test/mocha/history-alpha.js
@@ -198,13 +198,13 @@ module.exports = ({api, consensusApi, eventTemplate, nodes, opTemplate}) => ({
     nodes,
     to: 'gamma'
   }, callback)],
-  cp27: ['cp26', (results, callback) => api.copyAndMerge({
+  cp27: ['cp25', 'cp26', (results, callback) => api.copyAndMerge({
     consensusApi,
     from: 'gamma',
     nodes,
     to: 'beta'
   }, callback)],
-  cp28: ['cp25', 'cp27', (results, callback) => api.copyAndMerge({
+  cp28: ['cp27', (results, callback) => api.copyAndMerge({
     consensusApi,
     from: 'beta',
     nodes,


### PR DESCRIPTION
This fixes a couple 1 in 300 race conditions turned up by looping the entire test suite on testcloud.

I'd like to get the merged into master so you we can rebase #multihashes/#promises on it so it doesn't interfere with your promises work @dlongley .