### PR TITLE
Fix treeHash assignment in config events.

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -847,7 +847,7 @@ async function _processOperations({ledgerNode, operations}) {
   return Promise.all(operations.map(async operation => {
     await ledgerNode.operations.validate(operation);
     const operationHash = await _util.hasher(operation);
-    // TODO: do we need `recordId`? what is it for, statistics?
+    // the `recordId` property is indexed in the storage layer
     const recordId = _util.generateRecordId({ledgerNode, operation});
     return {meta: {operationHash}, operation, recordId};
   }));

--- a/lib/ledgerConfiguration.js
+++ b/lib/ledgerConfiguration.js
@@ -33,7 +33,7 @@ api.change = callbackify(async (
     const {id: creatorId} = await _voters.get({ledgerNodeId: ledgerNode.id});
     const head = await _events._getLocalBranchHead({creatorId, ledgerNode});
     event.parentHash = [head.eventHash];
-    event.treeHash = head;
+    event.treeHash = head.eventHash;
   }
   const eventHash = await _util.hasher(event);
   await _events.add({event, eventHash, genesis, genesisBlock, ledgerNode});


### PR DESCRIPTION
This is an interesting accidental discovery.  This error changed `event.treeHash` from a string to an object, and nothing missed a beat and configuration change was working properly.  This is a *possible* indication that `event.treeHash` is just not used anywhere!

I'll be looking into that further.