### PR TITLE
Ensure that basisBlockHeight is set.

### DIFF
--- a/lib/cache/OperationQueue.js
+++ b/lib/cache/OperationQueue.js
@@ -32,7 +32,8 @@ module.exports = class OperationQueue {
    * @return a Promise that resolves to `true` or `false`.
    */
   async hasNextChunk() {
-    if(this.opKeys) {
+    if(Array.isArray(this.opKeys) && this.opKeys.length > 0 &&
+      Number.isInteger(this.basisBlockHeight)) {
       return true;
     }
 
@@ -41,7 +42,7 @@ module.exports = class OperationQueue {
     // the next chunk was not popped off the queue, likely because an event
     // creation failed... so we can resume here)
     this.opKeys = await cache.client.lrange(this.chunkCacheKey, 0, -1);
-    if(this.opKeys.length > 0) {
+    if(this.opKeys.length > 0 && Number.isInteger(this.basisBlockHeight)) {
       this.chunkCached = true;
       return true;
     }
@@ -60,7 +61,7 @@ module.exports = class OperationQueue {
     }
 
     // record the basisBlockHeight of the first operation,
-    const basisBlockHeight = _cacheKey
+    const basisBlockHeight = this.basisBlockHeight = _cacheKey
       .basisBlockHeightFromOperationKey(nextKeys[0]);
 
     // since the queue is FIFO, we can stop when we hit an operation with a
@@ -74,7 +75,6 @@ module.exports = class OperationQueue {
     }
     logger.debug('New operations found.', {basisBlockHeight, opCount});
 
-    this.basisBlockHeight = basisBlockHeight;
     // record that a subset of the available operations is being returned
     this.hasMore = listLength > maxOperations || nextKeys.length > opCount;
     this.opKeys = nextKeys.slice(0, opCount);


### PR DESCRIPTION
This issue manifest as events being created that had `null` for basisBlockHeight.