### PR TITLE
No ops for electors

### DIFF
--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -25,6 +25,33 @@ api.getLatest = callbackify(async (ledgerNode) => {
 });
 
 /**
+ * Get all peers that participated in the block at the given `blockHeight`.
+ *
+ * @param blockHeight the block height to get the participants for.
+ * @param ledgerNode the ledger node to check.
+ *
+ * @return a Promise that resolves to an object with:
+ *           consensusProofPeers - peers that participated in consensus proving.
+ *           mergeEventPeers - peers that participated with merge events.
+ */
+api.getParticipants = callbackify(async ({blockHeight, ledgerNode}) => {
+  // special case genesis block -- only need to get mergeEventPeers, there is
+  // only one and it is the same as the consensusProofPeers
+  if(blockHeight === 0) {
+    const mergeEventPeers = await _getMergeEventPeers(
+      {blockHeight, ledgerNode});
+    const consensusProofPeers = mergeEventPeers.slice();
+    return {consensusProofPeers, mergeEventPeers};
+  }
+
+  // any other block
+  const [consensusProofPeers, mergeEventPeers] = await Promise.all([
+    _getConsensusProofPeers({blockHeight, ledgerNode}),
+    _getMergeEventPeers({blockHeight, ledgerNode})]);
+  return {consensusProofPeers, mergeEventPeers};
+});
+
+/**
  * Gets the latest consensus block and returns the new proposed block height
  * for the ledger (i.e. the current `blockHeight + 1`) and the latest block
  * hash as what would become the next `previousBlockHash`.
@@ -213,4 +240,37 @@ async function _expandConsensusProofEvents({block, ledgerNode}) {
     block.consensusProof[eventsToFetch[e.meta.eventHash]] = e.event;
   });
   delete block.consensusProofHash;
+}
+
+async function _getConsensusProofPeers({blockHeight, ledgerNode}) {
+  const {collection} = ledgerNode.storage.blocks;
+  const eventCollectionName = ledgerNode.storage.events.collection.s.name;
+  const records = await collection.aggregate([
+    {$match: {'block.blockHeight': blockHeight}},
+    {$project: {_id: 0, 'block.consensusProofHash': 1}},
+    {$limit: 1},
+    {$lookup: {
+      from: eventCollectionName,
+      let: {consensusProofHash: '$block.consensusProofHash'},
+      pipeline: [
+        {$match: {$expr: {$in: ['$meta.eventHash', '$$consensusProofHash']}}},
+        {$project: {_id: 0, 'meta.continuity2017.creator': 1}}
+      ],
+      as: 'peers'
+    }},
+    {$unwind: '$peers'},
+    {$group: {_id: '$peers.meta.continuity2017.creator'}},
+    {$project: {'block': 0}}
+  ], {allowDiskUse: true}).toArray();
+  return records.map(r => r._id);
+}
+
+async function _getMergeEventPeers({blockHeight, ledgerNode}) {
+  const {collection} = ledgerNode.storage.events;
+  // covered under `continuity3`
+  const query = {
+    'meta.blockHeight': blockHeight,
+    'meta.continuity2017.type': 'm'
+  };
+  return collection.distinct('meta.continuity2017.creator', query);
 }

--- a/lib/election.js
+++ b/lib/election.js
@@ -114,10 +114,12 @@ api.getBlockElectors = callbackify(async ({ledgerNode, blockHeight}) => {
   }
 
   // electors not in cache, will need to be computed
-  const [ledgerConfiguration, {eventBlock}] = await Promise.all([
+  const [ledgerConfiguration, latestBlockSummary] = await Promise.all([
     _getLatestConfig(ledgerNode),
     ledgerNode.storage.blocks.getLatestSummary(ledgerNode)
   ]);
+
+  const {eventBlock} = latestBlockSummary;
 
   // FIXME: do we need to force this ... can we avoid this check?
   // ensure requested `blockHeight` matches next block
@@ -138,7 +140,7 @@ api.getBlockElectors = callbackify(async ({ledgerNode, blockHeight}) => {
       'Elector selection method is invalid.', 'InvalidStateError');
   }
   electors = await electorSelectionMethod.api.getBlockElectors(
-    {ledgerNode, ledgerConfiguration, blockHeight});
+    {ledgerNode, ledgerConfiguration, latestBlockSummary, blockHeight});
 
   // cache electors
   await _cache.consensus.setElectors({electors, blockHeight, ledgerNodeId});

--- a/lib/events.js
+++ b/lib/events.js
@@ -844,6 +844,10 @@ async function _addContinuityIndexes({ledgerNode}) {
   const {id: ledgerNodeId} = ledgerNode;
   const {id: localCreatorId} = await voters.get({ledgerNodeId});
 
+  // FIXME: review all indexes to ensure they are properly "partial" or not...
+  // need to remember that event collection may need to be shared with
+  // different consensus methods
+
   // add indexes specific to Continuity
   const collection = ledgerNode.storage.events.collection.s.name;
   await brCreateIndexes([{
@@ -887,6 +891,17 @@ async function _addContinuityIndexes({ledgerNode}) {
     },
     options: {
       sparse: false, unique: false, background: false, name: 'continuity2'
+    }
+  }, {
+    // for cache repair and participant queries
+    collection,
+    fields: {
+      'meta.blockHeight': 1,
+      'meta.continuity2017.type': 1,
+      'meta.continuity2017.creator': 1,
+    },
+    options: {
+      sparse: false, unique: false, background: false, name: 'continuity3'
     }
   }]);
 }

--- a/lib/signature.js
+++ b/lib/signature.js
@@ -6,6 +6,7 @@
 const _ = require('lodash');
 const _voters = require('./voters');
 const bedrock = require('bedrock');
+const {constants} = bedrock.config;
 const {callbackify, BedrockError} = bedrock.util;
 const jsigs = require('jsonld-signatures')();
 const logger = require('./logger');

--- a/lib/simpleElectorSelection.js
+++ b/lib/simpleElectorSelection.js
@@ -3,13 +3,11 @@
  */
 'use strict';
 
-const _ = require('lodash');
 const _blocks = require('./blocks');
 const bedrock = require('bedrock');
 const brLedgerNode = require('bedrock-ledger-node');
-const {callbackify, BedrockError} = bedrock.util;
+const {callbackify} = bedrock.util;
 const crypto = require('crypto');
-const {jsonld} = bedrock;
 const logger = require('./logger');
 
 // maximum number of electors if not specified in the ledger configuration
@@ -30,42 +28,10 @@ bedrock.events.on('bedrock.start', () => {
 });
 
 api.getBlockElectors = callbackify(async (
-  {ledgerNode, ledgerConfiguration, blockHeight}) => {
-  // NOTE: events *must* be expanded here as they are used below
-  const {eventBlock} = await _blocks.getLatest(ledgerNode);
-  const expectedBlockHeight = eventBlock.block.blockHeight + 1;
-  if(expectedBlockHeight !== blockHeight) {
-    throw new BedrockError(
-      'Invalid `blockHeight` specified.', 'InvalidStateError', {
-        blockHeight,
-        expectedBlockHeight
-      });
-  }
-
-  // get previous consensus events
-  const previousEvents = eventBlock.block.event;
-
-  // aggregate recommended electors
-  let electors = [];
-  for(const event of previousEvents) {
-    if(!jsonld.hasValue(event, 'type', 'ContinuityMergeEvent')) {
-      // regular event
-      continue;
-    }
-    // TODO: is `e.proof.creator` check robust enough? Can it assume
-    //   a single signature and that it's by the voter? (merge events are
-    //   only meant to be signed by the voter)
-    electors.push(event.proof.creator);
-    // TODO: support recommended electors?
-    /*const recommended = jsonld.getValues(event, 'recommendedElector');
-    // only accept a recommendation if there is exactly 1
-    if(recommended.length === 1) {
-      // TODO: recommended elector needs to be validated -- only
-      //   previous participants (those that have generated signed merge
-      //   events) can be recommended
-      electors.push(recommended[0]);
-    }*/
-  }
+  {ledgerNode, ledgerConfiguration, latestBlockSummary, blockHeight}) => {
+  // get partipicants for the last block
+  const {consensusProofPeers, mergeEventPeers} = await _blocks.getParticipants(
+    {blockHeight: blockHeight - 1, ledgerNode});
 
   // TODO: we should be able to easily remove previously detected
   // byzantine nodes (e.g. those that forked at least) from the electors
@@ -74,19 +40,17 @@ api.getBlockElectors = callbackify(async (
   //   twice for now -- add comprehensive elector selection and
   //   recommended elector vote aggregating algorithm in v2
   const aggregate = {};
-  electors = _.uniq(electors);
-  electors.forEach(e => aggregate[e] = {id: e, weight: 1});
+  let electors = mergeEventPeers.map(id => {
+    return aggregate[id] = {id, weight: 1};
+  });
   // TODO: weight previous electors more heavily to encourage continuity
-  const consensusProof =
-    eventBlock.block.consensusProof;
-  _.uniq(consensusProof.map(e => e.proof.creator))
-    .forEach(id => {
-      if(id in aggregate) {
-        aggregate[id].weight = 3;
-      } else {
-        aggregate[id] = {id, weight: 2};
-      }
-    });
+  consensusProofPeers.map(id => {
+    if(id in aggregate) {
+      aggregate[id].weight = 3;
+    } else {
+      aggregate[id] = {id, weight: 2};
+    }
+  });
   electors = Object.values(aggregate);
 
   // get elector count, defaulting to MAX_ELECTOR_COUNT if not set
@@ -113,6 +77,8 @@ api.getBlockElectors = callbackify(async (
   }
   }*/
 
+  const {blockHash} = latestBlockSummary.eventBlock.meta;
+
   // break ties via sorting
   electors.sort((a, b) => {
     // 1. sort descending by weight
@@ -122,13 +88,13 @@ api.getBlockElectors = callbackify(async (
       return b.weight - a.weight;
     }
 
-    // TODO: when mixing in data, why not `xor` instead of sha-256?
+    // FIXME: when mixing in data, why not `xor` instead of sha-256?
 
     // generate and cache hashes
     // the hash of the previous block is combined with the elector id to
     // prevent any elector from *always* being sorted to the top
-    a.hash = a.hash || _sha256(eventBlock.meta.blockHash + _sha256(a.id));
-    b.hash = b.hash || _sha256(eventBlock.meta.blockHash + _sha256(b.id));
+    a.hash = a.hash || _sha256(blockHash + _sha256(a.id));
+    b.hash = b.hash || _sha256(blockHash + _sha256(b.id));
 
     // 2. sort by hash
     return a.hash.localeCompare(b.hash);


### PR DESCRIPTION
This eliminates retrieving all operations on all events from the previous block when computing electors. This depends on PR #111 and it will be easier to review once that one is merged.