### PR TITLE
Make getGenesisHead query covered.

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -525,14 +525,17 @@ api.getGenesisHead = callbackify(async ({ledgerNode}) => {
   }
 
   // get genesis hash from storage
-  const query = {'meta.continuity2017.type': 'm'};
-  const projection =
-    {_id: 0, 'meta.eventHash': 1, 'meta.continuity2017.generation': 1};
+  // audit:continuity/7e2d6fab-c13c-42d9-9fe0-c6b080225ab8.md
+  const query = {
+    'meta.continuity2017.type': 'm',
+    'meta.continuity2017.generation': 0
+  };
+  const projection = {_id: 0, 'meta.eventHash': 1};
   const eventsCollection = ledgerNode.storage.events.collection;
   const [{meta}] = await eventsCollection.find(query, projection)
-    .sort({'meta.continuity2017.generation': 1}).limit(1)
+    .limit(1)
     .toArray();
-  if(!(meta && meta.continuity2017.generation === 0)) {
+  if(!meta) {
     throw new BedrockError(
       'The genesis merge event was not found.',
       'InvalidStateError', {


### PR DESCRIPTION
This was covered before, but was scanning thousands (all) of merge event keys and sorting etc..  Genesis merge is always the only generation===0 event.