### PR TITLE
Fix events.create return value.

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -196,7 +196,7 @@ api.create = callbackify(async ({ledgerNode}) => {
   const queue = new _cache.OperationQueue({ledgerNodeId});
   if(!await queue.hasNextChunk()) {
     logger.debug('No new operations.');
-    return {truncated: false};
+    return {hasMore: false};
   }
 
   // get chunk of operations to put into the event concurrently with


### PR DESCRIPTION
Replace `truncated` with `hasMore`.

`hasMore` corresponds to the one place where the `events.create` API is utilized here: https://github.com/digitalbazaar/bedrock-ledger-consensus-continuity/blob/master/lib/agents/operation-agent.js#L55-L62