### PR TITLE
Make query covered.

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -483,10 +483,10 @@ api.getHead = callbackify(async (
 
   // no head found yet; use latest local merge event
   if(!head) {
+    // audit:continuity/b0fbe194-18b4-4fc5-80f8-89859da41f0f.md
     const query = {
       'meta.continuity2017.type': 'm',
-      'meta.continuity2017.creator': creatorId,
-      'meta.continuity2017.generation': {$exists: true}
+      'meta.continuity2017.creator': creatorId
     };
     const projection = {
       _id: 0, 'meta.eventHash': 1, 'meta.continuity2017.generation': 1


### PR DESCRIPTION
I'm going to be auditing all of the queries since I've discovered Robo 3T (formerly Robomongo) https://robomongo.org/download I know @gannan08 has been using this tool.  We are able to copy javascript code into the Robo3T console and execute queries, but more importantly, easily add `.explain("executionStats")`.  This procedure was *extremely* tedious using the mongo shell.

When you see `audit:continuity/b0fbe194-18b4-4fc5-80f8-89859da41f0f.md` that means https://github.com/digitalbazaar/bedrock-ledger-query-audit/blob/master/continuity/b0fbe194-18b4-4fc5-80f8-89859da41f0f.md

I want to create this association with queries and audits, I'm open to suggestions about how to improve the process.  I'm not using the full URL because of 80 char limit and a wrapped URL is not that useful.

Now, regarding this PR, but removing this one line, this becomes a covered query because the $exist was causing the document to get pulled.