### PR TITLE
Reorganize redis cache code.

### DIFF
--- a/lib/OperationQueue.js
+++ b/lib/OperationQueue.js
@@ -1,0 +1,129 @@
+/*!
+ * Copyright (c) 2017-2018 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const _cacheKey = require('./cache-key');
+const _util = require('./util');
+const bedrock = require('bedrock');
+const cache = require('bedrock-redis');
+const {config} = bedrock;
+const logger = require('./logger');
+
+const eventsConfig = config['ledger-consensus-continuity'].events;
+
+module.exports = class OperationQueue {
+  constructor({ledgerNodeId}) {
+    this.chunk = null;
+    this.chunkCached = false;
+    this.ledgerNodeId = ledgerNodeId;
+    // key for the list of all operation keys in the next chunk
+    this.chunkCacheKey = _cacheKey.operationSelectedList(ledgerNodeId);
+    // keys for all operations in the next chunk in the queue
+    this.opKeys = null;
+    // key to master operation list (list of keys for all pending operations)
+    this.opListKey = _cacheKey.operationList(ledgerNodeId);
+    // tracks whether or not there are more operations after the next chunk
+    this.hasMore = false;
+  }
+
+  /**
+   * Returns whether or not there is another chunk of operations that can
+   * be put into a local regular event.
+   *
+   * @return a Promise that resolves to `true` or `false`.
+   */
+  async hasNextChunk() {
+    if(this.opKeys) {
+      return true;
+    }
+
+    // first, see if the next chunk of operations has already been cached
+    // in redis (this happens when a previous call to `hasNext` occurred but
+    // the next chunk was not popped off the queue, likely because an event
+    // creation failed... so we can resume here)
+    this.opKeys = await cache.client.lrange(this.chunkCacheKey, 0, -1);
+    if(this.opKeys.length > 0) {
+      return this.chunkCached = true;
+    }
+
+    // no next chunk of operations cached yet, so create one that will be
+    // cached when `getNextChunk` is called and its operations are retrieved
+    const {maxOperations} = eventsConfig;
+    const [listLength, nextKeys] = await cache.client.multi()
+      .llen(this.opListKey)
+      .lrange(this.opListKey, 0, maxOperations - 1)
+      .exec();
+    if(listLength === 0) {
+      // no new operations
+      this.opKeys = null;
+      return false;
+    }
+    if(listLength > maxOperations) {
+      this.hasMore = true;
+    }
+    logger.debug(`New operations found: ${listLength}`);
+    this.opKeys = nextKeys;
+    return true;
+  }
+
+  /**
+   * Get the next set of operations to insert into a local regular event.
+   *
+   * @return a Promise that resolves to an object with:
+   *   operations - an array of operations lexicographically ordered by hash.
+   *   TODO: rename to `hasMore`
+   *   truncated - true if there are even more operations after the next
+   *     chunk of operations.
+   */
+  async getNextChunk() {
+    if(this.chunk) {
+      // next chunk already cached in memory, return it
+      return this.chunk;
+    }
+
+    // create an atomic redis transaction that will:
+    // 1. Get all operations matching `opKeys`.
+    // Then, if the next chunk of operations hasn't been cached yet...
+    // 2. Remove the operation keys from the master operation key list.
+    // 3. Cache the next chunk of operations by storing their keys in a list.
+    const getOperationsTxn = cache.client.multi().mget(this.opKeys);
+    if(!this.chunkCached) {
+      // remove next chunk ops from the master operation list
+      // ltrim *keeps* items from start to end
+      getOperationsTxn.ltrim(this.opListKey, this.opKeys.length, -1);
+      // create the next chunk
+      getOperationsTxn.rpush(this.chunkCacheKey, this.opKeys);
+    }
+
+    // execute the redis transaction and get the operations for the chunk
+    const [opJsons] = await getOperationsTxn.exec();
+    // Note: tested different methods for fastest parsing, this was the winner
+    // https://github.com/digitalbazaar/loop-bench
+    const operations = opJsons.map(JSON.parse);
+    // lexicographic sort on the hash of the operation determines the
+    // order of operations in events
+    _util.sortOperations(operations);
+    return this.chunk = {operations, truncated: this.hasMore};
+  }
+
+  /**
+   * Pop the next chunk of operations off of the queue. This method should
+   * only be called once the operations have been successfully written to
+   * a local regular event.
+   *
+   * @return a Promise that resolves once the operation completes.
+   */
+  async popChunk() {
+    if(this.chunk) {
+      // clear the events from the redis operation queue
+      await cache.client.multi()
+        // remove the cached chunk
+        .del(this.chunkCacheKey)
+        // delete the keys that contain the operation documents
+        .del(this.opKeys)
+        .exec();
+      this.opKeys = this.chunk = null;
+    }
+  }
+};

--- a/lib/OperationQueue.js
+++ b/lib/OperationQueue.js
@@ -60,9 +60,7 @@ module.exports = class OperationQueue {
       this.opKeys = null;
       return false;
     }
-    if(listLength > maxOperations) {
-      this.hasMore = true;
-    }
+    this.hasMore = listLength > maxOperations;
     logger.debug(`New operations found: ${listLength}`);
     this.opKeys = nextKeys;
     return true;
@@ -125,6 +123,7 @@ module.exports = class OperationQueue {
         .del(this.opKeys)
         .exec();
       this.opKeys = this.chunk = null;
+      this.chunkCached = false;
     }
   }
 };

--- a/lib/OperationQueue.js
+++ b/lib/OperationQueue.js
@@ -44,7 +44,8 @@ module.exports = class OperationQueue {
     // creation failed... so we can resume here)
     this.opKeys = await cache.client.lrange(this.chunkCacheKey, 0, -1);
     if(this.opKeys.length > 0) {
-      return this.chunkCached = true;
+      this.chunkCached = true;
+      return true;
     }
 
     // no next chunk of operations cached yet, so create one that will be

--- a/lib/Timer.js
+++ b/lib/Timer.js
@@ -1,0 +1,32 @@
+/*!
+ * Copyright (c) 2017-2018 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const cache = require('bedrock-redis');
+
+module.exports = class Timer {
+  // start timer
+  start({name, ledgerNodeId}) {
+    if(!(name && typeof name === 'string')) {
+      throw new Error('"name" must be a string.');
+    }
+    if(!(ledgerNodeId && typeof ledgerNodeId === 'string')) {
+      throw new Error('"ledgerNodeId" must be a string.');
+    }
+    this.name = name;
+    this.ledgerNodeId = ledgerNodeId;
+    this.startTime = 0;
+  }
+
+  // stop timer, record result (ignore errors, for stats only), and
+  // return duration for external use
+  stop() {
+    // TODO: prefix with `timer|`
+    const {name, ledgerNodeId, startTime} = this;
+    const duration = Date.now() - startTime;
+    cache.client.set(`${name}|${ledgerNodeId}`, duration)
+      .catch(() => {});
+    return duration;
+  }
+};

--- a/lib/Timer.js
+++ b/lib/Timer.js
@@ -3,6 +3,7 @@
  */
 'use strict';
 
+const _cacheKey = require('./cache-key');
 const cache = require('bedrock-redis');
 
 module.exports = class Timer {
@@ -22,11 +23,10 @@ module.exports = class Timer {
   // stop timer, record result (ignore errors, for stats only), and
   // return duration for external use
   stop() {
-    // TODO: prefix with `timer|`
     const {name, ledgerNodeId, startTime} = this;
     const duration = Date.now() - startTime;
-    cache.client.set(`${name}|${ledgerNodeId}`, duration)
-      .catch(() => {});
+    const key = _cacheKey.timer({name, ledgerNodeId});
+    cache.client.set(key, duration).catch(() => {});
     return duration;
   }
 };

--- a/lib/Timer.js
+++ b/lib/Timer.js
@@ -16,7 +16,7 @@ module.exports = class Timer {
     }
     this.name = name;
     this.ledgerNodeId = ledgerNodeId;
-    this.startTime = 0;
+    this.startTime = Date.now();
   }
 
   // stop timer, record result (ignore errors, for stats only), and

--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -4,11 +4,10 @@
 'use strict';
 
 const _ = require('lodash');
-const _cacheKey = require('./cache-key');
+const _cache = require('./cache');
 const _storage = require('./storage');
 const _util = require('./util');
 const bedrock = require('bedrock');
-const cache = require('bedrock-redis');
 const {callbackify, BedrockError} = bedrock.util;
 const {config} = bedrock;
 const pLimit = require('p-limit');
@@ -55,8 +54,7 @@ api.getNextBlockInfo = callbackify(async (ledgerNode) => {
 });
 
 // TODO: document
-// find hashes for merge events in last block and remove them from the cache,
-//   incr blockHeight
+// ensure block is committed to cache
 api.repairCache = callbackify(async ({blockHeight, ledgerNode}) => {
   const ledgerNodeId = ledgerNode.id;
   const {collection} = ledgerNode.storage.events;
@@ -74,7 +72,8 @@ api.repairCache = callbackify(async ({blockHeight, ledgerNode}) => {
   // FIXME: does the return value of this function make sense or is it
   // just leaking the results from an old `async.auto`?
   const eventHash = records.map(e => e.meta.eventHash);
-  const cache = await _updateCache({hashes: eventHash, ledgerNodeId});
+  const cache = await _cache.blocks.commitBlock(
+    {eventHashes: eventHash, ledgerNodeId});
   return {eventHash, cache};
 });
 
@@ -179,7 +178,8 @@ api.write = callbackify(async ({ledgerNode, state, consensusResult}) => {
   //   new configuration has been validated and accepted (or rejected)
   await ledgerNode.storage.blocks.add(blockRecord);
 
-  await _updateCache({hashes: consensusResult.mergeEventHash, ledgerNodeId});
+  await _cache.blocks.commitBlock(
+    {eventHashes: consensusResult.mergeEventHash, ledgerNodeId});
 
   // FIXME: is returning a boolean necessary?
   return true;
@@ -193,9 +193,9 @@ api.writeGenesis = callbackify(async ({block, ledgerNode}) => {
   };
   await ledgerNode.storage.blocks.add({block, meta});
 
-  // add block height to cache
-  const blockHeightKey = _cacheKey.blockHeight(ledgerNode.id);
-  await cache.client.set(blockHeightKey, 0);
+  // add initial block height to cache
+  await _cache.blocks.setBlockHeight(
+    {blockHeight: 0, ledgerNodeId: ledgerNode.id});
 });
 
 function _generateBlockId({blockHeight, ledgerId}) {
@@ -242,16 +242,4 @@ async function _expandConsensusProofEvents({block, ledgerNode}) {
     block.consensusProof[eventsToFetch[e.meta.eventHash]] = e.event;
   });
   delete block.consensusProofHash;
-}
-
-function _updateCache({hashes, ledgerNodeId}) {
-  const blockHeightKey = _cacheKey.blockHeight(ledgerNodeId);
-  const outstandingMergeKey = _cacheKey.outstandingMerge(ledgerNodeId);
-  const eventKeys = hashes.map(eventHash => _cacheKey.event(
-    {eventHash, ledgerNodeId}));
-  return cache.client.multi()
-    .srem(outstandingMergeKey, eventKeys)
-    .del(eventKeys)
-    .incr(blockHeightKey)
-    .exec();
 }

--- a/lib/cache-key.js
+++ b/lib/cache-key.js
@@ -30,7 +30,7 @@ api.eventCountPeer = ({ledgerNodeId, second}) =>
 api.eventQueue = ledgerNodeId => `eq|${_lni(ledgerNodeId)}`;
 api.eventQueueSet = ledgerNodeId => `eqs|${_lni(ledgerNodeId)}`;
 
-api.genesis = (ledger) => `g|${ledger.substr(-36)}`;
+api.genesis = (ledgerNodeId) => `g|${_lni(ledgerNodeId)}`;
 
 // NOTE: this key contains the head that has been stored in mongo, this head
 // can be used for $graphLookup operations
@@ -48,9 +48,6 @@ api.gossipNotification = creatorId => `gn|${_ci(creatorId)}`;
 api.lastPeerHeads = ledgerNodeId => `lph|${_lni(ledgerNodeId)}`;
 
 api.ledgerNode = creatorId => `ln|${_ci(creatorId)}`;
-
-api.manifest = ({ledgerNodeId, manifestId}) =>
-  `m|${_lni(ledgerNodeId)}|${manifestId}`;
 
 api.mergeDebounce = ledgerNodeId => `md|${_lni(ledgerNodeId)}`;
 

--- a/lib/cache-key.js
+++ b/lib/cache-key.js
@@ -19,6 +19,8 @@ api.blockHeight = ledgerNodeId => `bh|${_lni(ledgerNodeId)}`;
 
 api.childless = ledgerNodeId => `cl|${_lni(ledgerNodeId)}`;
 
+api.diff = uuid => `d|${uuid}`;
+
 api.event = ({eventHash, ledgerNodeId}) =>
   `e|${_lni(ledgerNodeId)}|${eventHash}`;
 
@@ -82,6 +84,8 @@ api.publicKey = ({ledgerNodeId, publicKeyId}) =>
   `pk|${_lni(ledgerNodeId)}|${_ci(publicKeyId)}`;
 
 api.voter = ledgerNodeId => `v|${_lni(ledgerNodeId)}`;
+
+api.timer = ({name, ledgerNodeId}) => `t|${name}|${_lni(ledgerNodeId)}`;
 
 const lastPathReg = /([^\/]*)\/*$/;
 function _ci(creatorId) {

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -421,21 +421,6 @@ api.events.difference = async ({eventHashes, ledgerNodeId}) => {
 };
 
 /**
- * Track duplicate events for statistics analysis.
- *
- * @param count the number of additional duplicate events detected.
- */
-api.events.trackDuplicates = async ({count}) => {
-  if(count === 0) {
-    // nothing to do
-    return;
-  }
-  // for statistics purposes only, ignore errors
-  cache.client.incrby(`dup-${Math.round(Date.now() / 60000)}`, count)
-    .catch(() => {});
-};
-
-/**
  * Gets the reset history of merge events from the cache. This history includes
  * all merge events in the cache that have not achieved consensus and a map of
  * each event's hash to each event. The event data model is also modified

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -1,0 +1,557 @@
+/*!
+ * Copyright (c) 2017-2018 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const _cacheKey = require('./cache-key');
+const bedrock = require('bedrock');
+const cache = require('bedrock-redis');
+const {config} = bedrock;
+const logger = require('./logger');
+const uuid = require('uuid/v4');
+const {BedrockError} = bedrock.util;
+
+const eventsConfig = config['ledger-consensus-continuity'].events;
+const operationsConfig = config['ledger-consensus-continuity'].operations;
+
+const api = {};
+module.exports = api;
+
+// expose cache key API for testing
+api.cacheKey = _cacheKey;
+
+api.Timer = require('./Timer');
+api.OperationQueue = require('./OperationQueue');
+
+api.blocks = {};
+
+/**
+ * Sets the current block height in the cache for a ledger node.
+ *
+ * @param blockHeight the block height to set.
+ * @param ledgerNodeId the ID of the ledger node to update.
+ *
+ * @return a Promise that resolves once the operation completes.
+ */
+api.blocks.setBlockHeight = async ({blockHeight, ledgerNodeId}) => {
+  const key = _cacheKey.blockHeight(ledgerNodeId);
+  await cache.client.set(key, blockHeight);
+};
+
+/**
+ * Commits a block by removing outstanding merge events from the event cache
+ * and updating the block height after a successful merge.
+ *
+ * @param eventHashes the hashes of the merge events from the block to commit.
+ * @param ledgerNodeId the ID of the ledger node to update.
+ *
+ * @return a Promise that resolves once the operation completes.
+ */
+api.blocks.commitBlock = async ({eventHashes, ledgerNodeId}) => {
+  const blockHeightKey = _cacheKey.blockHeight(ledgerNodeId);
+  const outstandingMergeKey = _cacheKey.outstandingMerge(ledgerNodeId);
+  const eventKeys = eventHashes.map(
+    eventHash => _cacheKey.event({eventHash, ledgerNodeId}));
+  return cache.client.multi()
+    .srem(outstandingMergeKey, eventKeys)
+    .del(eventKeys)
+    .incr(blockHeightKey)
+    .exec();
+};
+
+api.events = {};
+
+/**
+ * Adds an event received from a peer to the cache for later inserting into
+ * persistent storage.
+ *
+ * @param event the event to cache.
+ * @param meta the meta data for the event.
+ * @param ledgerNodeId the ID of the ledger node to cache it for.
+ *
+ * @return a Promise that resolves once the operation completes.
+ */
+api.events.addPeerEvent = async ({event, meta, ledgerNodeId}) => {
+  const {eventHash} = meta;
+  const {creator: creatorId, generation, type} = meta.continuity2017;
+  const eventKey = _cacheKey.event({eventHash, ledgerNodeId});
+  const eventQueueKey = _cacheKey.eventQueue(ledgerNodeId);
+  const eventQueueSetKey = _cacheKey.eventQueueSet(ledgerNodeId);
+  const eventJson = JSON.stringify({event, eventHash, meta});
+
+  // TODO: it would be great to find some common abstractions between
+  // adding peer, merge, and local events to help with maintanence and
+  // correctness... see `addLocalMergeEvent` and `addLocalRegularEvent`
+
+  // perform update in a single atomic transaction
+  const txn = cache.client.multi();
+  if(type === 'r') {
+    // Note: peer regular events have `operationRecords` not `operation` at
+    // this point
+    const opCountKey = _cacheKey.opCountPeer(
+      {ledgerNodeId, second: Math.round(Date.now() / 1000)});
+    txn.incrby(opCountKey, event.operationRecords.length);
+    txn.expire(opCountKey, operationsConfig.counter.ttl);
+  }
+  if(type === 'm') {
+    const headGenerationKey = _cacheKey.headGeneration(
+      {eventHash, ledgerNodeId});
+    const latestPeerHeadKey = _cacheKey.latestPeerHead(
+      {creatorId, ledgerNodeId});
+    // expire the key in an hour, in case the peer/creator goes dark
+    txn.hmset(latestPeerHeadKey, 'h', eventHash, 'g', generation);
+    txn.expire(latestPeerHeadKey, 3600);
+    // this key is set to expire in the event-writer
+    txn.set(headGenerationKey, generation);
+  }
+  // add the hash to the set used to check for dups and ancestors
+  txn.sadd(eventQueueSetKey, eventHash);
+  // create a key that contains the event and meta
+  txn.set(eventKey, eventJson);
+  // push to the list that is handled in the event-writer
+  txn.rpush(eventQueueKey, eventKey);
+  txn.publish(`continuity2017|peerEvent|${ledgerNodeId}`, 'new');
+  return txn.exec();
+  // TODO: abstract `publish` into some notify/check API on this file to keep
+  // it isolated and easier to maintain
+};
+
+/**
+ * Adds the summary information for a local merge event to the cache for later
+ * processing by the consensus algorithm. Local merge events are already
+ * present in storage before this method is called; this merely adds a summary
+ * of their information to the cache so it can be pulled down with the rest
+ * of "recent history" to be processed by the consensus algorithm.
+ *
+ * @param event the event to cache.
+ * @param meta the meta data for the event.
+ * @param ledgerNodeId the ID of the ledger node to cache it for.
+ *
+ * @return a Promise that resolves once the operation completes.
+ */
+api.events.addLocalMergeEvent = async ({event, meta, ledgerNodeId}) => {
+  const childlessKey = _cacheKey.childless(ledgerNodeId);
+  const {creator: creatorId, generation} = meta.continuity2017;
+  const {eventHash} = meta;
+  const headKey = _cacheKey.head({creatorId, ledgerNodeId});
+  const eventKey = _cacheKey.event({eventHash, ledgerNodeId});
+  const outstandingMergeKey = _cacheKey.outstandingMerge(ledgerNodeId);
+  const {parentHash, treeHash, type} = event;
+  const parentHashes = parentHash.filter(h => h !== treeHash);
+  // no need to set a headGeneration key here, those are only used for
+  // processing peer merge events
+  // TODO: `creator` is quite a long URL, can a substitution be made?
+
+  // for local merge events we only cache a summary of the event; it does not
+  // include its operations and it puts `eventHash` at the top level to
+  // assist the consensus algorithm (it is not put in `meta` like it is
+  // for persistent ledger storage (e.g. mongo)
+  const eventSummary = JSON.stringify({
+    eventHash,
+    event: {parentHash, treeHash, type},
+    meta: {continuity2017: {creator: creatorId}}
+  });
+  try {
+    const result = cache.client.multi()
+      .srem(childlessKey, parentHashes)
+      .set(eventKey, eventSummary)
+      .sadd(outstandingMergeKey, eventKey)
+      .hmset(headKey, 'h', eventHash, 'g', generation)
+      .publish(`continuity2017|event|${ledgerNodeId}`, 'merge')
+      .exec();
+    // result is inspected in unit tests
+    return result;
+  } catch(e) {
+    // FIXME: fail gracefully
+    // failure here means head information would be corrupt which
+    // cannot be allowed
+    logger.error('Could not set head.', {
+      creatorId,
+      // FIXME: fix when logger.error works properly
+      err1: e,
+      generation,
+      headKey,
+      ledgerNodeId,
+    });
+    throw e;
+  }
+};
+
+/**
+ * Tracks that a new local regular event has been added that needs merging.
+ *
+ * @param eventHash the hash of the new local regular event.
+ * @param ledgerNodeId the ID of the ledger node the event was added to.
+ *
+ * @return a Promise that resolves once the operation completes.
+ */
+api.events.addLocalRegularEvent = async ({eventHash, ledgerNodeId}) => {
+  // new local events are `childless` meaning that they have no events
+  // that descend from them; they must be merged
+  const childlessKey = _cacheKey.childless(ledgerNodeId);
+  const localRegularEventCountKey = _cacheKey.eventCountLocal(
+    {ledgerNodeId, second: Math.round(Date.now() / 1000)});
+  return cache.client.multi()
+    .sadd(childlessKey, eventHash)
+    .incr(localRegularEventCountKey)
+    .expire(localRegularEventCountKey, eventsConfig.counter.ttl)
+    // inform ConsensusAgent and other listeners about new regular events
+    // so that they can be merged
+    .publish(`continuity2017|event|${ledgerNodeId}`, 'regular')
+    .exec();
+};
+
+/**
+ * Get the current merge status information for the ledger node identified
+ * by the given ID. This status information includes whether or not the
+ * ledger node is lagging/behind in gossip (indicating that it should not
+ * merge any events until caught up) and the hashes of any childless
+ * events (targets for merging ... to become the parents of the next
+ * potential merge event).
+ *
+ * @param ledgerNodeId the ID of the ledger node to get the merge status for.
+ *
+ * @return a Promise that resolves to the merge status info.
+ */
+api.events.getMergeStatus = async ({ledgerNodeId}) => {
+  // see if there are any childless events to be merged and if the node
+  // is too far behind in gossip to merge
+  const childlessKey = _cacheKey.childless(ledgerNodeId);
+  const gossipBehindKey = _cacheKey.gossipBehind(ledgerNodeId);
+  const [gossipBehind, childlessHashes] = await cache.client.multi()
+    .get(gossipBehindKey)
+    .smembers(childlessKey)
+    .exec();
+  // TODO: `gossipBehind` seems like it could have a more clear name
+  return {gossipBehind: gossipBehind !== null, childlessHashes};
+};
+
+/**
+ * Sets the current head for a creator ID in the cache. This head is stable,
+ * meaning it refers to an event that is in storage.
+ *
+ * @param creatorId the ID of the creator to set the head for.
+ * @param ledgerNodeId the ID of the ledger node to use.
+ * @param eventHash the event hash for the head.
+ * @param generation the generation for the head.
+ *
+ * @return a Promise that resolves once the operation completes.
+ */
+api.events.setHead = async (
+  {creatorId, ledgerNodeId, eventHash, generation}) => {
+  const key = _cacheKey.head({creatorId, ledgerNodeId});
+  await _setHead({key, eventHash, generation});
+};
+
+/**
+ * Gets the current head from the cache. This head is stable, meaning it refers
+ * to an event that is in storage.
+ *
+ * @param creatorId the ID of the creator to get the head for.
+ * @param ledgerNodeId the ID of the ledger node to check.
+ *
+ * @return a Promise that resolves to the head or `null` if none found.
+ */
+api.events.getHead = async ({creatorId, ledgerNodeId}) => {
+  const key = _cacheKey.head({creatorId, ledgerNodeId});
+  return _getHead({key});
+};
+
+/**
+ * Sets the genesis head from the cache.
+ *
+ * @param eventHash the event hash for the genesis merge event.
+ * @param ledgerNodeId the ID of the ledger node to update.
+ *
+ * @return a Promise that resolves once the operation completes.
+ */
+api.events.setGenesisHead = async ({eventHash, ledgerNodeId}) => {
+  const key = _cacheKey.genesis(ledgerNodeId);
+  await cache.client.set(key, eventHash);
+};
+
+/**
+ * Gets the genesis head from the cache.
+ *
+ * @param ledgerNodeId the ID of the ledger node to check.
+ *
+ * @return a Promise that resolves to the head or `null` if none found.
+ */
+api.events.getGenesisHead = async ({ledgerNodeId}) => {
+  const key = _cacheKey.genesis(ledgerNodeId);
+  const eventHash = await cache.client.get(key);
+  if(eventHash) {
+    return {eventHash, generation: 0};
+  }
+  return null;
+};
+
+/**
+ * Gets the *very* latest head in the event cache that may not have been
+ * written to storage yet, i.e. it can be *more recent* than just getting
+ * the head for a node. This head is useful during gossip, but not for merging
+ * events because it is not stable enough.
+ *
+ * @param creatorId the ID of the creator to get the latest head for.
+ * @param ledgerNodeId the ID of the ledger node to check.
+ *
+ * @return a Promise that resolves to the latest head or `null` if none found.
+ */
+api.events.getUncommittedHead = async ({creatorId, ledgerNodeId}) => {
+  const key = _cacheKey.latestPeerHead({creatorId, ledgerNodeId});
+  return _getHead({key});
+};
+
+/**
+ * Gets the generation for a single event identified by the given event hash
+ * and stored by the given ledger node. The generation indicates the order of
+ * an event relative to its creator node. A generation of `0` is the genesis
+ * event and events count up from there, scoped to each node.
+ *
+ * @param eventHash the hash of the event to get the generation for.
+ * @param ledgerNodeId the ID of the ledger node to use.
+ *
+ * @return a Promise that resolves to the generation for the event.
+ */
+api.events.getGeneration = async ({eventHash, ledgerNodeId}) => {
+  // first check cache
+  const key = _cacheKey.headGeneration({eventHash, ledgerNodeId});
+  const generation = await cache.client.get(key);
+  if(generation !== null) {
+    return parseInt(generation, 10);
+  }
+  // no generation found for the eventHash
+  return generation;
+};
+
+/**
+ * Bulk sets the generation for every event in the given Map.
+ *
+ * @param generationMap a Map of eventHash => generation to set.
+ * @param ledgerNodeId the ID of the ledger node to use.
+ *
+ * @return a Promise that resolves once the operation completes.
+ */
+api.events.setGenerations = async ({generationMap, ledgerNodeId}) => {
+  if(generationMap.size === 0) {
+    // nothing to do
+    return;
+  }
+  // use a single atomic transaction to set all generations
+  const txn = cache.client.multi();
+  for(const [eventHash, generation] of generationMap) {
+    const key = _cacheKey.headGeneration({eventHash, ledgerNodeId});
+    txn.set(key, generation, 'EX', 36000);
+  }
+  return txn.exec();
+};
+
+/**
+ * Bulk gets the generations for all events identified by the given hashes.
+ *
+ * @param eventHashes the hashes of the events to get the generations for.
+ * @param ledgerNodeId the ID of the ledger node to use.
+ *
+ * @return a Promise that resolves to an object with:
+ *         generationMap: a Map of eventHash => generation where the entries
+ *           will preserve the order of `eventHashes`; any missing generation
+ *           will be `null`.
+ *         notFound: an array of eventHashes that were not found.
+ */
+api.events.getGenerations = async ({eventHashes, ledgerNodeId}) => {
+  // create keys in order (ensures event hash order is preserved)
+  const keys = eventHashes.map(eventHash =>
+    _cacheKey.headGeneration({eventHash, ledgerNodeId}));
+  const generations = await cache.client.mget(keys);
+
+  // insert entries into generation map in order
+  const generationMap = new Map();
+  const notFound = [];
+  let index = 0;
+  for(const eventHash in eventHashes) {
+    const generation = generations[index++];
+    if(generation === null) {
+      notFound.push(eventHash);
+      generationMap.set(eventHash, null);
+    } else {
+      generationMap.set(eventHash, parseInt(generation, 10));
+    }
+  }
+  return {generationMap, notFound};
+};
+
+/**
+ * Compute the difference between the given event hashes and those that are
+ * in the event cache, i.e. return which event hashes are NOT in the cache.
+ *
+ * @param eventHashes the hashes of events to look for.
+ * @param ledgerNodeId the ID of the ledger node to check.
+ *
+ * @return a Promise that resolves to an array with the events that are
+ *         not in the cache.
+ */
+api.events.difference = async ({eventHashes, ledgerNodeId}) => {
+  if(eventHashes.length === 0) {
+    return [];
+  }
+  // get a random key to use for the diff operation
+  const diffKey = `d|${uuid()}`;
+  // get key for event queue
+  const eventQueueSetKey = _cacheKey.eventQueueSet(ledgerNodeId);
+
+  // TODO: this could be implemented as smembers as well and diff the hashes
+  // as an array, if the eventQueueSetKey contains a large set, then the
+  // existing implementation is good
+
+  // Note: Here we use an atomic transaction that adds an entry to redis
+  //   just to perform a diff and then removes it.
+  // 1. Add `diffKey` with `eventHashes` array as the value.
+  // 2. Run `sdiff` to diff that value with what is in the event queue
+  //    for the ledger node (using key `eventQueueSetKey`).
+  // 3. Delete the `diffKey` once we're done running the diff.
+  //
+  // the results of `sadd` is in result[0], `sdiff` is in result[1], so
+  // we destructure result[1] into `notFound` (i.e. events not in the queue)
+  const [, notFound] = await cache.client.multi()
+    .sadd(diffKey, eventHashes)
+    .sdiff(diffKey, eventQueueSetKey)
+    .del(diffKey)
+    .exec();
+  return notFound;
+};
+
+/**
+ * Track duplicate events for statistics analysis.
+ *
+ * @param count the number of additional duplicate events detected.
+ */
+api.events.trackDuplicates = async ({count}) => {
+  if(count === 0) {
+    // nothing to do
+    return;
+  }
+  // for statistics purposes only, ignore errors
+  cache.client.incrby(`dup-${Math.round(Date.now() / 60000)}`, count)
+    .catch(() => {});
+};
+
+/**
+ * Gets the reset history of merge events from the cache. This history includes
+ * all merge events in the cache that have not achieved consensus and a map of
+ * each event's hash to each event. The event data model is also modified
+ * with custom fields to assist in the consensus algorithm. Each event
+ * looks like: `{eventHash, event, meta, _children, _parents}`. The
+ * `_children` and `_parents` arrays will be populated by the consensus
+ * algorithm. The `event` value only has summary info like tree and parent
+ * hashes and does not include operations.
+ *
+ * @param ledgerNodeId the ID of the ledger node to check.
+ *
+ * @return a Promise that resolves to an object with:
+ *           events - an array of events with a data model customized for
+ *             the consensus algorithm.
+ *           eventMap - a map of event hash => event (with custom data model).
+ */
+api.events.getRecentHistory = async ({ledgerNodeId}) => {
+  const events = [];
+  const eventMap = {};
+
+  // get all *merge* events available
+  const outstandingMergeKey = _cacheKey.outstandingMerge(ledgerNodeId);
+  const keys = await cache.client.smembers(outstandingMergeKey);
+  if(!(keys && keys.length > 0)) {
+    // no recent history to merge detected
+    return {events, eventMap};
+  }
+
+  // result contains an array of JSON for event summary data (tree and parent
+  // hash info, no operations, etc.)
+  const result = await cache.client.mget(keys);
+  // sanity check to ensure all merge events could be retrieved... if
+  // `null` is in the array then at least one is missing
+  if(result.includes(null)) {
+    // FIXME: is this recoverable? how? document if so... does `repairCache`
+    // handle it?
+    throw new BedrockError(
+      'One or more events are missing from the cache.',
+      'InvalidStateError', {
+        httpStatusCode: 400,
+        public: true,
+      });
+  }
+  for(const eventSummaryJson of result) {
+    const parsed = JSON.parse(eventSummaryJson);
+    const {eventHash} = parsed;
+    const {parentHash, treeHash, type} = parsed.event;
+    const {creator} = parsed.meta.continuity2017;
+    const doc = {
+      _children: [],
+      _parents: [],
+      eventHash,
+      event: {parentHash, treeHash, type},
+      meta: {continuity2017: {creator}}
+    };
+    events.push(doc);
+    eventMap[doc.eventHash] = doc;
+  }
+
+  return {events, eventMap};
+};
+
+api.gossip = {};
+
+/**
+ * Called when a node receives a notification from another peer.
+ *
+ * @param recipientId the ID of the recipient of the notification.
+ * @param senderId the ID of the sender of the notification.
+ *
+ * @return a Promise that resolves once the operation completes.
+ */
+api.gossip.addNotification = async ({receiverId, senderId}) => {
+  const key = _cacheKey.gossipNotification(receiverId);
+  // a set is used here because it only allows unique values
+  return cache.client.sadd(key, senderId);
+};
+
+api.operations = {};
+
+/**
+ * Adds an operation to the cache.
+ *
+ * @param operation the operation to cache.
+ * @param operationHash the hash for the operation.
+ * @param recordId the `database.hash` of the ID of the record for the
+ *          operation.
+ * @param ledgerNodeId the ID of the ledger node to update.
+ *
+ * @return a Promise that resolves once the operation completes.
+ */
+api.operations.add = async (
+  {operation, operationHash, recordId, ledgerNodeId}) => {
+  // using uuid instead of hash because duplicate operations are allowed
+  const opKey = _cacheKey.operation({ledgerNodeId, opId: uuid()});
+  const opListKey = _cacheKey.operationList(ledgerNodeId);
+  const opCountKey = _cacheKey.opCountLocal(
+    {ledgerNodeId, second: Math.round(Date.now() / 1000)});
+  return cache.client.multi()
+    .incr(opCountKey)
+    .expire(opCountKey, operationsConfig.counter.ttl)
+    .set(opKey, JSON.stringify({operation, meta: {operationHash}, recordId}))
+    .rpush(opListKey, opKey)
+    .publish(`continuity2017|operation|${ledgerNodeId}`, 'add')
+    .exec();
+};
+
+async function _setHead({key, eventHash, generation}) {
+  return cache.client.hmset(key, 'h', eventHash, 'g', generation);
+}
+
+async function _getHead({key}) {
+  const [eventHash, generation] = await cache.client.hmget(key, 'h', 'g');
+  // redis returns null if key is not found
+  if(eventHash === null) {
+    return null;
+  }
+  return {eventHash, generation: parseInt(generation, 10)};
+}

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -152,7 +152,7 @@ api.events.addLocalMergeEvent = async ({event, meta, ledgerNodeId}) => {
     meta: {continuity2017: {creator: creatorId}}
   });
   try {
-    const result = cache.client.multi()
+    const result = await cache.client.multi()
       .srem(childlessKey, parentHashes)
       .set(eventKey, eventSummary)
       .sadd(outstandingMergeKey, eventKey)

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -321,7 +321,7 @@ api.events.getGeneration = async ({eventHash, ledgerNodeId}) => {
     return parseInt(generation, 10);
   }
   // no generation found for the eventHash
-  return generation;
+  return null;
 };
 
 /**
@@ -395,7 +395,7 @@ api.events.difference = async ({eventHashes, ledgerNodeId}) => {
     return [];
   }
   // get a random key to use for the diff operation
-  const diffKey = `d|${uuid()}`;
+  const diffKey = _cacheKey.diff(uuid());
   // get key for event queue
   const eventQueueSetKey = _cacheKey.eventQueueSet(ledgerNodeId);
 

--- a/lib/election.js
+++ b/lib/election.js
@@ -6,7 +6,7 @@
 const _ = require('lodash');
 const bedrock = require('bedrock');
 const _blocks = require('./blocks');
-const cache = require('bedrock-redis');
+const _cache = require('./cache');
 const {callbackify, BedrockError} = bedrock.util;
 const brLedgerNode = require('bedrock-ledger-node');
 const logger = require('./logger');
@@ -38,10 +38,6 @@ bedrock.events.on('bedrock.start', async () => {
 const api = {};
 module.exports = api;
 
-api._client = require('./client');
-api._hasher = brLedgerNode.consensus._hasher;
-api._storage = require('./storage');
-api._voters = require('./voters');
 api._consensus = require('./consensus');
 // exposed for testing
 api._getElectorBranches = api._consensus._getElectorBranches;
@@ -67,17 +63,14 @@ api._findMergeEventProof = api._consensus._findMergeEventProof;
 api.findConsensus = callbackify(async (
   {ledgerNode, history, blockHeight, electors}) => {
   logger.verbose('Start sync _runConsensusInPool, electors', {electors});
-  const startTime = Date.now();
+  const timer = new _cache.Timer();
+  timer.start({name: 'findConsensus', ledgerNodeId: ledgerNode.id});
   let consensus;
-  let err;
   try {
     consensus = await _runConsensusInPool(
       {ledgerNode, history, blockHeight, electors});
   } finally {
-    // failure to cache logging info not critical, ignore in `.catch`
-    const duration = Date.now() - startTime;
-    cache.client.set(`findConsensus|${ledgerNode.id}`, duration)
-      .catch(() => {});
+    const duration = await timer.stop();
     logger.verbose('End sync _runConsensusInPool', {duration});
   }
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -632,13 +632,6 @@ async function _pruneManifest({ledgerNode, manifest, eventHashes}) {
   // remove linear search below)
   const notFound = await api.difference({eventHashes, ledgerNode});
 
-  // Note: typically this function is called from gossip using a set of
-  // events that were requested ... here we track how many of these events
-  // we actually already had, indicating that we're being inefficient and
-  // requesting duplicate events we don't need
-  const dupCount = eventHashes.length - notFound.length;
-  _cache.events.trackDuplicates({count: dupCount});
-
   // remove any hashes that *were* found in storage/cache from the manifest, so
   // that the manifest only has hashes NOT in storage/cache when it is returned
   // FIXME: why a full clone and not just `.filter`?

--- a/lib/events.js
+++ b/lib/events.js
@@ -571,7 +571,7 @@ api.getGenesisHead = callbackify(async ({ledgerNode}) => {
   head = {eventHash: meta.eventHash, generation: 0};
 
   // update cache before returning head so it can be used next time
-  _cache.events.setGenesisHead({eventHash: head.eventHash, ledgerNodeId});
+  await _cache.events.setGenesisHead({eventHash: head.eventHash, ledgerNodeId});
 
   return head;
 });
@@ -649,15 +649,15 @@ async function _pruneManifest({ledgerNode, manifest, eventHashes}) {
 
 // all ancestors should exist in redis or mongo, diff should be empty
 async function _checkAncestors({ledgerNode, parentHash}) {
-  const result = await api.difference({eventHashes: parentHash, ledgerNode});
-  if(result.length !== 0) {
+  const missing = await api.difference({eventHashes: parentHash, ledgerNode});
+  if(missing.length !== 0) {
     throw new BedrockError(
       'Events from `parentHash` and/or `treeHash` are missing.',
       'InvalidStateError', {
         httpStatusCode: 400,
         // TODO: a more accurate missing array can be computed
         // taking into account the cache hits
-        missing: result,
+        missing,
         public: true,
       });
   }

--- a/lib/events.js
+++ b/lib/events.js
@@ -5,13 +5,12 @@
 
 const _ = require('lodash');
 const _blocks = require('./blocks');
-const _cacheKey = require('./cache-key');
+const _cache = require('./cache');
 const _operations = require('./operations');
 const _util = require('./util');
 const _voters = require('./voters');
 const bedrock = require('bedrock');
 const brLedgerNode = require('bedrock-ledger-node');
-const cache = require('bedrock-redis');
 const {callbackify, BedrockError} = bedrock.util;
 const {config} = bedrock;
 const continuityStorage = require('./storage');
@@ -20,14 +19,10 @@ const jsonld = bedrock.jsonld;
 const logger = require('./logger');
 const {promisify} = require('util');
 const signature = require('./signature');
-const uuid = require('uuid/v4');
 const voters = require('./voters');
 
 // TODO: remove once bedrock-validation supports promises
 const validate = promisify(require('bedrock-validation').validate);
-
-const eventsConfig = config['ledger-consensus-continuity'].events;
-const operationsConfig = config['ledger-consensus-continuity'].operations;
 
 const api = {};
 module.exports = api;
@@ -185,7 +180,8 @@ api.aggregateHistory = callbackify(async ({
     {$unwind: '$_parents'},
     {$replaceRoot: {newRoot: '$_parents'}},
   ];
-  const startTime = Date.now();
+  const timer = new _cache.Timer();
+  timer.start({name: 'aggregate', ledgerNodeId: ledgerNode.id});
   const history = await collection.aggregate(
     pipeline, {allowDiskUse: true}).toArray();
   if(history.length === 0) {
@@ -193,71 +189,56 @@ api.aggregateHistory = callbackify(async ({
   }
 
   const sortedHistory = _sortHistory(history);
-
-  // set duration timer (ignore errors, for stats only)
-  cache.client.set(`aggregate|${ledgerNode.id}`, Date.now() - startTime)
-    .catch(() => {});
-
+  timer.stop();
   return sortedHistory;
 });
 
 // TODO: document (create a regular local event w/operations)
 api.create = callbackify(async ({ledgerNode}) => {
   logger.verbose('Attempting to create an event.');
-  try {
-    // get a chunk of operations to put into the event
-    const {operations, operationHash, truncated, opKeys} =
-      await _getOperationChunk({ledgerNode});
 
-    // TODO: could fetch `voter` and head concurrently with fetching operations
-    // once it's clear that those operations exist
-    const ledgerNodeId = ledgerNode.id;
-    const {id: creatorId} = await voters.get({ledgerNodeId});
-    const {eventHash: headHash} = await api._getLocalBranchHead(
-      {creatorId, ledgerNode});
-
-    // create the event and its hash
-    const event = {
-      '@context': config.constants.WEB_LEDGER_CONTEXT_V1_URL,
-      type: 'WebLedgerOperationEvent',
-      operationHash,
-      parentHash: [headHash],
-      treeHash: headHash
-    };
-    const eventHash = await _util.hasher(event);
-
-    // store the operations first (if this fails, the same event hash will be
-    // generated on retry)
-    await _operations.write({eventHash, ledgerNode, operations});
-
-    // store the event
-    await api.add({event, eventHash, ledgerNode});
-
-    // TODO: move to a separate redis/cache file/module
-    // clear the events from the redis operation queue
-    const opSelectedListKey = _cacheKey.operationSelectedList(ledgerNodeId);
-    await cache.client.multi()
-      // remove the selected list entirely
-      .del(opSelectedListKey)
-      // delete the keys that contain the operation documents
-      .del(opKeys)
-      .exec();
-
-    return {truncated};
-  } catch(e) {
-    // FIXME: remove try/catch and just return early by checking
-    // operations.length === 0
-    if(e.name === 'AbortError') {
-      return {truncated: false};
-    }
-    throw e;
+  const ledgerNodeId = ledgerNode.id;
+  const queue = new _cache.OperationQueue({ledgerNodeId});
+  if(!await queue.hasNextChunk()) {
+    logger.debug('No new operations.');
+    return {truncated: false};
   }
+
+  // get chunk of operations to put into the event concurrently with
+  // fetching the head hash to merge on top of
+  const [{operations, truncated}, {eventHash: headHash}] = await Promise.all([
+    queue.getNextChunk(),
+    voters.get({ledgerNodeId}).then(({id: creatorId}) =>
+      api._getLocalBranchHead({creatorId, ledgerNode}))]);
+
+  // create the event and its hash
+  const event = {
+    '@context': config.constants.WEB_LEDGER_CONTEXT_V1_URL,
+    type: 'WebLedgerOperationEvent',
+    operationHash: operations.map(op => op.meta.operationHash),
+    parentHash: [headHash],
+    treeHash: headHash
+  };
+  const eventHash = await _util.hasher(event);
+
+  // store the operations first (if this fails, the same event hash will be
+  // generated on retry)
+  await _operations.write({eventHash, ledgerNode, operations});
+
+  // store the event
+  await api.add({event, eventHash, ledgerNode});
+
+  // event successfully written, can now pop the chunk off the queue
+  await queue.popChunk();
+
+  return {truncated};
 });
 
 // called from consensus worker
 api.getRecentHistory = callbackify(async ({creatorId, ledgerNode}) => {
   logger.verbose('Start getRecentHistory');
-  const startTime = Date.now();
+  const timer = new _cache.Timer();
+  timer.start({name: 'recentHistoryMergeOnly', ledgerNodeId: ledgerNode.id});
 
   const localBranchHead = await api._getLocalBranchHead(
     {creatorId, ledgerNode});
@@ -270,73 +251,22 @@ api.getRecentHistory = callbackify(async ({creatorId, ledgerNode}) => {
       });
   }
 
-  // TODO: document
-  const outstandingMergeKey = _cacheKey.outstandingMerge(ledgerNode.id);
-  const keys = await cache.client.smembers(outstandingMergeKey);
+  const {events, eventMap} = await _cache.events.getRecentHistory(
+    {ledgerNodeId: ledgerNode.id});
 
-  const events = [];
-  const eventMap = {};
-  if(keys && keys.length > 0) {
-    // TODO: document (...if any result is `null` then events are missing)
-    const result = await cache.client.mget(keys);
-    if(result.indexOf(null) !== -1) {
-      throw new BedrockError(
-        'One or more events are missing from the cache.',
-        'InvalidStateError', {
-          httpStatusCode: 400,
-          public: true,
-        });
-    }
-    // TODO: document the data model here
-    for(const eventSummaryJson of result) {
-      const parsed = JSON.parse(eventSummaryJson);
-      const {eventHash} = parsed;
-      const {parentHash, treeHash, type} = parsed.event;
-      const {creator} = parsed.meta.continuity2017;
-      const doc = {
-        _children: [],
-        _parents: [],
-        eventHash,
-        event: {parentHash, treeHash, type},
-        meta: {continuity2017: {creator}}
-      };
-      events.push(doc);
-      eventMap[doc.eventHash] = doc;
-    }
-  }
-
-  // ignore errors, just stats calculations
-  const duration = Date.now() - startTime;
-  cache.client.set(`recentHistoryMergeOnly|${ledgerNode.id}`, duration)
-    .catch(() => {});
+  const duration = timer.stop();
   logger.verbose('End getRecentHistory', {duration});
 
   return {events, eventMap, localBranchHead};
 });
 
 api.merge = callbackify(async ({creatorId, ledgerNode}) => {
-  // TODO: move to redis/cache separate file/module
-  // if no childless events to be merged, return
-  const childlessKey = _cacheKey.childless(ledgerNode.id);
-  const gossipBehind = _cacheKey.gossipBehind(ledgerNode.id);
-  const multi = cache.client.multi();
-  multi.get(gossipBehind);
-  multi.smembers(childlessKey);
-  const result = await multi.exec();
+  // get hashes of events that can be merged and set them as the parent hashes
+  // for the potential new merge event
+  const parentHashes = await _getMergeableHashes({ledgerNode});
 
-  // if the gossipBehind key is set, do not merge
-  if(result[0] !== null) {
-    return null;
-  }
-
-  // if there are no childless events, do not merge
-  const parentHashes = result[1];
+  // nothing to merge
   if(parentHashes.length === 0) {
-    return null;
-  }
-
-  // if no outstanding regular events to merge, return
-  if(!await _hasOutstandingRegularEvents({ledgerNode})) {
     return null;
   }
 
@@ -376,7 +306,7 @@ api.merge = callbackify(async ({creatorId, ledgerNode}) => {
   const record = await ledgerNode.storage.events.add({event: signed, meta});
 
   // update cache
-  await _updateCache({eventRecord: record, ledgerNodeId});
+  await _cache.events.addLocalMergeEvent({...record, ledgerNodeId});
 
   // FIXME: return {record, truncated} instead of mixing truncated into record
   //return {record, truncated};
@@ -386,7 +316,9 @@ api.merge = callbackify(async ({creatorId, ledgerNode}) => {
 api.repairCache = callbackify(async ({eventHash, ledgerNode}) => {
   const ledgerNodeId = ledgerNode.id;
   const eventRecord = await ledgerNode.storage.events.get(eventHash);
-  const updateCache = await _updateCache({eventRecord, ledgerNodeId});
+  // FIXME: update tests to make return value make more sense
+  const updateCache = await _cache.events.addLocalMergeEvent(
+    {...eventRecord, ledgerNodeId});
   return {updateCache};
 });
 
@@ -500,32 +432,16 @@ api.getHeads = callbackify(async ({eventHashes, ledgerNode}) => {
   if(!ledgerNode) {
     throw new TypeError('"ledgerNode" is required.');
   }
-  // eventHash, generation
-  const headGenerationMap = new Map();
-  // add every hash to headGenerationMap to ensure order is preserved
-  eventHashes.forEach(eventHash => headGenerationMap.set(eventHash, null));
+  // Map of: eventHash => generation
   const ledgerNodeId = ledgerNode.id;
+  // first, get generations from cache
+  const {generationMap: headGenerationMap, notFound} =
+    await _cache.events.getGenerations({eventHashes, ledgerNodeId});
 
-  // first, get heads from redis cache
-  const keys = eventHashes.map(
-    eventHash => _cacheKey.headGeneration({eventHash, ledgerNodeId}));
-  const cacheMisses = [];
-  const result = await cache.client.mget(keys);
-  result.forEach((generation, i) => {
-    // redis returns null for misses
-    if(generation === null) {
-      // the eventHash, not the cache key
-      cacheMisses.push(eventHashes[i]);
-      return;
-    }
-    // the eventHash, not the cache key
-    headGenerationMap.set(eventHashes[i], parseInt(generation, 10));
-  });
-
-  // for every cache miss, get heads from storage
-  if(cacheMisses.length > 0) {
+  // for every cache miss, get generations from storage
+  if(notFound.length > 0) {
     const {collection} = ledgerNode.storage.events;
-    const query = {'meta.eventHash': {$in: cacheMisses}};
+    const query = {'meta.eventHash': {$in: notFound}};
     const projection = {
       _id: 0, 'meta.eventHash': 1, 'meta.continuity2017.generation': 1
     };
@@ -539,17 +455,9 @@ api.getHeads = callbackify(async ({eventHashes, ledgerNode}) => {
       toBeCached.set(meta.eventHash, meta.continuity2017.generation);
     });
 
-    // FIXME: move to redis/cache file/module
     // update cache
-    if(toBeCached.size > 0) {
-      const txn = cache.client.multi();
-      for(const [eventHash, generation] of toBeCached) {
-        const headGenerationKey = _cacheKey.headGeneration(
-          {eventHash, ledgerNodeId});
-        txn.set(headGenerationKey, generation, 'EX', 36000);
-      }
-      await txn.exec();
-    }
+    await _cache.events.setGenerations(
+      {generationMap: toBeCached, ledgerNodeId});
   }
 
   for(const [eventHash, generation] of headGenerationMap) {
@@ -572,6 +480,7 @@ api.getHeads = callbackify(async ({eventHashes, ledgerNode}) => {
 // and use an appropriate name since
 // this is not just for local branch, this finds the latest merge event from
 // the specified creator
+// FIXME: rename to `getHead` since this works for all branches
 api._getLocalBranchHead = callbackify(async (
   {useCache = true, creatorId, latest = false, ledgerNode}) => {
   if(!useCache && latest) {
@@ -581,34 +490,22 @@ api._getLocalBranchHead = callbackify(async (
   }
   const ledgerNodeId = ledgerNode.id;
   const eventsCollection = ledgerNode.storage.events.collection;
-  const headCacheKey = _cacheKey.head({creatorId, ledgerNodeId});
 
   let head;
 
-  // `latest` flag is set, so using `latestPeerHead`, if available, is valid
+  // `latest` flag is set, so using a head that is not yet committed to
+  // storage, if available, is valid
   if(latest) {
-    // NOTE: latestPeerHead is the *very* latest head in the event pipeline
-    // which may not have been written to mongo yet. This head is useful
-    // during gossip, but not for merging events.
-    const latestPeerHeadKey = _cacheKey.latestPeerHead(
-      {creatorId, ledgerNodeId});
-    const [eventHash, generation] = await cache.client.hmget(
-      latestPeerHeadKey, 'h', 'g');
-    // redis returns null if key is not found
-    if(eventHash !== null) {
-      head = {eventHash, generation: parseInt(generation, 10)};
-    }
+    // NOTE: The uncommitted head is the *very* latest head in the event
+    // pipeline which may not have been written to storage yet. This head is
+    // useful during gossip, but not for merging events because it lacks
+    // stability.
+    head = await _cache.events.getUncommittedHead({creatorId, ledgerNodeId});
   }
 
-  // no head found yet; get it from cache if allowed
+  // no head found yet; get head from cache if allowed
   if(!head && useCache) {
-    // return regular heads from cache/mongo even if latest flag is set
-    const [eventHash, generation] = await cache.client.hmget(
-      headCacheKey, 'h', 'g');
-    // redis returns null if key is not found
-    if(eventHash !== null) {
-      head = {eventHash, generation: parseInt(generation, 10)};
-    }
+    head = await _cache.events.getHead({creatorId, ledgerNodeId});
   }
 
   // no head found yet; use latest local merge event
@@ -632,7 +529,8 @@ api._getLocalBranchHead = callbackify(async (
 
       // update cache if flag is set
       if(useCache) {
-        await cache.client.hmset(headCacheKey, 'h', eventHash, 'g', generation);
+        await _cache.events.setHead(
+          {creatorId, ledgerNodeId, eventHash, generation});
       }
     }
   }
@@ -646,14 +544,11 @@ api._getLocalBranchHead = callbackify(async (
 });
 
 api.getGenesisHead = callbackify(async ({ledgerNode}) => {
-  // generation for genesis is always zero
-  const generation = 0;
-
-  // get genesis event hash from cache
-  const genesisCacheKey = _cacheKey.genesis(ledgerNode.ledger);
-  const genesisCache = await cache.client.get(genesisCacheKey);
-  if(genesisCache) {
-    return {eventHash: genesisCache, generation: 0};
+  // get genesis head from cache
+  const ledgerNodeId = ledgerNode.id;
+  let head = await _cache.events.getGenesisHead({ledgerNodeId});
+  if(head) {
+    return head;
   }
 
   // get genesis hash from storage
@@ -672,32 +567,81 @@ api.getGenesisHead = callbackify(async ({ledgerNode}) => {
         public: true,
       });
   }
-  const head = {eventHash: meta.eventHash, generation};
+  // generation for genesis is always zero
+  head = {eventHash: meta.eventHash, generation: 0};
 
   // update cache before returning head so it can be used next time
-  await cache.client.set(genesisCacheKey, head.eventHash);
+  _cache.events.setGenesisHead({eventHash: head.eventHash, ledgerNodeId});
 
   return head;
 });
 
-// return hashes that do not exist in redis or mongo
-async function _diffManifest({ledgerNode, manifest, eventHashes}) {
+api.difference = async ({eventHashes, ledgerNode}) => {
+  // first check event queue in the cache...
+  const notFound = await _cache.events.difference(
+    {eventHashes, ledgerNodeId: ledgerNode.id});
+  if(notFound.length === 0) {
+    return notFound;
+  }
+  // ...of the events not found in the event queue (redis), return those that
+  // are also not in storage (mongo), i.e. we haven't stored them at all
+  return ledgerNode.storage.events.difference(notFound);
+};
+
+api.processEvents = callbackify(async ({events, ledgerNode}) => {
+  logger.verbose('Processing events.', {
+    eventCount: events.length
+  });
+
+  const rawManifest = events;
+  const rawManifestEventHashes = rawManifest.map(e => e.eventHash);
+  const manifest = await _pruneManifest(
+    {ledgerNode, manifest: rawManifest,
+      eventHashes: rawManifestEventHashes});
+
+  // start with de-duped manifest
+  const allAncestors = [].concat(...manifest.map(r => r.event.parentHash));
+  // remove dups and any ancestors that are contained in the
+  // manifest itself
+  const eventHashes = _.uniq(allAncestors).filter(
+    a => !rawManifestEventHashes.includes(a));
+  await _checkAncestors({eventHashes, ledgerNode});
+
+  // add in serial to ensure that events are stored in the proper order
+  for(const e of manifest) {
+    await ledgerNode.events.add({continuity2017: {peer: true}, event: e.event});
+  }
+});
+
+/**
+ * Removes any event hashes from a manifest that are already present in
+ * the ledger node's cache or storage, i.e. hashes for events that are not
+ * needed.
+ *
+ * @param ledgerNode the ledger node to check.
+ * @param manifest the manifest of events.
+ * @param eventHashes the hashes of the events in the manifest.
+ */
+async function _pruneManifest({ledgerNode, manifest, eventHashes}) {
   if(eventHashes.length === 0) {
     return;
   }
   // of the `eventHashes` given, determine which are not found in our
-  // event queue or in storage via `_diff`
-  const notFound = await _diff({eventHashes, ledgerNode});
-  // TODO: why is this a duplicate count instead of just a count of what
-  // events we don't have?
+  // event queue or in storage
+  // FIXME: wrap `notFound` in a Set for performance improvements? (i.e.
+  // remove linear search below)
+  const notFound = await api.difference({eventHashes, ledgerNode});
+
+  // Note: typically this function is called from gossip using a set of
+  // events that were requested ... here we track how many of these events
+  // we actually already had, indicating that we're being inefficient and
+  // requesting duplicate events we don't need
   const dupCount = eventHashes.length - notFound.length;
-  if(dupCount !== 0) {
-    // for statistics purposes only, ignore errors
-    cache.client.incrby(`dup-${Math.round(Date.now() / 60000)}`, dupCount)
-      .catch(() => {});
-  }
-  // remove any hashes that *are* found from the manifest, so that the
-  // manifest only has not found hashes when it is returned
+  _cache.events.trackDuplicates({count: dupCount});
+
+  // remove any hashes that *were* found in storage/cache from the manifest, so
+  // that the manifest only has hashes NOT in storage/cache when it is returned
+  // FIXME: why a full clone and not just `.filter`?
   const _manifest = bedrock.util.clone(manifest);
   _.remove(_manifest, e => !notFound.includes(e.eventHash));
   return _manifest;
@@ -705,7 +649,7 @@ async function _diffManifest({ledgerNode, manifest, eventHashes}) {
 
 // all ancestors should exist in redis or mongo, diff should be empty
 async function _checkAncestors({ledgerNode, parentHash}) {
-  const result = await _diff({eventHashes: parentHash, ledgerNode});
+  const result = await api.difference({eventHashes: parentHash, ledgerNode});
   if(result.length !== 0) {
     throw new BedrockError(
       'Events from `parentHash` and/or `treeHash` are missing.',
@@ -719,68 +663,6 @@ async function _checkAncestors({ledgerNode, parentHash}) {
   }
 }
 
-// TODO: move to redis/cache file/module for reuse
-async function _diff({eventHashes, ledgerNode}) {
-  if(eventHashes.length === 0) {
-    return [];
-  }
-  const ledgerNodeId = ledgerNode.id;
-  const manifestId = uuid();
-  const eventQueueSetKey = _cacheKey.eventQueueSet(ledgerNodeId);
-  const manifestKey = _cacheKey.manifest({ledgerNodeId, manifestId});
-
-  // TODO: this could be implemented as smembers as well and diff the hashes
-  // as an array, if the eventQueueSetKey contains a large set, then the
-  // existing implementation is good
-
-  // Note: Here we add an entry to redis just to perform a diff...
-  // 1. Add `manifestKey` with `eventHashes` array as the value
-  // 2. Run `sdiff` to do diff that value with what is in the event queue
-  //    for the ledger node (using key `eventQueueSetKey`)
-  // 3. Delete the `manifestKey` once we're done running the diff
-  // ... and results of `sadd` is in result[0], `sdiff` is in result[1], so
-  // we destructure result[1] into `notFound` (i.e. events not in the queue)
-  const [, notFound] = await cache.client.multi()
-    .sadd(manifestKey, eventHashes)
-    .sdiff(manifestKey, eventQueueSetKey)
-    .del(manifestKey)
-    .exec();
-  // ...of the events not found in the event queue (redis), return those that
-  // are also not in storage (mongo), i.e. we haven't stored them at all
-  return ledgerNode.storage.events.difference(notFound);
-}
-
-api.processEvents = callbackify(async ({events, ledgerNode}) => {
-  logger.verbose('Processing events.', {
-    eventCount: events.length
-  });
-
-  const rawManifest = events;
-  const rawManifestEventHashes = rawManifest.map(e => e.eventHash);
-  const manifest = await _diffManifest(
-    {ledgerNode, manifest: rawManifest,
-      eventHashes: rawManifestEventHashes});
-
-  // start with de-duped manifest
-  // TODO: change to use this commented line
-  //const allAncestors = [].concat(...manifest.map(r => r.event.parentHash));
-  const allAncestors = [];
-  for(let i = 0; i < manifest.length; ++i) {
-    Array.prototype.push.apply(
-      allAncestors, manifest[i].event.parentHash);
-  }
-  // remove dups and any ancestors that are contained in the
-  // manifest itself
-  const eventHashes = _.uniq(allAncestors).filter(
-    a => !rawManifestEventHashes.includes(a));
-  await _checkAncestors({eventHashes, ledgerNode});
-
-  // add in serial to ensure that events are stored in the proper order
-  for(const e of manifest) {
-    await ledgerNode.events.add({continuity2017: {peer: true}, event: e.event});
-  }
-});
-
 async function _genesisProofCreate({ledgerNode, eventHash}) {
   const doc = {
     '@context': config.constants.WEB_LEDGER_CONTEXT_V1_URL,
@@ -792,6 +674,27 @@ async function _genesisProofCreate({ledgerNode, eventHash}) {
   const mergeEvent = await voters.sign({doc, ledgerNodeId});
   const mergeHash = await _util.hasher(mergeEvent);
   return {creator, mergeEvent, mergeHash};
+}
+
+async function _getMergeableHashes({ledgerNode}) {
+  const {gossipBehind, childlessHashes} = await _cache.events.getMergeStatus(
+    {ledgerNodeId: ledgerNode.id});
+  // if behind in gossip, do not merge
+  if(gossipBehind) {
+    return [];
+  }
+
+  // if there are no childless events, nothing to merge
+  if(childlessHashes.length === 0) {
+    return [];
+  }
+
+  // if no outstanding regular events to merge, nothing to merge
+  if(!await _hasOutstandingRegularEvents({ledgerNode})) {
+    return [];
+  }
+
+  return childlessHashes;
 }
 
 // determine if there are any non-consensus events of type
@@ -809,15 +712,14 @@ async function _hasOutstandingRegularEvents({ledgerNode}) {
   return !!record;
 }
 
-// looks in queue and database for an event
+// looks in cache and storage for an event's generation
 async function _getGeneration({eventHash, ledgerNode}) {
   // first check cache
-  const headGenerationKey = _cacheKey.headGeneration(
+  const generation = await _cache.events.getGeneration(
     {eventHash, ledgerNodeId: ledgerNode.id});
-  const generation = await cache.client.get(headGenerationKey);
   if(generation !== null) {
     // cache hit
-    return parseInt(generation, 10);
+    return generation;
   }
 
   // check storage
@@ -889,7 +791,7 @@ async function _processPeerRegularEvent({event, ledgerNode, needed}) {
 
   // lexicographic sort on the hash of the operation determines the
   // order of operations in events
-  _sortOperations(operationRecords);
+  _util.sortOperations(operationRecords);
 
   for(let i = 0; i < operationRecords.length; ++i) {
     const {meta} = operationRecords[i];
@@ -966,95 +868,6 @@ async function _processPeerEvent({event, ledgerNode, needed}) {
       httpStatusCode: 404,
       public: true,
     });
-}
-
-async function _queueEvent({event, ledgerNodeId, meta}) {
-  const {eventHash} = meta;
-  const {creator: creatorId, generation, type} = meta.continuity2017;
-  const eventKey = _cacheKey.event({eventHash, ledgerNodeId});
-  const eventQueueKey = _cacheKey.eventQueue(ledgerNodeId);
-  const eventQueueSetKey = _cacheKey.eventQueueSet(ledgerNodeId);
-  const eventJson = JSON.stringify({event, eventHash, meta});
-
-  // NOTE: redis multi is an atomic operation
-  const multi = cache.client.multi();
-  if(type === 'r') {
-    const opCountKey = _cacheKey.opCountPeer(
-      {ledgerNodeId, second: Math.round(Date.now() / 1000)});
-    multi.incrby(opCountKey, event.operationRecords.length);
-    multi.expire(opCountKey, operationsConfig.counter.ttl);
-  }
-  if(type === 'm') {
-    const headGenerationKey = _cacheKey.headGeneration(
-      {eventHash, ledgerNodeId});
-    const latestPeerHeadKey = _cacheKey.latestPeerHead(
-      {creatorId, ledgerNodeId});
-    // expired the key in an hour, incase the peer/creator goes dark
-    multi.hmset(latestPeerHeadKey, 'h', eventHash, 'g', generation);
-    multi.expire(latestPeerHeadKey, 3600);
-    // this key is set to expire in the event-writer
-    multi.set(headGenerationKey, generation);
-  }
-  // add the hash to the set used to check for dups and ancestors
-  multi.sadd(eventQueueSetKey, eventHash);
-  // create a key that contains the event and meta
-  multi.set(eventKey, eventJson);
-  // push to the list that is handled in the event-writer
-  multi.rpush(eventQueueKey, eventKey);
-  multi.publish(`continuity2017|peerEvent|${ledgerNodeId}`, 'new');
-  return multi.exec();
-}
-
-// sort an array of operation records, mutates operations
-function _sortOperations(operations) {
-  operations.sort((a, b) => a.meta.operationHash.localeCompare(
-    b.meta.operationHash));
-}
-
-async function _updateCache({eventRecord, ledgerNodeId}) {
-  const childlessKey = _cacheKey.childless(ledgerNodeId);
-  const {creator: creatorId, generation} = eventRecord.meta.continuity2017;
-  const {eventHash} = eventRecord.meta;
-  const headKey = _cacheKey.head({creatorId, ledgerNodeId});
-  const eventKey = _cacheKey.event({eventHash, ledgerNodeId});
-  const outstandingMergeKey = _cacheKey.outstandingMerge(ledgerNodeId);
-  const {parentHash, treeHash, type} = eventRecord.event;
-  const parentHashes = _.without(parentHash, treeHash);
-  // no need to set a headGeneration key here, those are only used for
-  // processing peer merge events
-  // TODO: `creator` is quite a long URL, can a substitution be made?
-
-  // the redis cached event format puts `eventHash` at the top level, not in
-  // `meta` like in ledger storage (e.g. mongo)
-  const cacheEvent = JSON.stringify({
-    eventHash,
-    event: {parentHash, treeHash, type},
-    meta: {continuity2017: {creator: creatorId}}
-  });
-  try {
-    const result = cache.client.multi()
-      .srem(childlessKey, parentHashes)
-      .set(eventKey, cacheEvent)
-      .sadd(outstandingMergeKey, eventKey)
-      .hmset(headKey, 'h', eventHash, 'g', generation)
-      .publish(`continuity2017|event|${ledgerNodeId}`, 'merge')
-      .exec();
-    // result is inspected in unit tests
-    return result;
-  } catch(e) {
-    // FIXME: fail gracefully
-    // failure here means head information would be corrupt which
-    // cannot be allowed
-    logger.error('Could not set head.', {
-      creatorId,
-      // FIXME: fix when logger.error works properly
-      err1: e,
-      generation,
-      headKey,
-      ledgerNodeId,
-    });
-    throw e;
-  }
 }
 
 async function _addContinuityIndexes({ledgerNode}) {
@@ -1230,11 +1043,10 @@ async function _writeEvent(
     }
   }
 
-  // write peer events to the queue and local events to storage
+  // write peer events to the cache and local events to storage
   if(fromPeer) {
-    // events from peers that can be re-acquired go into redis queue
-    const {event, meta} = eventRecord;
-    await _queueEvent({event, ledgerNodeId, meta});
+    // events from peers that can be reacquired go into the cache
+    await _cache.events.addPeerEvent({...eventRecord, ledgerNodeId});
     // return `eventRecord` as is
     return eventRecord;
   }
@@ -1254,18 +1066,14 @@ async function _writeEvent(
     return eventRecord;
   }
 
-  // the cache needs to be updated here as local events were committed
-  // directly to mongo that need consensus
-  const childlessKey = _cacheKey.childless(ledgerNodeId);
-  const eventCountKey = _cacheKey.eventCountLocal(
-    {ledgerNodeId, second: Math.round(Date.now() / 1000)});
-  await cache.client.multi()
-    .sadd(childlessKey, eventRecord.meta.eventHash)
-    .incr(eventCountKey)
-    .expire(eventCountKey, eventsConfig.counter.ttl)
-    // inform ConsensusAgent and other listeners about new regular events
-    .publish(`continuity2017|event|${ledgerNodeId}`, 'regular')
-    .exec();
+  // the cache needs to be updated here as a local event was committed
+  // to storage and it now needs to be merged...
+  // FIXME: is this note true? it appears that storage will not ever be
+  // consulted if this call fails... do we recover properly?
+  // Note: If this call fails, the consensus agent will still eventually
+  // find the event in storage and merge it in; updating the cache just
+  // expedites the process
+  await _cache.events.addLocalRegularEvent({eventHash, ledgerNodeId});
 
   return eventRecord;
 }
@@ -1305,68 +1113,6 @@ function _sortHistory(history) {
     e._p = true;
     sortedHistory.push(e.meta.eventHash);
   }
-}
-
-// TODO: move to a redis/cache file and rename
-async function _getOperationChunk({ledgerNode}) {
-  const ledgerNodeId = ledgerNode.id;
-  const opListKey = _cacheKey.operationList(ledgerNodeId);
-  const opSelectedListKey = _cacheKey.operationSelectedList(ledgerNodeId);
-  let truncated = false;
-
-  // TODO: move into a redis function `operationQueue.pop` or similar
-  const getOperationsTxn = cache.client.multi();
-
-  // find redis keys for operations for the event...
-  // first, check for selected ops which indicates a previous event creation
-  let opKeys = await cache.client.lrange(opSelectedListKey, 0, -1);
-  if(opKeys.length > 0) {
-    // previous keys found, reuse to retry creation process
-    getOperationsTxn.mget(opKeys);
-  } else {
-    // no previous operation keys found, so get a new list of operations
-    // from the redis operation queue
-    const {maxOperations} = eventsConfig;
-    const [listLength, chunk] = await cache.client.multi()
-      .llen(opListKey)
-      .lrange(opListKey, 0, maxOperations - 1)
-      .exec();
-    if(listLength === 0) {
-      logger.debug('No new operations.');
-      throw new BedrockError(
-        'No new operations to create an event with.', 'AbortError');
-    }
-    if(listLength > maxOperations) {
-      truncated = true;
-    }
-    logger.debug(`New operations found: ${listLength}`);
-    opKeys = chunk;
-    getOperationsTxn.mget(opKeys);
-
-    // remove selected operations from the master operation list
-    // ltrim *keeps* items from start to end
-    getOperationsTxn.ltrim(opListKey, opKeys.length, -1);
-
-    // record the selected keys in case event creation fails
-    getOperationsTxn.rpush(opSelectedListKey, opKeys);
-  }
-
-  // get operations to put into the event
-  const [opJsons] = await getOperationsTxn.exec();
-  const ops = [];
-  for(const opJson of opJsons) {
-    ops.push(JSON.parse(opJson));
-  }
-  // lexicographic sort on the hash of the operation determines the
-  // order of operations in events
-  _sortOperations(ops);
-  const operations = [];
-  const operationHash = [];
-  for(let i = 0; i < ops.length; ++i) {
-    operations.push(ops[i]);
-    operationHash.push(ops[i].meta.operationHash);
-  }
-  return {operations, operationHash, truncated, opKeys};
 }
 
 // FIXME: move to a new `history.js` file

--- a/lib/gossip.js
+++ b/lib/gossip.js
@@ -4,16 +4,13 @@
 'use strict';
 
 const _ = require('lodash');
-const _cacheKey = require('./cache-key');
 const _client = require('./client');
 const _events = require('./events');
 const _voters = require('./voters');
 const bedrock = require('bedrock');
 const brLedgerNode = require('bedrock-ledger-node');
-const cache = require('bedrock-redis');
 const {callbackify, BedrockError} = bedrock.util;
 const logger = require('./logger');
-const uuid = require('uuid/v4');
 const JSONStream = require('JSONStream');
 const PQueue = require('p-queue');
 
@@ -83,42 +80,13 @@ api.getHeads = callbackify(async ({creatorId}) => {
   return heads;
 });
 
-// TODO: almost fully duplicated in `events.js`, move to redis/cache
-// file/module for reuse
 async function _diff({eventHashes, ledgerNode}) {
-  if(eventHashes.length === 0) {
+  const notFound = await _events.difference({eventHashes, ledgerNode});
+  if(notFound.length === 0) {
     return [];
   }
-  const ledgerNodeId = ledgerNode.id;
-  const manifestId = uuid();
-  const eventQueueSetKey = _cacheKey.eventQueueSet(ledgerNodeId);
-  const manifestKey = _cacheKey.manifest({ledgerNodeId, manifestId});
-
-  // TODO: this could be implemented as smembers as well and diff the hashes
-  // as an array, if the eventQueueSetKey contains a large set, then the
-  // existing implementation is good
-
-  // Note: Here we add an entry to redis just to perform a diff...
-  // 1. Add `manifestKey` with `eventHashes` array as the value
-  // 2. Run `sdiff` to do diff that value with what is in the event queue
-  //    for the ledger node (using key `eventQueueSetKey`)
-  // 3. Delete the `manifestKey` once we're done running the diff
-  // ... and results of `sadd` is in result[0], `sdiff` is in result[1], so
-  // we destructure result[1] into `notFound` (i.e. events not in the queue)
-  const [, notFound] = await cache.client.multi()
-    .sadd(manifestKey, eventHashes)
-    .sdiff(manifestKey, eventQueueSetKey)
-    .del(manifestKey)
-    .exec();
-  // ...of the events not found in the event queue (redis), return those that
-  // are also not in storage (mongo), i.e. we haven't stored them at all
-  const diff = await ledgerNode.storage.events.difference(notFound);
-  if(diff.length === 0) {
-    return [];
-  }
-
   // the order of eventHashes must be preserved
-  const needSet = new Set(diff);
+  const needSet = new Set(notFound);
   return eventHashes.filter(h => needSet.has(h));
 }
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -23,9 +23,11 @@ api.consensusMethod = 'Continuity2017';
 
 // require submodules as private APIs
 api._blocks = require('./blocks');
-api._cacheKey = require('./cache-key');
+api._cache = require('./cache');
+api._client = require('./client');
 api._events = require('./events');
 api._election = require('./election');
+api._gossip = require('./gossip');
 api._hasher = brLedgerNode.consensus._hasher;
 api._server = require('./server');
 api._voters = require('./voters');

--- a/lib/operations.js
+++ b/lib/operations.js
@@ -4,15 +4,10 @@
 'use strict';
 
 const _ = require('lodash');
-const _cacheKey = require('./cache-key');
+const _cache = require('./cache');
 const _util = require('./util');
 const bedrock = require('bedrock');
-const cache = require('bedrock-redis');
 const {callbackify} = require('bedrock').util;
-const {config} = bedrock;
-const uuid = require('uuid/v4');
-
-const opConfig = config['ledger-consensus-continuity'].operations;
 
 const api = {};
 module.exports = api;
@@ -29,26 +24,23 @@ module.exports = api;
  */
 api.add = callbackify(async ({operation, ledgerNode}) => {
   const ledgerNodeId = ledgerNode.id;
-  // using uuid instead of hash because duplicate operations are allowed
-  const opKey = _cacheKey.operation({ledgerNodeId, opId: uuid()});
-  const opListKey = _cacheKey.operationList(ledgerNodeId);
-  const opCountKey = _cacheKey.opCountLocal(
-    {ledgerNodeId, second: Math.round(Date.now() / 1000)});
   const recordId = _util.generateRecordId({ledgerNode, operation});
   const operationHash = await _util.hasher(operation);
-  // TODO: move to redis/cache file/module
-  await cache.client.multi()
-    .incr(opCountKey)
-    .expire(opCountKey, opConfig.counter.ttl)
-    .set(opKey, JSON.stringify(
-      {operation, meta: {operationHash}, recordId}))
-    .rpush(opListKey, opKey)
-    .publish(`continuity2017|operation|${ledgerNodeId}`, 'add')
-    .exec();
+  await _cache.operations.add(
+    {operation, operationHash, recordId, ledgerNodeId});
   return {operation, meta: {operationHash}, recordId};
 });
 
-api.write = callbackify(async ({eventHash, ledgerNode, operations}) => {
+/**
+ * Writes operations to storage.
+ *
+ * @param operations the operations to store.
+ * @param eventHash the event hash for the events the operations are in.
+ * @param ledgerNode the node that is tracking this operation.
+ *
+ * @return a Promise that resolves once the operation completes.
+ */
+api.write = callbackify(async ({operations, eventHash, ledgerNode}) => {
   const records = [];
   for(let i = 0; i < operations.length; ++i) {
     const record = operations[i];

--- a/lib/server.js
+++ b/lib/server.js
@@ -3,14 +3,13 @@
  */
 'use strict';
 
-const _cacheKey = require('./cache-key');
+const _cache = require('./cache');
 const _events = require('./events');
 const _gossip = require('./gossip');
 const _voters = require('./voters');
 const bedrock = require('bedrock');
 const bodyParser = require('body-parser');
 const brRest = require('bedrock-rest');
-const cache = require('bedrock-redis');
 const {callbackify, BedrockError} = bedrock.util;
 const config = require('bedrock').config;
 const brLedgerNode = require('bedrock-ledger-node');
@@ -19,8 +18,6 @@ const logger = require('./logger');
 // const stream = require('stream');
 // const JSONStream = require('JSONStream');
 // const validate = require('bedrock-validation').validate;
-
-// const cacheConfig = config['ledger-consensus-continuity'].gossip.cache;
 
 require('bedrock-express');
 require('bedrock-permission');
@@ -182,20 +179,19 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
     })
   }));
 
-  // TODO: add validator
+  // FIXME: add validation
   app.post(routes.notify, brRest.when.prefers.ld, (req, res, next) => {
-    const creatorId = config.server.baseUri +
+    const receiverId = config.server.baseUri +
       '/consensus/continuity2017/voters/' + req.params.voterId;
-    const callerId = req.body.callerId;
-    if(!callerId) {
+    const senderId = req.body.callerId;
+    if(!senderId) {
       return next(new BedrockError(
         '`callerId` is required.', 'DataError',
         {httpStatusCode: 400, public: true}));
     }
-    const notificationKey = _cacheKey.gossipNotification(creatorId);
-    // a set is used here because it only allows unique values
-    cache.client.sadd(notificationKey, callerId, () => {
-      res.status(204).end();
-    });
+    // ignore failure to cache notification, not a critical error
+    _cache.gossip.addNotification({receiverId, senderId})
+      .catch(() => {});
+    res.status(204).end();
   });
 });

--- a/lib/util.js
+++ b/lib/util.js
@@ -20,3 +20,14 @@ api.generateRecordId = ({ledgerNode, operation}) => {
 };
 
 api.hasher = brLedgerNode.consensus._hasher;
+
+/**
+ * Lexicographically sorts an array of operation records by
+ * `meta.operationHash`. The given array of operations is mutated.
+ *
+ * @param operations the array of operations to sort by operation hash.
+ */
+api.sortOperations = (operations) => {
+  operations.sort((a, b) => a.meta.operationHash.localeCompare(
+    b.meta.operationHash));
+};

--- a/lib/voters.js
+++ b/lib/voters.js
@@ -8,7 +8,7 @@ const bedrock = require('bedrock');
 const brDidClient = require('bedrock-did-client');
 const bs58 = require('bs58');
 const cache = require('bedrock-redis');
-const {callbackify, BedrockError} = bedrock.util;
+const {callbackify} = bedrock.util;
 const {config} = bedrock;
 const chloride = require('chloride');
 const jsigs = require('jsonld-signatures')();
@@ -71,6 +71,12 @@ api.get = callbackify(async (
     }
 
     // voter not found, try to create it...
+
+    // FIXME: is this lock really necessary? At worst we generate an extra
+    // key that we throw out when we get a duplicate error ... we could
+    // simplify this implementation by just waiting a random amount of time
+    // the first time ... and then creating the key... if we really even
+    // need to do that; this should not be a big deal
 
     // lock to do key generation
     const lockKey = `keygenerationlock|${ledgerNodeId}`;

--- a/lib/worker.js
+++ b/lib/worker.js
@@ -1,14 +1,10 @@
 /*!
- * Web Ledger Continuity2017 consensus worker.
- *
  * Copyright (c) 2017-2018 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 
 const _ = require('lodash');
-const _gossip = require('./gossip');
 const bedrock = require('bedrock');
-const brLedgerNode = require('bedrock-ledger-node');
 const {callbackify} = bedrock.util;
 const logger = require('./logger');
 const {promisify} = require('util');
@@ -25,15 +21,7 @@ require('./config');
 const api = {};
 module.exports = api;
 
-api._cacheKey = require('./cache-key');
-api._client = require('./client');
-api._election = require('./election');
-api._events = require('./events');
-api._hasher = brLedgerNode.consensus._hasher;
-api._storage = require('./storage');
-api._voters = require('./voters');
 // exposed for testing
-api._gossipWith = _gossip.gossipWith;
 api.EventWriter = EventWriter;
 
 // temporary hack to access/update ledger node meta

--- a/test/mocha/10-api.js
+++ b/test/mocha/10-api.js
@@ -197,7 +197,7 @@ describe('Continuity2017', () => {
   // FIXME: this API chaanged and tests need to be updated accordingly
   describe('getRecentHistory API', () => {
     it('history includes one local event and one local merge event', done => {
-      const getRecentHistory = consensusApi._events.getRecentHistory;
+      const {getRecentHistory} = consensusApi._events;
       const eventTemplate = mockData.events.alpha;
       const opTemplate = mockData.operations.alpha;
       async.auto({

--- a/test/mocha/10-api.js
+++ b/test/mocha/10-api.js
@@ -57,7 +57,7 @@ describe('Continuity2017', () => {
           });
       }],
       genesisMerge: ['creator', (results, callback) => {
-        consensusApi._worker._events._getLocalBranchHead({
+        consensusApi._events._getLocalBranchHead({
           ledgerNode,
           creatorId: results.creator.id
         }, (err, result) => {
@@ -197,7 +197,7 @@ describe('Continuity2017', () => {
   // FIXME: this API chaanged and tests need to be updated accordingly
   describe('getRecentHistory API', () => {
     it('history includes one local event and one local merge event', done => {
-      const getRecentHistory = consensusApi._worker._events.getRecentHistory;
+      const getRecentHistory = consensusApi._events.getRecentHistory;
       const eventTemplate = mockData.events.alpha;
       const opTemplate = mockData.operations.alpha;
       async.auto({
@@ -232,7 +232,7 @@ describe('Continuity2017', () => {
       }, done);
     });
     it('history includes 4 local events and one local merge event', done => {
-      const getRecentHistory = consensusApi._worker._events.getRecentHistory;
+      const getRecentHistory = consensusApi._events.getRecentHistory;
       const eventTemplate = mockData.events.alpha;
       const opTemplate = mockData.operations.alpha;
       async.auto({
@@ -268,9 +268,8 @@ describe('Continuity2017', () => {
       }, done);
     });
     it.skip('history includes 1 remote merge and one local merge event', done => {
-      const mergeBranches = consensusApi._worker._events.mergeBranches;
-      const getRecentHistory =
-        consensusApi._worker._events.getRecentHistory;
+      const mergeBranches = consensusApi._events.mergeBranches;
+      const getRecentHistory = consensusApi._events.getRecentHistory;
       async.auto({
         remoteEvent: callback => helpers.addRemoteEvents(
           {consensusApi, ledgerNode, mockData}, callback),
@@ -324,8 +323,8 @@ describe('Continuity2017', () => {
       }, done);
     });
     it.skip('contains two remote merge and one local merge event', done => {
-      const mergeBranches = consensusApi._worker._events.mergeBranches;
-      const getRecentHistory = consensusApi._worker._events.getRecentHistory;
+      const mergeBranches = consensusApi._events.mergeBranches;
+      const getRecentHistory = consensusApi._events.getRecentHistory;
       async.auto({
         // 2 remote merge events from the same creator chained together
         remoteEvent: callback => helpers.addRemoteEvents(
@@ -372,7 +371,7 @@ describe('Continuity2017', () => {
       }, done);
     });
     it.skip('contains two remote merge events before a local merge', done => {
-      const getRecentHistory = consensusApi._worker._events.getRecentHistory;
+      const getRecentHistory = consensusApi._events.getRecentHistory;
       async.auto({
         // 2 remote merge events from the same creator chained together
         remoteEvent: callback => helpers.addRemoteEvents(
@@ -404,7 +403,7 @@ describe('Continuity2017', () => {
       }, done);
     });
     it.skip('history includes one local event before local merge', done => {
-      const getRecentHistory = consensusApi._worker._events.getRecentHistory;
+      const getRecentHistory = consensusApi._events.getRecentHistory;
       const testEvent = bedrock.util.clone(mockData.events.alpha);
       testEvent.operation[0].record.id = `https://example.com/event/${uuid()}`;
       async.auto({
@@ -428,7 +427,7 @@ describe('Continuity2017', () => {
       }, done);
     });
     it.skip('history includes 4 local events before a local merge', done => {
-      const getRecentHistory = consensusApi._worker._events.getRecentHistory;
+      const getRecentHistory = consensusApi._events.getRecentHistory;
       const eventTemplate = mockData.events.alpha;
       async.auto({
         addEvent: callback => helpers.addEvent(
@@ -455,7 +454,7 @@ describe('Continuity2017', () => {
       }, done);
     });
     it.skip('includes 4 LEs and 2 RMEs before local merge', done => {
-      const getRecentHistory = consensusApi._worker._events.getRecentHistory;
+      const getRecentHistory = consensusApi._events.getRecentHistory;
       const eventTemplate = mockData.events.alpha;
       async.auto({
         addEvent: callback => helpers.addEvent(

--- a/test/mocha/100-performance.js
+++ b/test/mocha/100-performance.js
@@ -47,7 +47,7 @@ describe.skip('Performance - Consensus Client - getBlockStatus API', () => {
           callback();
         })],
       getVoter: ['consensusPlugin', 'ledgerNode', (results, callback) => {
-        consensusApi._worker._voters.get(ledgerNode.id, (err, result) => {
+        consensusApi._voters.get(ledgerNode.id, (err, result) => {
           voterId = result.id;
           callback();
         });
@@ -74,7 +74,7 @@ describe.skip('Performance - Consensus Client - getBlockStatus API', () => {
     it(`gets block status ${opNum} times`, function(done) {
       this.timeout(120000);
       runPasses({
-        func: consensusApi._worker._client.getBlockStatus,
+        func: consensusApi._client.getBlockStatus,
         blockHeight: 1,
         voterId,
         opNum,

--- a/test/mocha/25-agent-get-event.js
+++ b/test/mocha/25-agent-get-event.js
@@ -46,7 +46,7 @@ describe('Consensus Agent - Get Event API', () => {
           callback();
         })],
       getVoter: ['consensusPlugin', 'ledgerNode', (results, callback) => {
-        consensusApi._worker._voters.get({ledgerNodeId}, (err, result) => {
+        consensusApi._voters.get({ledgerNodeId}, (err, result) => {
           voterId = result.id;
           ledgerNode.creatorId = result.id;
           callback();

--- a/test/mocha/30-agent-add-event.js
+++ b/test/mocha/30-agent-add-event.js
@@ -47,7 +47,7 @@ describe.skip('Consensus Agent - Add Event API', () => {
           callback();
         })],
       getVoter: ['consensusPlugin', 'ledgerNode', (results, callback) => {
-        consensusApi._worker._voters.get(ledgerNode.id, (err, result) => {
+        consensusApi._voters.get(ledgerNode.id, (err, result) => {
           voterId = result.id;
           callback();
         });
@@ -59,7 +59,7 @@ describe.skip('Consensus Agent - Add Event API', () => {
     const testRegularEvent = bedrock.util.clone(mockData.events.alpha);
     testRegularEvent.operation[0].record.id =
       `https://example.com/event/${uuid()}`;
-    const getHead = consensusApi._worker._events._getLocalBranchHead;
+    const getHead = consensusApi._events._getLocalBranchHead;
     async.auto({
       head: callback => getHead({
         ledgerNodeId: ledgerNode.id,
@@ -100,7 +100,7 @@ describe.skip('Consensus Agent - Add Event API', () => {
     const testMergeEvent = bedrock.util.clone(mockData.mergeEvents.alpha);
     // use a valid keypair from mocks
     const keyPair = mockData.groups.authorized;
-    const getHead = consensusApi._worker._events._getLocalBranchHead;
+    const getHead = consensusApi._events._getLocalBranchHead;
     async.auto({
       head: callback => getHead({
         ledgerNodeId: ledgerNode.id,

--- a/test/mocha/32-agent-get-history.js
+++ b/test/mocha/32-agent-get-history.js
@@ -42,9 +42,9 @@ describe.skip('Consensus Agent - Get History API', () => {
             return callback(err);
           }
           consensusApi = result.api;
-          getHistory = consensusApi._worker._client.getHistory;
-          getRecentHistory = consensusApi._worker._events.getRecentHistory;
-          mergeBranches = consensusApi._worker._events.mergeBranches;
+          getHistory = consensusApi._client.getHistory;
+          getRecentHistory = consensusApi._events.getRecentHistory;
+          mergeBranches = consensusApi._events.mergeBranches;
           callback();
         }),
       ledgerNode: ['clean', (results, callback) => brLedgerNode.add(
@@ -56,7 +56,7 @@ describe.skip('Consensus Agent - Get History API', () => {
           callback(null, result);
         })],
       creator: ['consensusPlugin', 'ledgerNode', (results, callback) => {
-        consensusApi._worker._voters.get(ledgerNode.id, (err, result) => {
+        consensusApi._voters.get(ledgerNode.id, (err, result) => {
           if(err) {
             return callback(err);
           }
@@ -65,7 +65,7 @@ describe.skip('Consensus Agent - Get History API', () => {
         });
       }],
       genesisMerge: ['consensusPlugin', 'ledgerNode', (results, callback) => {
-        consensusApi._worker._events._getLocalBranchHead({
+        consensusApi._events._getLocalBranchHead({
           ledgerNode: ledgerNode.id,
           eventsCollection: ledgerNode.storage.events.collection,
           creatorId: peerId
@@ -170,7 +170,7 @@ describe.skip('Consensus Agent - Get History API', () => {
        two remote merge events
   */
   it('returns a local merge and two remote merge event ', done => {
-    const getHistory = consensusApi._worker._client.getHistory;
+    const getHistory = consensusApi._client.getHistory;
     async.auto({
       remoteEvents: callback => async.times(2, (i, callback) =>
         helpers.addRemoteEvents(

--- a/test/mocha/40-client-get-event.js
+++ b/test/mocha/40-client-get-event.js
@@ -45,7 +45,7 @@ describe.skip('Consensus Client - getEvent API', () => {
           callback();
         })],
       getVoter: ['consensusPlugin', 'ledgerNode', (results, callback) => {
-        consensusApi._worker._voters.get(ledgerNode.id, (err, result) => {
+        consensusApi._voters.get(ledgerNode.id, (err, result) => {
           peerId = result.id;
           callback();
         });
@@ -60,7 +60,7 @@ describe.skip('Consensus Client - getEvent API', () => {
   });
   it('should get an event', done => {
     async.auto({
-      get: callback => consensusApi._worker._client.getEvent(
+      get: callback => consensusApi._client.getEvent(
         {eventHash, peerId}, (err, result) => {
           should.not.exist(err);
           should.exist(result);
@@ -75,7 +75,7 @@ describe.skip('Consensus Client - getEvent API', () => {
   });
   it('returns an error on an unknown event', done => {
     async.auto({
-      get: callback => consensusApi._worker._client.getEvent(
+      get: callback => consensusApi._client.getEvent(
         {eventHash: uuid(), peerId}, (err, result) => {
           should.exist(err);
           should.not.exist(result);

--- a/test/mocha/45-client-send-event.js
+++ b/test/mocha/45-client-send-event.js
@@ -40,7 +40,7 @@ describe.skip('Consensus Client - sendEvent API', () => {
           callback();
         })],
       getVoter: ['consensusPlugin', 'ledgerNode', (results, callback) => {
-        consensusApi._worker._voters.get(ledgerNode.id, (err, result) => {
+        consensusApi._voters.get(ledgerNode.id, (err, result) => {
           peerId = result.id;
           callback();
         });
@@ -51,7 +51,7 @@ describe.skip('Consensus Client - sendEvent API', () => {
     const testEvent = bedrock.util.clone(mockData.events.alpha);
     const testEventId = 'https://example.com/events/' + uuid();
     testEvent.operation[0].record.id = testEventId;
-    const getHead = ledgerNode.consensus._worker._events._getLocalBranchHead;
+    const getHead = ledgerNode.consensus._events._getLocalBranchHead;
     async.auto({
       head: callback => getHead({
         ledgerNodeId: ledgerNode.id,
@@ -65,7 +65,7 @@ describe.skip('Consensus Client - sendEvent API', () => {
       hash: ['head', (results, callback) =>
         helpers.testHasher(testEvent, callback)],
       send: ['hash', (results, callback) =>
-        consensusApi._worker._client.sendEvent(
+        consensusApi._client.sendEvent(
           {eventHash: results.hash, event: testEvent, peerId},
           (err, result) => {
             assertNoError(err);
@@ -82,7 +82,7 @@ describe.skip('Consensus Client - sendEvent API', () => {
     async.auto({
       hash: callback => brLedgerNode.consensus._hasher(testEvent, callback),
       send: ['hash', (results, callback) =>
-        consensusApi._worker._client.sendEvent({
+        consensusApi._client.sendEvent({
           eventHash: results.hash,
           event: testEvent,
           peerId: 'https://' + uuid() + '.com'
@@ -101,7 +101,7 @@ describe.skip('Consensus Client - sendEvent API', () => {
     async.auto({
       hash: callback => brLedgerNode.consensus._hasher(testEvent, callback),
       send: ['hash', (results, callback) =>
-        consensusApi._worker._client.sendEvent({
+        consensusApi._client.sendEvent({
           eventHash: results.hash,
           event: testEvent,
           peerId

--- a/test/mocha/66-election_findMergeEventProof.js
+++ b/test/mocha/66-election_findMergeEventProof.js
@@ -38,11 +38,9 @@ describe('Election API _findMergeEventProof', () => {
             return callback(err);
           }
           consensusApi = result.api;
-          getRecentHistory = consensusApi._worker._events.getRecentHistory;
-          _getElectorBranches =
-            consensusApi._worker._election._getElectorBranches;
-          _findMergeEventProof =
-            consensusApi._worker._election._findMergeEventProof;
+          getRecentHistory = consensusApi._events.getRecentHistory;
+          _getElectorBranches = consensusApi._election._getElectorBranches;
+          _findMergeEventProof = consensusApi._election._findMergeEventProof;
           EventWriter = consensusApi._worker.EventWriter;
           callback();
         }),
@@ -55,13 +53,13 @@ describe('Election API _findMergeEventProof', () => {
           callback(null, result);
         })],
       creatorId: ['consensusPlugin', 'ledgerNode', (results, callback) => {
-        consensusApi._worker._voters.get(
+        consensusApi._voters.get(
           {ledgerNodeId: nodes.alpha.id}, (err, result) => {
             callback(null, result.id);
           });
       }],
       // genesisMerge: ['creatorId', (results, callback) => {
-      //   consensusApi._worker._events._getLocalBranchHead({
+      //   consensusApi._events._getLocalBranchHead({
       //     creatorId: results.creatorId,
       //     ledgerNode: nodes.alpha
       //   }, (err, result) => {
@@ -119,16 +117,15 @@ describe('Election API _findMergeEventProof', () => {
           // attach eventWriter to the node
           ledgerNode.eventWriter = new EventWriter(
             {immediate: true, ledgerNode});
-          consensusApi._worker._voters.get(
-            {ledgerNodeId}, (err, result) => {
-              if(err) {
-                return callback(err);
-              }
-              peers[i] = result.id;
-              ledgerNode.creatorId = result.id;
-              helpers.peersReverse[result.id] = i;
-              callback();
-            });
+          consensusApi._voters.get({ledgerNodeId}, (err, result) => {
+            if(err) {
+              return callback(err);
+            }
+            peers[i] = result.id;
+            ledgerNode.creatorId = result.id;
+            helpers.peersReverse[result.id] = i;
+            callback();
+          });
         }, callback)]
     }, done);
   });
@@ -308,7 +305,7 @@ describe('Election API _findMergeEventProof', () => {
             callback();
           }),
         creator: ['add', (results, callback) =>
-          consensusApi._worker._voters.get(
+          consensusApi._voters.get(
             {ledgerNodeId: nodes.epsilon.id}, (err, result) => {
               if(err) {
                 return callback(err);

--- a/test/mocha/67-election-get-elector-branches.js
+++ b/test/mocha/67-election-get-elector-branches.js
@@ -44,12 +44,12 @@ describe.skip('Election API _getElectorBranches', () => {
           callback(null, result);
         })],
       creatorId: ['consensusPlugin', 'ledgerNode', (results, callback) => {
-        consensusApi._worker._voters.get(nodes.alpha.id, (err, result) => {
+        consensusApi._voters.get(nodes.alpha.id, (err, result) => {
           callback(null, result.id);
         });
       }],
       genesisMerge: ['creatorId', (results, callback) => {
-        consensusApi._worker._events._getLocalBranchHead({
+        consensusApi._events._getLocalBranchHead({
           ledgerNodeId: nodes.alpha.id,
           eventsCollection: nodes.alpha.storage.events.collection,
           creatorId: results.creatorId
@@ -103,7 +103,7 @@ describe.skip('Election API _getElectorBranches', () => {
       //   })],
       creator: ['nodeBeta', 'nodeGamma', 'nodeDelta', (results, callback) =>
         async.eachOf(nodes, (n, i, callback) =>
-          consensusApi._worker._voters.get(n.id, (err, result) => {
+          consensusApi._voters.get(n.id, (err, result) => {
             if(err) {
               return callback(err);
             }
@@ -119,11 +119,9 @@ describe.skip('Election API _getElectorBranches', () => {
       console.log(
         `${nodeLabel}: ${nodes[nodeLabel].storage.events.collection.s.name}`);
     });
-    const getRecentHistory = consensusApi._worker._events.getRecentHistory;
-    const _getElectorBranches =
-      consensusApi._worker._election._getElectorBranches;
-    const _findMergeEventProof =
-      consensusApi._worker._election._findMergeEventProof;
+    const getRecentHistory = consensusApi._events.getRecentHistory;
+    const _getElectorBranches = consensusApi._election._getElectorBranches;
+    const _findMergeEventProof = consensusApi._election._findMergeEventProof;
     const eventTemplate = mockData.events.alpha;
     async.auto({
       // add a regular event and merge on every node

--- a/test/mocha/68-election-get-ancestors.js
+++ b/test/mocha/68-election-get-ancestors.js
@@ -50,7 +50,7 @@ describe('Election API _getAncestors', () => {
       creatorId: ['consensusPlugin', 'ledgerNode', (results, callback) => {
         const ledgerNode = nodes.alpha;
         const {id: ledgerNodeId} = ledgerNode;
-        consensusApi._worker._voters.get({ledgerNodeId}, (err, result) => {
+        consensusApi._voters.get({ledgerNodeId}, (err, result) => {
           ledgerNode.creatorId = result.id;
           callback(null, result.id);
         });
@@ -58,7 +58,7 @@ describe('Election API _getAncestors', () => {
       genesisMerge: ['creatorId', (results, callback) => {
         const ledgerNode = nodes.alpha;
         const {creatorId} = ledgerNode;
-        consensusApi._worker._events._getLocalBranchHead(
+        consensusApi._events._getLocalBranchHead(
           {creatorId, ledgerNode}, (err, result) => {
             if(err) {
               return callback(err);
@@ -113,7 +113,7 @@ describe('Election API _getAncestors', () => {
           // attach eventWriter to the node
           ledgerNode.eventWriter = new EventWriter(
             {immediate: true, ledgerNode});
-          consensusApi._worker._voters.get({ledgerNodeId}, (err, result) => {
+          consensusApi._voters.get({ledgerNodeId}, (err, result) => {
             if(err) {
               return callback(err);
             }
@@ -126,7 +126,7 @@ describe('Election API _getAncestors', () => {
   });
   it('gets no events', async () => {
     // the genesisMerge already has consensus
-    const getAncestors = consensusApi._worker._election._getAncestors;
+    const getAncestors = consensusApi._election._getAncestors;
     const hashes = {mergeEventHashes: [], parentHashes: [genesisMerge]};
     const result = await getAncestors({ledgerNode: nodes.alpha, hashes});
     should.exist(result);
@@ -134,7 +134,7 @@ describe('Election API _getAncestors', () => {
     result.should.have.length(0);
   });
   it('gets two events', done => {
-    const getAncestors = consensusApi._worker._election._getAncestors;
+    const getAncestors = consensusApi._election._getAncestors;
     const ledgerNode = nodes.alpha;
     const eventTemplate = mockData.events.alpha;
     const opTemplate = mockData.operations.alpha;
@@ -158,7 +158,7 @@ describe('Election API _getAncestors', () => {
     }, done);
   });
   it('gets four events', done => {
-    const getAncestors = consensusApi._worker._election._getAncestors;
+    const getAncestors = consensusApi._election._getAncestors;
     const ledgerNode = nodes.alpha;
     const eventTemplate = mockData.events.alpha;
     const opTemplate = mockData.operations.alpha;
@@ -187,7 +187,7 @@ describe('Election API _getAncestors', () => {
     }, done);
   });
   it('gets 4 events involving 2 nodes', done => {
-    const getAncestors = consensusApi._worker._election._getAncestors;
+    const getAncestors = consensusApi._election._getAncestors;
     const ledgerNode = nodes.alpha;
     const eventTemplate = mockData.events.alpha;
     const opTemplate = mockData.operations.alpha;
@@ -224,7 +224,7 @@ describe('Election API _getAncestors', () => {
   // FIXME: this test likely needs to be removed, the returned data structure
   // no longer matches the assertions
   it.skip('gets 4 events without duplicates', done => {
-    const getAncestors = consensusApi._worker._election._getAncestors;
+    const getAncestors = consensusApi._election._getAncestors;
     const ledgerNode = nodes.alpha;
     const eventTemplate = mockData.events.alpha;
     async.auto({

--- a/test/mocha/69-election-find-consensus.js
+++ b/test/mocha/69-election-find-consensus.js
@@ -49,7 +49,7 @@ describe('Election API findConsensus', () => {
         })],
       creatorId: ['consensusPlugin', 'ledgerNode', (results, callback) => {
         const {id: ledgerNodeId} = nodes.alpha;
-        consensusApi._worker._voters.get({ledgerNodeId}, (err, result) => {
+        consensusApi._voters.get({ledgerNodeId}, (err, result) => {
           callback(null, result.id);
         });
       }],
@@ -100,7 +100,7 @@ describe('Election API findConsensus', () => {
           // attach eventWriter to the node
           ledgerNode.eventWriter = new EventWriter(
             {immediate: true, ledgerNode});
-          consensusApi._worker._voters.get({ledgerNodeId}, (err, result) => {
+          consensusApi._voters.get({ledgerNodeId}, (err, result) => {
             if(err) {
               return callback(err);
             }
@@ -114,8 +114,8 @@ describe('Election API findConsensus', () => {
   });
   it('single node consensus', done => {
     // the genesisMerge already has consensus
-    const findConsensus = consensusApi._worker._election.findConsensus;
-    const getRecentHistory = consensusApi._worker._events.getRecentHistory;
+    const findConsensus = consensusApi._election.findConsensus;
+    const getRecentHistory = consensusApi._events.getRecentHistory;
     const ledgerNode = nodes.alpha;
     const {creatorId} = ledgerNode;
     const electors = [{id: peers.alpha}];
@@ -144,8 +144,8 @@ describe('Election API findConsensus', () => {
     }, done);
   });
   it('properly does not reach consensus with four electors', done => {
-    const findConsensus = consensusApi._worker._election.findConsensus;
-    const getRecentHistory = consensusApi._worker._events.getRecentHistory;
+    const findConsensus = consensusApi._election.findConsensus;
+    const getRecentHistory = consensusApi._events.getRecentHistory;
     const ledgerNode = nodes.alpha;
     const {creatorId} = ledgerNode;
     const electors = [
@@ -170,8 +170,8 @@ describe('Election API findConsensus', () => {
   });
   it('ledger history alpha', function(done) {
     this.timeout(120000);
-    const findConsensus = consensusApi._worker._election.findConsensus;
-    const getRecentHistory = consensusApi._worker._events.getRecentHistory;
+    const findConsensus = consensusApi._election.findConsensus;
+    const getRecentHistory = consensusApi._events.getRecentHistory;
     const electors = _.values(peers).map(p => ({id: p}));
     async.auto({
       build: callback => helpers.buildHistory(
@@ -226,8 +226,8 @@ describe('Election API findConsensus', () => {
   });
   it('ledger history beta', function(done) {
     this.timeout(120000);
-    const findConsensus = consensusApi._worker._election.findConsensus;
-    const getRecentHistory = consensusApi._worker._events.getRecentHistory;
+    const findConsensus = consensusApi._election.findConsensus;
+    const getRecentHistory = consensusApi._events.getRecentHistory;
     const electors = _.values(peers).map(p => ({id: p}));
     async.auto({
       build: callback => helpers.buildHistory(
@@ -277,8 +277,8 @@ describe('Election API findConsensus', () => {
   });
   it('ledger history gamma', function(done) {
     this.timeout(120000);
-    const findConsensus = consensusApi._worker._election.findConsensus;
-    const getRecentHistory = consensusApi._worker._events.getRecentHistory;
+    const findConsensus = consensusApi._election.findConsensus;
+    const getRecentHistory = consensusApi._events.getRecentHistory;
     const electors = _.values(peers).map(p => ({id: p}));
     async.auto({
       build: callback => helpers.buildHistory(
@@ -328,8 +328,8 @@ describe('Election API findConsensus', () => {
   });
   it('ledger history delta', function(done) {
     this.timeout(120000);
-    const findConsensus = consensusApi._worker._election.findConsensus;
-    const getRecentHistory = consensusApi._worker._events.getRecentHistory;
+    const findConsensus = consensusApi._election.findConsensus;
+    const getRecentHistory = consensusApi._events.getRecentHistory;
     const electors = _.values(peers).map(p => ({id: p}));
     async.auto({
       // add node epsilon for this test and remove it afterwards
@@ -348,7 +348,7 @@ describe('Election API findConsensus', () => {
           // attach eventWriter to the node
           ledgerNode.eventWriter = new EventWriter(
             {immediate: true, ledgerNode});
-          consensusApi._worker._voters.get({ledgerNodeId}, (err, result) => {
+          consensusApi._voters.get({ledgerNodeId}, (err, result) => {
             if(err) {
               return callback(err);
             }
@@ -417,8 +417,8 @@ describe('Election API findConsensus', () => {
     }, done);
   });
   it('add regular event with no merge before findConsensus', done => {
-    const findConsensus = consensusApi._worker._election.findConsensus;
-    const getRecentHistory = consensusApi._worker._events.getRecentHistory;
+    const findConsensus = consensusApi._election.findConsensus;
+    const getRecentHistory = consensusApi._events.getRecentHistory;
     const ledgerNode = nodes.alpha;
     const electors = _.values(peers).map(p => ({id: p}));
     const eventTemplate = mockData.events.alpha;

--- a/test/mocha/75-events-api.js
+++ b/test/mocha/75-events-api.js
@@ -36,7 +36,7 @@ describe('events API', () => {
             return callback(err);
           }
           consensusApi = result.api;
-          _cacheKey = consensusApi._cacheKey;
+          _cacheKey = consensusApi._cache.cacheKey;
           repairCache = consensusApi._events.repairCache;
           callback();
         }),
@@ -49,7 +49,7 @@ describe('events API', () => {
           callback(null, result);
         })],
       creatorId: ['consensusPlugin', 'ledgerNode', (results, callback) => {
-        consensusApi._worker._voters.get(
+        consensusApi._voters.get(
           {ledgerNodeId: nodes.alpha.id}, (err, result) => {
             callback(null, result.id);
           });
@@ -96,7 +96,7 @@ describe('events API', () => {
       //   })],
       creator: ['nodeBeta', 'nodeGamma', 'nodeDelta', (results, callback) =>
         async.eachOf(nodes, (n, i, callback) =>
-          consensusApi._worker._voters.get(
+          consensusApi._voters.get(
             {ledgerNodeId: n.id}, (err, result) => {
               if(err) {
                 return callback(err);

--- a/test/mocha/76-events-merge-branches-api.js
+++ b/test/mocha/76-events-merge-branches-api.js
@@ -35,7 +35,7 @@ describe('events.mergeBranches API', () => {
             return callback(err);
           }
           consensusApi = result.api;
-          merge = consensusApi._worker._events.merge;
+          merge = consensusApi._events.merge;
           EventWriter = consensusApi._worker.EventWriter;
           callback();
         }),
@@ -49,14 +49,14 @@ describe('events.mergeBranches API', () => {
         })],
       creatorId: ['consensusPlugin', 'ledgerNode', (results, callback) => {
         const {id: ledgerNodeId} = nodes.alpha;
-        consensusApi._worker._voters.get({ledgerNodeId}, (err, result) => {
+        consensusApi._voters.get({ledgerNodeId}, (err, result) => {
           callback(null, result.id);
         });
       }],
       genesisMerge: ['creatorId', (results, callback) => {
         const ledgerNode = nodes.alpha;
         const {creatorId} = results;
-        consensusApi._worker._events._getLocalBranchHead(
+        consensusApi._events._getLocalBranchHead(
           {creatorId, ledgerNode}, (err, result) => {
             if(err) {
               return callback(err);
@@ -111,7 +111,7 @@ describe('events.mergeBranches API', () => {
           // attach eventWriter to the node
           ledgerNode.eventWriter = new EventWriter(
             {immediate: true, ledgerNode});
-          consensusApi._worker._voters.get({ledgerNodeId}, (err, result) => {
+          consensusApi._voters.get({ledgerNodeId}, (err, result) => {
             if(err) {
               return callback(err);
             }

--- a/test/mocha/80-blocks-api.js
+++ b/test/mocha/80-blocks-api.js
@@ -39,7 +39,7 @@ describe('blocks API', () => {
             return callback(err);
           }
           consensusApi = result.api;
-          _cacheKey = consensusApi._cacheKey;
+          _cacheKey = consensusApi._cache.cacheKey;
           repairCache = consensusApi._blocks.repairCache;
           callback();
         }),
@@ -52,13 +52,13 @@ describe('blocks API', () => {
           callback(null, result);
         })],
       creatorId: ['consensusPlugin', 'ledgerNode', (results, callback) => {
-        consensusApi._worker._voters.get(
+        consensusApi._voters.get(
           {ledgerNodeId: nodes.alpha.id}, (err, result) => {
             callback(null, result.id);
           });
       }],
       genesisMerge: ['creatorId', (results, callback) => {
-        consensusApi._worker._events._getLocalBranchHead({
+        consensusApi._events._getLocalBranchHead({
           creatorId: results.creatorId,
           ledgerNode: nodes.alpha,
         }, (err, result) => {
@@ -111,7 +111,7 @@ describe('blocks API', () => {
       //   })],
       creator: ['nodeBeta', 'nodeGamma', 'nodeDelta', (results, callback) =>
         async.eachOf(nodes, (n, i, callback) =>
-          consensusApi._worker._voters.get(
+          consensusApi._voters.get(
             {ledgerNodeId: n.id}, (err, result) => {
               if(err) {
                 return callback(err);

--- a/test/mocha/91-basic-multinode.js
+++ b/test/mocha/91-basic-multinode.js
@@ -102,7 +102,7 @@ describe.skip('Multinode Basics', () => {
 
     // populate peers and init heads
     before(done => async.eachOf(nodes, (ledgerNode, i, callback) =>
-      consensusApi._worker._voters.get(ledgerNode.id, (err, result) => {
+      consensusApi._voters.get(ledgerNode.id, (err, result) => {
         peers[i] = result.id;
         heads[i] = [];
         callback();

--- a/test/mocha/92-xblock-multinode.js
+++ b/test/mocha/92-xblock-multinode.js
@@ -96,7 +96,7 @@ describe('X Block Test', () => {
 
     // populate peers and init heads
     before(done => async.eachOf(nodes, (ledgerNode, i, callback) =>
-      consensusApi._worker._voters.get(
+      consensusApi._voters.get(
         {ledgerNodeId: ledgerNode.id}, (err, result) => {
           peers[i] = result.id;
           heads[i] = [];

--- a/test/mocha/gossip-cycle.js
+++ b/test/mocha/gossip-cycle.js
@@ -23,7 +23,7 @@ api.alpha = (
         callback)],
     // beta gossips with alpha
     betaGossip1: ['alphaAddEvent1', (results, callback) =>
-      consensusApi._worker._gossipWith(
+      consensusApi._gossip.gossipWith(
         {ledgerNode: nodes.beta, peerId: peers.alpha}, (err, result) => {
           assertNoError(err);
           // alpha knows about the merge event added to alpha during this cycle
@@ -50,7 +50,7 @@ api.beta = (
       {consensusApi, eventTemplate, ledgerNode: nodes.gamma}, callback),
     // gamma gossips with beta
     gammaGossip1: ['gammaAddEvent1', (results, callback) =>
-      consensusApi._worker._gossipWith(
+      consensusApi._gossip.gossipWith(
         {ledgerNode: nodes.gamma, peerId: peers.beta}, callback)],
     // beta adds and event and merges which includes events from gamma
     betaAddEvent1: ['gammaGossip1', (results, callback) =>
@@ -62,7 +62,7 @@ api.beta = (
         {consensusApi, eventTemplate, ledgerNode: nodes.alpha}, callback)],
     // beta gossips with alpha
     betaGossip1: ['alphaAddEvent1', (results, callback) =>
-      consensusApi._worker._gossipWith(
+      consensusApi._gossip.gossipWith(
         {ledgerNode: nodes.beta, peerId: peers.alpha}, (err, result) => {
           assertNoError(err);
           // console.log('ALPHA', peers.alpha);
@@ -108,14 +108,14 @@ api.gamma = (
     deltaAddEvent1: callback => helpers.addEventAndMerge(
       {consensusApi, eventTemplate, ledgerNode: nodes.delta}, callback),
     deltaGossip1: ['deltaAddEvent1', (results, callback) =>
-      consensusApi._worker._gossipWith(
+      consensusApi._gossip.gossipWith(
         {ledgerNode: nodes.delta, peerId: peers.gamma}, callback)],
     gammaAddEvent1: ['deltaGossip1', (results, callback) =>
       helpers.addEventAndMerge(
         {consensusApi, eventTemplate, ledgerNode: nodes.gamma}, callback)],
     // gamma gossips with beta
     gammaGossip1: ['gammaAddEvent1', (results, callback) =>
-      consensusApi._worker._gossipWith(
+      consensusApi._gossip.gossipWith(
         {ledgerNode: nodes.gamma, peerId: peers.beta}, callback)],
     // beta adds and event and merges which includes events from gamma
     betaAddEvent1: ['gammaGossip1', (results, callback) =>
@@ -127,7 +127,7 @@ api.gamma = (
         {consensusApi, eventTemplate, ledgerNode: nodes.alpha}, callback)],
     // beta gossips with alpha
     betaGossip1: ['alphaAddEvent1', (results, callback) =>
-      consensusApi._worker._gossipWith(
+      consensusApi._gossip.gossipWith(
         {ledgerNode: nodes.beta, peerId: peers.alpha}, (err, result) => {
           assertNoError(err);
           result.peerHistory.creatorHeads[peers.alpha]
@@ -159,7 +159,7 @@ api.gamma = (
           callback();
         })],
     betaGossip2: ['betaGossip1', (results, callback) =>
-      consensusApi._worker._gossipWith(
+      consensusApi._gossip.gossipWith(
         {ledgerNode: nodes.beta, peerId: peers.alpha}, (err, result) => {
           assertNoError(err);
           result.peerHistory.creatorHeads[peers.alpha]
@@ -183,21 +183,21 @@ api.delta = (
     deltaAddEvent1: callback => helpers.addEventAndMerge(
       {consensusApi, eventTemplate, ledgerNode: nodes.delta}, callback),
     deltaGossip1: ['deltaAddEvent1', (results, callback) =>
-      consensusApi._worker._gossipWith(
+      consensusApi._gossip.gossipWith(
         {ledgerNode: nodes.delta, peerId: peers.gamma}, callback)],
     gammaAddEvent1: ['deltaGossip1', (results, callback) =>
       helpers.addEventAndMerge(
         {consensusApi, eventTemplate, ledgerNode: nodes.gamma}, callback)],
     // gamma gossips with beta
     gammaGossip1: ['gammaAddEvent1', (results, callback) =>
-      consensusApi._worker._gossipWith(
+      consensusApi._gossip.gossipWith(
         {ledgerNode: nodes.gamma, peerId: peers.beta}, callback)],
     // beta adds and event and merges which includes events from gamma
     betaAddEvent1: ['gammaGossip1', (results, callback) =>
       helpers.addEventAndMerge(
         {consensusApi, eventTemplate, ledgerNode: nodes.beta}, callback)],
     betaGossip1: ['betaAddEvent1', (results, callback) =>
-      consensusApi._worker._gossipWith(
+      consensusApi._gossip.gossipWith(
         {ledgerNode: nodes.beta, peerId: peers.delta}, callback)],
     deltaAddEvent2: ['betaGossip1', (results, callback) =>
       helpers.addEventAndMerge(
@@ -207,7 +207,7 @@ api.delta = (
         {consensusApi, eventTemplate, ledgerNode: nodes.alpha}, callback)],
     // beta gossips with alpha
     deltaGossip2: ['alphaAddEvent1', (results, callback) =>
-      consensusApi._worker._gossipWith(
+      consensusApi._gossip.gossipWith(
         {ledgerNode: nodes.delta, peerId: peers.alpha}, (err, result) => {
           assertNoError(err);
           result.peerHistory.creatorHeads[peers.alpha]
@@ -241,7 +241,7 @@ api.delta = (
           callback();
         })],
     // betaGossip2: ['betaGossip1', (results, callback) =>
-    //   consensusApi._worker._gossipWith(
+    //   consensusApi._gossip.gossipWith(
     //     {ledgerNode: nodes.beta, peerId: peers.alpha}, (err, result) => {
     //       assertNoError(err);
     //       result.peerHistory.creatorHeads[peers.alpha]

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -105,7 +105,7 @@ api.addEventAndMerge = ({
       '`consensusApi`, `eventTemplate`, and `ledgerNode` are required.');
   }
   const events = {};
-  const merge = consensusApi._worker._events.merge;
+  const merge = consensusApi._events.merge;
   async.auto({
     addEvent: callback => api.addEvent(
       {count, eventTemplate, ledgerNode, opTemplate}, (err, result) => {
@@ -196,7 +196,7 @@ api.addRemoteEvents = ({
     // use a valid keypair from mocks
     const keyPair = mockData.groups.authorized;
     // NOTE: using the local branch head for treeHash of the remote merge event
-    const getHead = consensusApi._worker._events._getLocalBranchHead;
+    const getHead = consensusApi._events._getLocalBranchHead;
     async.auto({
       head: callback => getHead({
         // unknown creator will yield genesis merge event
@@ -287,7 +287,7 @@ api.buildHistory = ({consensusApi, historyId, mockData, nodes}, callback) => {
 api.copyAndMerge = (
   {consensusApi, from, nodes, to, useSnapshot = false}, callback) => {
   const copyFrom = [].concat(from);
-  const merge = consensusApi._worker._events.merge;
+  const merge = consensusApi._events.merge;
   async.auto({
     copy: callback => async.eachSeries(copyFrom, (f, callback) =>
       api.copyEvents(


### PR DESCRIPTION
The only cache code that wasn't moved over yet has to do with keys and voters -- as this code might be evicted anyway, due to public key simplification.

There are still some minor small improvements that could be made as needed, but the major overhaul is done.