### PR TITLE
Decide when seeing `f+1` endorsed proposals for the same set.

### DIFF
--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -1653,7 +1653,7 @@ function _computeSupport({
     1. If support is not for the proposal, reject.
     2. Otherwise, if >= f+1 support something other than the proposal and
        each of those sets is a larger set and has been endorsed, reject.
-    3. If not rejected, see if >= 2f+1 endorsed proposals for the same thing
+    3. If not rejected, see if >= f+1 endorsed proposals for the same thing
        we support, decide. CAVEAT: If `recoveryElectors.length > 0`, then
        a decision can only be made when `recoveryDecisionThreshold` decision
        events, each created by a recovery elector that does not have a pending
@@ -1901,11 +1901,11 @@ function _computeSupport({
   }
 
   /*
-  If existing proposal intact and a supermajority of endorsed proposals
+  If existing proposal intact and at least `f+1` of endorsed proposals
   support the same set, then consensus has been reached. Otherwise, continue
   on and hope the next event will decide...
   */
-  if(proposal && nextChoice.endorsedProposalCount >= supermajority) {
+  if(proposal && nextChoice.endorsedProposalCount >= (f + 1)) {
     // TODO: can we optimize such that once `_decision` is set ... skip all
     // the tallying and just check `_consensusReached` at the top of the
     // function? ...what else needs to be propagated for this to work?


### PR DESCRIPTION
This is an experimental branch with an optimization for decisions. Instead of waiting for `2f+1` endorsed proposals, only `f+1` are necessary as they implicitly hide safe supermajority support in them. We need to run some tests on this, but a preliminary proof supports this concept.