### PR TITLE
Request needed events in chunks.

### DIFF
--- a/lib/gossip.js
+++ b/lib/gossip.js
@@ -9,10 +9,11 @@ const _events = require('./events');
 const _voters = require('./voters');
 const bedrock = require('bedrock');
 const brLedgerNode = require('bedrock-ledger-node');
-const {callbackify, BedrockError} = bedrock.util;
+const {config, util: {callbackify, BedrockError}} = bedrock;
 const logger = require('./logger');
 const ndjson = require('ndjson');
 const {validate} = require('bedrock-validation');
+const {'ledger-consensus-continuity': {gossip: {maxEvents}}} = config;
 
 const api = {};
 module.exports = api;
@@ -53,7 +54,6 @@ api.gossipWith = async ({callerId, ledgerNode, peer}) => {
     }
 
     try {
-      // removes event hashes from `needed` as they are received
       await _getNeeded({ledgerNode, needed, peerId});
     } catch(e) {
       if(_.get(e, 'details.httpStatusCode') === 404) {
@@ -61,14 +61,10 @@ api.gossipWith = async ({callerId, ledgerNode, peer}) => {
         await peer.success();
         return {creator, creatorHeads, history, done: true};
       }
-      // return error if all the needed events were not received
-      if(needed.length !== 0) {
-        throw new BedrockError(
-          'Some events requested from the peer were not received.',
-          'DataError', {needed, peerId}, e);
-      }
+
       throw e;
     }
+
     await peer.success();
     return {creator, creatorHeads, history, done: !truncated};
   } catch(e) {
@@ -109,106 +105,115 @@ async function _getNeeded({ledgerNode, needed, peerId}) {
   bail out. */
   let addEventError;
   let peerError;
-  let streamDone = false;
   const events = [];
 
-  return new Promise(async (resolve, reject) => {
-    // connect to peer and get event stream...
-    let stream;
-    try {
-      stream = await _client.getEvents({eventHash: needed, peerId});
-    } catch(error) {
-      if(error.response) {
-        // The request was made and the server responded with a status code
-        // that falls out of the range of 2xx
-        return _handleGossipError({reject, response: error.response});
+  // request events in chunks for size `maxEvents`
+  const chunks = _.chunk(needed, maxEvents);
+  for(const [i, eventHash] of chunks.entries()) {
+    let streamDone = false;
+    await new Promise(async (resolve, reject) => {
+      // connect to peer and get event stream...
+      let stream;
+      try {
+        stream = await _client.getEvents({eventHash, peerId});
+      } catch(error) {
+        if(error.response) {
+          // The request was made and the server responded with a status code
+          // that falls out of the range of 2xx
+          return _handleGossipError({reject, response: error.response});
+        }
+        // no response was received or something happened in setting up the
+        // request that triggered an Error
+        const message = error.message || 'An HTTP Error occurred.';
+        return reject(new BedrockError(message, 'NetworkError'));
       }
-      // no response was received or something happened in setting up the
-      // request that triggered an Error
-      const message = error.message || 'An HTTP Error occurred.';
-      return reject(new BedrockError(message, 'NetworkError'));
-    }
-    stream
-      .on('response', res => {
-        const {body, statusCode} = res;
-        if(statusCode !== 200) {
-          // set `peerError` because `error` handler will be called and
-          // it should not do anything
-          peerError = new BedrockError(
-            'An error occurred contacting a peer.', 'NetworkError',
-            {body, needed, peerId, statusCode});
-          stream.destroy();
-          // we couldn't have queued any events yet, so reject
-          reject(peerError);
-        }
-      })
-
-      // TODO: *might* be worth saving the stringified version of the incoming
-      // event which would save a `stringify` operation in the case where
-      // the event validates successfully. Just a matter of associating
-      // the raw data coming in now with the eventHash calculated later.
-      .pipe(ndjson.parse())
-      .on('data', data => {
-        // if an add event error previously occurred then we can't queue
-        // another event -- and other code will handle destroying stream
-        if(addEventError) {
-          return;
-        }
-
-        if(!(data && data.event)) {
-          stream.destroy();
-          logger.debug('MALFORMED EVENT', {data});
-          peerError = new BedrockError(
-            'Malformed event detected during gossip.',
-            'AbortError', {data, peerId});
-          // if queue is idle then nothing else will trigger reject so we must
-          return reject(peerError);
-        }
-        const result = validate('continuity.webLedgerEvents', data.event);
-        if(!result.valid) {
-          addEventError = result.error;
-          if(!streamDone) {
-            // there is no reason to continue receiving events since they
-            // must be added in order and we've hit an error adding this one
-            // so destroy the stream
+      stream
+        .on('response', res => {
+          const {body, statusCode} = res;
+          if(statusCode !== 200) {
+            // set `peerError` because `error` handler will be called and
+            // it should not do anything
+            peerError = new BedrockError(
+              'An error occurred contacting a peer.', 'NetworkError',
+              {body, needed, peerId, statusCode});
             stream.destroy();
+            // we couldn't have queued any events yet, so reject
+            reject(peerError);
           }
-          return reject(addEventError);
-        }
-        events.push(data.event);
-      })
-      .on('end', () => {
-        // track that stream is done so we know when to `resolve()` later or
-        // that we don't need to destroy it should an add event error occur
-        streamDone = true;
-        // if an add event error previously occurred then other code will
-        // handle destroying the stream
-        if(addEventError) {
-          return;
-        }
+        })
 
-        // the correct number of events have been received, submit the batch
-        if(events.length === needed.length) {
-          return _events.addBatch({events, ledgerNode, needed})
-            .then(resolve)
-            .catch(error => {
-              logger.error('An error occurred in `addBatch`', {error});
-              reject(error);
-            });
-        }
-        reject(new BedrockError(
-          'The peer did not provide all the requested events.',
-          'AbortError', {needed, peerId}));
-      })
-      .on('error', err => {
-        if(peerError || addEventError) {
-          // nothing to do, previous error already occurred
-          return;
-        }
-        peerError = err;
-        reject(peerError);
-      });
-  });
+        // TODO: *might* be worth saving the stringified version of the incoming
+        // event which would save a `stringify` operation in the case where
+        // the event validates successfully. Just a matter of associating
+        // the raw data coming in now with the eventHash calculated later.
+        .pipe(ndjson.parse())
+        .on('data', data => {
+          // if an add event error previously occurred then we can't queue
+          // another event -- and other code will handle destroying stream
+          if(addEventError) {
+            return;
+          }
+
+          if(!(data && data.event)) {
+            stream.destroy();
+            logger.debug('MALFORMED EVENT', {data});
+            peerError = new BedrockError(
+              'Malformed event detected during gossip.',
+              'AbortError', {data, peerId});
+            // if queue is idle then nothing else will trigger reject so we must
+            return reject(peerError);
+          }
+          const result = validate('continuity.webLedgerEvents', data.event);
+          if(!result.valid) {
+            addEventError = result.error;
+            if(!streamDone) {
+              // there is no reason to continue receiving events since they
+              // must be added in order and we've hit an error adding this one
+              // so destroy the stream
+              stream.destroy();
+            }
+            return reject(addEventError);
+          }
+          events.push(data.event);
+        })
+        .on('end', () => {
+          // track that stream is done so we know when to `resolve()` later or
+          // that we don't need to destroy it should an add event error occur
+          streamDone = true;
+          // if an add event error previously occurred then other code will
+          // handle destroying the stream
+          if(addEventError) {
+            return;
+          }
+
+          // not on the last chunk
+          if(i !== chunks.length - 1) {
+            return resolve();
+          }
+          // last chunk
+          // the correct number of events have been received, submit the batch
+          if(events.length === needed.length) {
+            return _events.addBatch({events, ledgerNode, needed})
+              .then(resolve)
+              .catch(error => {
+                logger.error('An error occurred in `addBatch`', {error});
+                reject(error);
+              });
+          }
+          reject(new BedrockError(
+            'The peer did not provide all the requested events.',
+            'AbortError', {needed, peerId}));
+        })
+        .on('error', err => {
+          if(peerError || addEventError) {
+            // nothing to do, previous error already occurred
+            return;
+          }
+          peerError = err;
+          reject(peerError);
+        });
+    });
+  }
 }
 
 function _handleGossipError({reject, response}) {


### PR DESCRIPTION
Somewhat recently a limit was added on the HTTP gossip endpoint for events that limit the number of events that can be requested at one time (250).  This PR adds the corresponding limits on the requesting side by separating the needed list of events into multiple chunks.