### PR TITLE
Explicit consensus

### DIFF
--- a/lib/agents/merge-agent.js
+++ b/lib/agents/merge-agent.js
@@ -124,7 +124,7 @@ module.exports = class MergeAgent extends ContinuityAgent {
     const collection = this.ledgerNode.storage.events.collection;
     const query = {
       'meta.continuity2017.type': 'm',
-      'meta.consensus': {$exists: false},
+      'meta.consensus': false,
     };
     // TODO: would specifying `limit` here be helpful?
     collection.count(query, {hint: 'continuity2'}, callback);

--- a/lib/election.js
+++ b/lib/election.js
@@ -210,7 +210,7 @@ async function _getAncestors({blockHeight, hashes, ledgerNode}) {
   const query = {
     'meta.eventHash': {},
     $or: [
-      {'meta.consensus': {$exists: false}},
+      {'meta.consensus': false},
       // events may have been assigned to the current block during a prior
       // failed operation. All events must be included so that `blockOrder`
       // can be properly computed

--- a/lib/events.js
+++ b/lib/events.js
@@ -1066,6 +1066,7 @@ async function _getStartHash(
   });
   const targetGeneration = peerLocalNodeHead.generation + maxDepth;
   const collection = ledgerNode.storage.events.collection;
+  // audit:continuity/763a9d0c-cbe3-4589-9a2a-793b41be1f73.md
   const query = {
     'meta.continuity2017.type': 'm',
     'meta.continuity2017.creator': creatorId,

--- a/lib/events.js
+++ b/lib/events.js
@@ -620,14 +620,15 @@ async function _getMergeableHashes({ledgerNode}) {
 // `r` (WebLedgerOperationEvent) or `c` (WebLedgerConfigurationEvent)
 async function _hasOutstandingRegularEvents({ledgerNode}) {
   const {collection} = ledgerNode.storage.events;
+  // audit:continuity/434f0b72-b06e-468c-b555-12352fdda365.md
   const query = {
     'meta.continuity2017.type': {$in: ['c', 'r']},
-    'meta.consensus': {$exists: false},
+    'meta.consensus': false,
   };
-  // covered query under `continuity2` index
-  const record = await collection.findOne(query, {
-    _id: 0, 'meta.continuity2017.type': 1
-  });
+  const projection = {
+    _id: 0, 'meta.consensus': 1
+  };
+  const record = await collection.findOne(query, projection);
   return !!record;
 }
 

--- a/lib/events.js
+++ b/lib/events.js
@@ -274,6 +274,7 @@ api.merge = callbackify(async ({creatorId, ledgerNode}) => {
 
   // local merge events must be written directly to storage
   const meta = {
+    consensus: false,
     continuity2017: {
       creator: creatorId,
       generation: nextGeneration,
@@ -654,6 +655,7 @@ async function _processLocalEvent({event, eventHash, ledgerNode}) {
   await validate('continuity.webLedgerEvents', event);
 
   const meta = {
+    consensus: false,
     continuity2017: {creator: creator.id, type: 'r'},
     eventHash,
   };
@@ -681,7 +683,7 @@ async function _processPeerConfigurationEvent({event, ledgerNode, needed}) {
       'The event supplied by the peer was not requested.',
       'DataError', {event, eventHash, needed});
   }
-  const meta = {continuity2017: {type: 'c'}, eventHash};
+  const meta = {consensus: false, continuity2017: {type: 'c'}, eventHash};
   return {event, meta};
 }
 
@@ -705,7 +707,7 @@ async function _processPeerRegularEvent({event, ledgerNode, needed}) {
       'The event supplied by the peer was not requested.',
       'DataError', {event, eventHash, needed});
   }
-  const meta = {continuity2017: {type: 'r'}, eventHash};
+  const meta = {consensus: false, continuity2017: {type: 'r'}, eventHash};
 
   // lexicographic sort on the hash of the operation determines the
   // order of operations in events
@@ -756,6 +758,7 @@ async function _processPeerMergeEvent({event, ledgerNode, needed}) {
 
   const generation = parentGeneration + 1;
   const meta = {
+    consensus: false,
     continuity2017: {creator, generation, type: 'm'},
     eventHash,
   };

--- a/lib/voters.js
+++ b/lib/voters.js
@@ -191,11 +191,6 @@ api.getPeerIds = callbackify(async ({creatorId, ledgerNode, limit}) => {
     // break... why?
     // exclude creatorId
     //'meta.continuity2017.creator': {$ne: creatorId},
-    $or: [{
-      'meta.consensus': {$exists: true}
-    }, {
-      'meta.consensus': {$exists: false}
-    }]
   };
   // FIXME: implement `limit` (and would need to sort by most recent events
   // as well)

--- a/test/mocha/91-basic-multinode.js
+++ b/test/mocha/91-basic-multinode.js
@@ -785,7 +785,7 @@ describe.skip('Multinode Basics', () => {
                         }),
                     consensus: callback =>
                       ledgerNode.storage.events.collection.find({
-                        'meta.consensus': {$exists: true}
+                        'meta.consensus': true
                       }).count((err, result) => {
                         assertNoError(err);
                         tableData[6].push(result.toString());

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -310,7 +310,7 @@ api.copyEvents = ({from, to, useSnapshot = false}, callback) => {
       // FIXME: use a more efficient query, the commented aggregate function
       // is evidently missing some events.
       collection.find({
-        'meta.consensus': {$exists: false}
+        'meta.consensus': false
       }, {'meta.eventHash': 1}).sort({'$natural': 1}).toArray(
         (err, results) => {
           if(err) {
@@ -533,7 +533,7 @@ api.snapshotEvents = ({ledgerNode}, callback) => {
   // FIXME: use a more efficient query, the commented aggregate function
   // is evidently missing some events.
   collection.find({
-    'meta.consensus': {$exists: false}
+    'meta.consensus': false
   }).sort({'$natural': 1}).toArray((err, result) => {
     if(err) {
       return callback(err);

--- a/test/package.json
+++ b/test/package.json
@@ -20,7 +20,7 @@
     "bedrock-ledger-consensus-continuity": "file:..",
     "bedrock-ledger-context": "^1.0.0",
     "bedrock-ledger-node": "digitalbazaar/bedrock-ledger-node#master",
-    "bedrock-ledger-storage-mongodb": "digitalbazaar/bedrock-ledger-storage-mongodb#master",
+    "bedrock-ledger-storage-mongodb": "digitalbazaar/bedrock-ledger-storage-mongodb#consensusExists",
     "bedrock-mongodb": "^5.0.0",
     "bedrock-passport": "^3.3.0",
     "bedrock-permission": "^2.4.3",


### PR DESCRIPTION
We've been doing `meta.consensus` wrong.  Any queries that involve `$exist` require the document to be examined even if the field is in the index.

So, by explicitly setting `meta.consensus` a whole raft of queries that we might have thought were covered are covered for free, and if they aren't now, they will be after the queries get audited.

Depends on: https://github.com/digitalbazaar/bedrock-ledger-storage-mongodb/pull/37