### PR TITLE
Remove operationHash from peer events.

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -876,6 +876,9 @@ async function _processPeerRegularEvent({event, ledgerNode, needed}) {
   _event.operationHash = operationRecords.map(o => o.meta.operationHash);
   const eventHash = await _util.hasher(_event);
 
+  // after `eventHash` has been computed `operationHash` is no longer needed
+  delete _event.operationHash;
+
   // TODO: more performant if implemented with a Set?
   if(!needed.includes(eventHash)) {
     throw new BedrockError(


### PR DESCRIPTION
I discovered that `operationHash` was being unnecessarily being stored into event records in the case of peer events, local events were already being constructed properly.