### PR TITLE
Simplify _hasSufficientEndorsements.

### DIFF
--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -758,7 +758,7 @@ function _findEndorsementMergeEvent(
 
       // see if there are a supermajority of endorsements of `x` now
       if(_hasSufficientEndorsements(
-        {ledgerNodeId, x, descendants, electorSet, supermajority})) {
+        {x, descendants, electorSet, supermajority})) {
         //console.log('supermajority of endorsements found at generation',
         //  treeDescendant._generation);
         //console.log();

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -1328,10 +1328,9 @@ function _descendsFrom(younger, older) {
 }
 
 function _hasSufficientEndorsements(
-  {ledgerNodeId, x, descendants, electorSet, supermajority}) {
+  {x, descendants, electorSet, supermajority}) {
   // always count `x` as self-endorsed
   const endorsements = new Set([_getCreator(x)]);
-  let total = 1;
   let next = [x];
   //console.log('checking for sufficient endorsements...');
   while(next.length > 0) {
@@ -1343,13 +1342,13 @@ function _hasSufficientEndorsements(
         // `event` is in the computed path of descendants
         for(const e of d) {
           const creator = _getCreator(e);
-          if(!endorsements.has(creator) && electorSet.has(creator)) {
+          if(electorSet.has(creator)) {
             endorsements.add(creator);
-            total++;
-            //console.log('total', total, 'supermajority', supermajority);
+            //console.log(
+            // 'total', endorsements.size, 'supermajority', supermajority);
             //console.log('electors', electorSet);
             //console.log('endorsements', endorsements);
-            if(total >= supermajority) {
+            if(endorsements.size >= supermajority) {
               return true;
             }
           }


### PR DESCRIPTION
This bench shows that just doing `set.add` is as fast or faster than doing a `set.has` test first.

EDIT: here's the link: https://github.com/digitalbazaar/loop-bench/blob/canonicalize/index14.js#L2-L4