### PR TITLE
4.x

### DIFF
--- a/lib/agents/consensus-agent.js
+++ b/lib/agents/consensus-agent.js
@@ -152,7 +152,7 @@ module.exports = class ConsensusAgent extends ContinuityAgent {
     });
 
     logger.verbose('_extendBlockchain.findConsensus complete.');
-    if(!consensusResult) {
+    if(!consensusResult.consensus) {
       return {consensus: false, writeBlock: false};
     }
     logger.verbose('Found consensus.');

--- a/lib/agents/consensus-agent.js
+++ b/lib/agents/consensus-agent.js
@@ -185,8 +185,7 @@ module.exports = class ConsensusAgent extends ContinuityAgent {
     state.recoveryElectors = blockElectors.recoveryElectors;
     state.recoveryGenerationThreshold =
       blockElectors.recoveryGenerationThreshold;
-    // FIXME: change to `first`
-    state.mode = 'firstWithConsensusProof';
+    state.mode = 'first';
     state.blockHeight = nextBlockHeight;
     state.previousBlockHash = previousBlockHash;
     state.previousBlockId = previousBlockId;

--- a/lib/agents/consensus-agent.js
+++ b/lib/agents/consensus-agent.js
@@ -148,7 +148,7 @@ module.exports = class ConsensusAgent extends ContinuityAgent {
       electors: state.electors,
       recoveryElectors: state.recoveryElectors,
       recoveryGenerationThreshold: state.recoveryGenerationThreshold,
-      recoveryDecisionThreshold: state.recoveryDecisionThreshold
+      mode: state.mode
     });
 
     logger.verbose('_extendBlockchain.findConsensus complete.');
@@ -185,7 +185,8 @@ module.exports = class ConsensusAgent extends ContinuityAgent {
     state.recoveryElectors = blockElectors.recoveryElectors;
     state.recoveryGenerationThreshold =
       blockElectors.recoveryGenerationThreshold;
-    state.recoveryDecisionThreshold = blockElectors.recoveryDecisionThreshold;
+    // FIXME: change to `first`
+    state.mode = 'firstWithConsensusProof';
     state.blockHeight = nextBlockHeight;
     state.previousBlockHash = previousBlockHash;
     state.previousBlockId = previousBlockId;

--- a/lib/agents/event-writer-agent.js
+++ b/lib/agents/event-writer-agent.js
@@ -128,7 +128,9 @@ module.exports = class EventWriter extends ContinuityAgent {
     multi.srem(this.cacheKey.eventQueueSet, Array.from(eventHashes));
     // update heads
     const creators = Object.keys(creatorHeads);
-    // contains cache keys for all new heads
+    // contains the current cache keys for all new heads
+    const currentKeysForNewHeads = new Set();
+    // contains new cache keys for all new heads
     const newHeadKeys = new Set();
     if(creators.length !== 0) {
       const {dupHashes} = storeEvents;
@@ -149,7 +151,12 @@ module.exports = class EventWriter extends ContinuityAgent {
         if(dupSet.has(eventHash)) {
           continue;
         }
-        newHeadKeys.add(_cacheKey.event({eventHash, ledgerNodeId}));
+        const currentKeyForNewHead = _cacheKey.event({eventHash, ledgerNodeId});
+        const newHeadKey = _cacheKey.outstandingMergeEvent(
+          {eventHash, ledgerNodeId});
+        multi.rename(currentKeyForNewHead, newHeadKey);
+        currentKeysForNewHeads.add(currentKeyForNewHead);
+        newHeadKeys.add(newHeadKey);
         const headGenerationKey = _cacheKey.headGeneration(
           {eventHash, ledgerNodeId});
         // these keys are mainly useful during gossip about recent events
@@ -165,8 +172,9 @@ module.exports = class EventWriter extends ContinuityAgent {
     }
     // remove head keys so they will not be removed from the cache
     if(newHeadKeys.size !== 0) {
-      _.pull(rangeData, ...newHeadKeys);
-      multi.sadd(this.cacheKey.outstandingMerge, Array.from(newHeadKeys));
+      // head keys have already been renamed, don't attempt to delete again
+      _.pull(rangeData, ...currentKeysForNewHeads);
+      multi.sadd(this.cacheKey.outstandingMerge, [...newHeadKeys]);
     }
     // TODO: maybe just mark these to expired because they could be used
     // for gossip

--- a/lib/cache/blocks.js
+++ b/lib/cache/blocks.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2017-2018 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2017-2019 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 
@@ -7,10 +7,14 @@ const cache = require('bedrock-redis');
 const _cacheKey = require('./cache-key');
 const {util: {BedrockError}} = require('bedrock');
 
-const api = {};
-module.exports = api;
-
-api.blockHeight = async ledgerNodeId => {
+/**
+ * Get the latest block height.
+ *
+ * @param ledgerNodeId {string} - The ID of the ledger node.
+ *
+ * @returns {Promise<Number>} The latest block height as an integer.
+ */
+exports.blockHeight = async ledgerNodeId => {
   const blockHeightKey = _cacheKey.blockHeight(ledgerNodeId);
   const result = await cache.client.get(blockHeightKey);
   if(result === null) {
@@ -22,15 +26,18 @@ api.blockHeight = async ledgerNodeId => {
 };
 
 /**
- * Commits a block by removing outstanding merge events from the event cache
- * and updating the block height after a successful merge.
+ * Commits a block:
+ * - remove events that have acheived consensus from the set of outstanding
+ *   merge events
+ * - remove cached merge event records
+ * - increment the cached blockHeight
  *
- * @param eventHashes the hashes of the merge events from the block to commit.
- * @param ledgerNodeId the ID of the ledger node to update.
+ * @param eventHashes  {string[]} - The hashes of the merge events in the block.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
  *
- * @return {Promise} resolves once the operation completes.
+ * @returns {Promise} resolves once the operation completes.
  */
-api.commitBlock = async ({eventHashes, ledgerNodeId}) => {
+exports.commitBlock = async ({eventHashes, ledgerNodeId}) => {
   const blockHeightKey = _cacheKey.blockHeight(ledgerNodeId);
   const outstandingMergeKey = _cacheKey.outstandingMerge(ledgerNodeId);
   const eventKeys = eventHashes.map(
@@ -43,14 +50,14 @@ api.commitBlock = async ({eventHashes, ledgerNodeId}) => {
 };
 
 /**
- * Stores block participation information for the given blockHeight.
+ * Get block participation information.
  *
- * @param blockHeight the block height to set.
- * @param ledgerNodeId the ID of the ledger node to update.
+ * @param blockHeight {Number} - The block height to get.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
  *
- * @return {Promise} includes consensusProofPeers and mergeEventPeers.
+ * @returns {Promise} includes consensusProofPeers and mergeEventPeers.
  */
-api.getParticipants = async ({blockHeight, ledgerNodeId}) => {
+exports.getParticipants = async ({blockHeight, ledgerNodeId}) => {
   const key = _cacheKey.blockParticipants(ledgerNodeId);
   const json = await cache.client.get(key);
   if(!json) {
@@ -68,29 +75,29 @@ api.getParticipants = async ({blockHeight, ledgerNodeId}) => {
 };
 
 /**
- * Sets the current block height in the cache for a ledger node.
+ * Sets the latest block height in the cache.
  *
- * @param blockHeight the block height to set.
- * @param ledgerNodeId the ID of the ledger node to update.
+ * @param blockHeight {Number} - The block height to set.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
  *
- * @return {Promise} resolves once the operation completes.
+ * @returns {Promise} resolves once the operation completes.
  */
-api.setBlockHeight = async ({blockHeight, ledgerNodeId}) => {
+exports.setBlockHeight = async ({blockHeight, ledgerNodeId}) => {
   const key = _cacheKey.blockHeight(ledgerNodeId);
   return cache.client.set(key, blockHeight);
 };
 
 /**
- * Stores block participation information for the given blockHeight.
+ * Store block participation information.
  *
- * @param blockHeight the block height to set.
- * @param consensusProofPeers {string[]} a list of peers.
- * @param ledgerNodeId the ID of the ledger node to update.
- * @param mergeEventPeers {string[]} a list of peers.
+ * @param blockHeight {Number} - The block height to set.
+ * @param consensusProofPeers {string[]} - A list of peers.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
+ * @param mergeEventPeers {string[]} - A list of peers.
  *
- * @return {Promise} resolves once the operation completes.
+ * @returns {Promise} resolves once the operation completes.
  */
-api.setParticipants = async (
+exports.setParticipants = async (
   {blockHeight, consensusProofPeers, ledgerNodeId, mergeEventPeers}) => {
   const key = _cacheKey.blockParticipants(ledgerNodeId);
   const json = JSON.stringify(

--- a/lib/cache/blocks.js
+++ b/lib/cache/blocks.js
@@ -41,7 +41,7 @@ exports.commitBlock = async ({eventHashes, ledgerNodeId}) => {
   const blockHeightKey = _cacheKey.blockHeight(ledgerNodeId);
   const outstandingMergeKey = _cacheKey.outstandingMerge(ledgerNodeId);
   const eventKeys = eventHashes.map(
-    eventHash => _cacheKey.event({eventHash, ledgerNodeId}));
+    eventHash => _cacheKey.outstandingMergeEvent({eventHash, ledgerNodeId}));
   return cache.client.multi()
     .srem(outstandingMergeKey, eventKeys)
     .del(eventKeys)

--- a/lib/cache/cache-key.js
+++ b/lib/cache/cache-key.js
@@ -69,6 +69,8 @@ api.ledgerNode = creatorId => `ln|${_ci(creatorId)}`;
 
 // contains a list of all non-consensus merge events, local and peer
 api.outstandingMerge = ledgerNodeId => `om|${_lni(ledgerNodeId)}`;
+api.outstandingMergeEvent = ({eventHash, ledgerNodeId}) =>
+  `ome|${_lni(ledgerNodeId)}|${eventHash}`;
 
 api.opCountLocal = ({ledgerNodeId, second}) =>
   `ocl|${_lni(ledgerNodeId)}|${second}`;

--- a/lib/cache/consensus.js
+++ b/lib/cache/consensus.js
@@ -1,42 +1,40 @@
 /*!
- * Copyright (c) 2017-2018 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2017-2019 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 
 const cache = require('bedrock-redis');
 const _cacheKey = require('./cache-key');
 
-const api = {};
-module.exports = api;
-
 /**
  * Adds the electors for the given block height to the cache for a ledger
  * node. Only one set of electors is ever cached at a time for a ledger node;
  * it includes the latest block height and the electors to use.
  *
- * @param electors the electors.
- * @param blockHeight the block height.
- * @param ledgerNodeId the ID of the ledger node.
+ * @param electors {Object} - The electors.
+ * @param blockHeight {Number} - The block height.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
  *
- * @return a Promise that resolves once the operation completes.
+ * @returns {Promise} resolves once the operation completes.
  */
-api.setElectors = async (
-  {electors, blockHeight, ledgerNodeId, recoveryMode}) => {
+exports.setElectors = async ({
+  electors, blockHeight, ledgerNodeId, recoveryMode
+}) => {
   const key = _cacheKey.electors(ledgerNodeId);
   return cache.client.set(key, JSON.stringify(
     {blockHeight, electors, recoveryMode}));
 };
 
 /**
- * Attempts to get the electors for the given blockHeight from the cache.
+ * Get the electors from the cache.
  *
- * @param blockHeight the block height.
- * @param ledgerNodeId the ID of the ledger node.
+ * @param blockHeight {Number} - The block height.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
  *
- * @return a Promise that resolves to the array of electors or to `null` if
+ * @returns {Promise} resolves to the array of electors or to `null` if
  *         the electors for the blockHeight were not found in the cache.
  */
-api.getElectors = async ({blockHeight, ledgerNodeId, recoveryMode}) => {
+exports.getElectors = async ({blockHeight, ledgerNodeId, recoveryMode}) => {
   const key = _cacheKey.electors(ledgerNodeId);
   const json = await cache.client.get(key);
   if(!json) {

--- a/lib/cache/events.js
+++ b/lib/cache/events.js
@@ -85,7 +85,8 @@ exports.addLocalMergeEvent = async ({event, meta, ledgerNodeId}) => {
   const {creator: creatorId, generation} = meta.continuity2017;
   const {eventHash} = meta;
   const headKey = _cacheKey.head({creatorId, ledgerNodeId});
-  const eventKey = _cacheKey.event({eventHash, ledgerNodeId});
+  const outstandingMergeEventKey = _cacheKey.outstandingMergeEvent(
+    {eventHash, ledgerNodeId});
   const eventGossipKey = _cacheKey.eventGossip({eventHash, ledgerNodeId});
   const outstandingMergeKey = _cacheKey.outstandingMerge(ledgerNodeId);
   const {parentHash, treeHash, type} = event;
@@ -107,11 +108,11 @@ exports.addLocalMergeEvent = async ({event, meta, ledgerNodeId}) => {
     const result = await cache.client.multi()
       .srem(childlessKey, parentHashes)
       // this key is removed when the event reaches consensus
-      .set(eventKey, eventSummary)
+      .set(outstandingMergeEventKey, eventSummary)
       // expire key which is used for gossip
       .hmset(eventGossipKey, 'event', fullEvent, 'meta', metaString)
       .expire(eventGossipKey, 600)
-      .sadd(outstandingMergeKey, eventKey)
+      .sadd(outstandingMergeKey, outstandingMergeEventKey)
       .hmset(headKey, 'h', eventHash, 'g', generation)
       .publish(`continuity2017|event|${ledgerNodeId}`, 'merge')
       .exec();

--- a/lib/cache/events.js
+++ b/lib/cache/events.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2017-2018 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2017-2019 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 
@@ -12,20 +12,17 @@ const {config, util: {BedrockError, uuid}} = bedrock;
 const operationsConfig = config['ledger-consensus-continuity'].operations;
 const eventsConfig = config['ledger-consensus-continuity'].events;
 
-const api = {};
-module.exports = api;
-
 /**
  * Adds an event received from a peer to the cache for later inserting into
  * persistent storage.
  *
- * @param event the event to cache.
- * @param meta the meta data for the event.
- * @param ledgerNodeId the ID of the ledger node to cache it for.
+ * @param event {Object} - The event to cache.
+ * @param meta {Object} - The meta data for the event.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
  *
- * @return a Promise that resolves once the operation completes.
+ * @returns {Promise} resolves once the operation completes.
  */
-api.addPeerEvent = async ({event, meta, ledgerNodeId}) => {
+exports.addPeerEvent = async ({event, meta, ledgerNodeId}) => {
   const {eventHash} = meta;
   const {creator: creatorId, generation, type} = meta.continuity2017;
   const eventKey = _cacheKey.event({eventHash, ledgerNodeId});
@@ -77,13 +74,13 @@ api.addPeerEvent = async ({event, meta, ledgerNodeId}) => {
  * of their information to the cache so it can be pulled down with the rest
  * of "recent history" to be processed by the consensus algorithm.
  *
- * @param event the event to cache.
- * @param meta the meta data for the event.
- * @param ledgerNodeId the ID of the ledger node to cache it for.
+ * @param event {Object} - The event to cache.
+ * @param meta {Object} - The meta data for the event.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
  *
- * @return a Promise that resolves once the operation completes.
+ * @returns {Promise} resolves once the operation completes.
  */
-api.addLocalMergeEvent = async ({event, meta, ledgerNodeId}) => {
+exports.addLocalMergeEvent = async ({event, meta, ledgerNodeId}) => {
   const childlessKey = _cacheKey.childless(ledgerNodeId);
   const {creator: creatorId, generation} = meta.continuity2017;
   const {eventHash} = meta;
@@ -137,14 +134,14 @@ api.addLocalMergeEvent = async ({event, meta, ledgerNodeId}) => {
 };
 
 /**
- * Tracks that a new local regular event has been added that needs merging.
+ * Record that a new local regular event has been added that needs merging.
  *
- * @param eventHash the hash of the new local regular event.
- * @param ledgerNodeId the ID of the ledger node the event was added to.
+ * @param eventHash {string} - The hash of the new local regular event.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
  *
- * @return a Promise that resolves once the operation completes.
+ * @returns {Promise} resolves once the operation completes.
  */
-api.addLocalRegularEvent = async ({eventHash, ledgerNodeId}) => {
+exports.addLocalRegularEvent = async ({eventHash, ledgerNodeId}) => {
   // new local events are `childless` meaning that they have no events
   // that descend from them; they must be merged
   const childlessKey = _cacheKey.childless(ledgerNodeId);
@@ -161,20 +158,29 @@ api.addLocalRegularEvent = async ({eventHash, ledgerNodeId}) => {
 };
 
 /**
- * Get an array of event hashes that have no children and are candidates to
+ * Get event hashes that have no children and are candidates to
  * be merged by the local node.
  *
- * @param ledgerNodeId the ID of the ledger node.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
  *
- * @return {Promise<string[]>} hashes for childless events.
+ * @returns {Promise<string[]>} hashes for childless events.
  */
-api.getChildlessHashes = async ({ledgerNodeId}) => {
+exports.getChildlessHashes = async ({ledgerNodeId}) => {
   const childlessKey = _cacheKey.childless(ledgerNodeId);
   const childlessHashes = await cache.client.smembers(childlessKey);
   return {childlessHashes};
 };
 
-api.getEvents = async ({eventHash, includeMeta = false, ledgerNodeId}) => {
+/**
+ * Get events.
+ *
+ * @param eventHash {string|string[]} - The event hash(es) to get.
+ * @param [includeMeta=false] {Boolean} - Include event meta data.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
+ *
+ * @returns {Promise<Object[]>} The events.
+ */
+exports.getEvents = async ({eventHash, includeMeta = false, ledgerNodeId}) => {
   eventHash = [].concat(eventHash);
   const fields = ['event'];
   if(includeMeta) {
@@ -199,18 +205,17 @@ api.getEvents = async ({eventHash, includeMeta = false, ledgerNodeId}) => {
 };
 
 /**
- * Get the current merge status information for the ledger node identified
- * by the given ID. This status information includes whether or not the
- * ledger node is lagging/behind in gossip (indicating that it should not
- * merge any events until caught up) and the hashes of any childless
- * events (targets for merging ... to become the parents of the next
- * potential merge event).
+ * Get the current merge status information. This status information includes:
+ * - whether or not the ledger node is lagging/behind in gossip
+ *   (indicating that it should not merge any events until caught up) and the
+ * - the hashes of any childless events (targets for merging ... to become the
+ *   parents of the next potential merge event).
  *
- * @param ledgerNodeId the ID of the ledger node to get the merge status for.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
  *
- * @return a Promise that resolves to the merge status info.
+ * @returns {Promise<Object>} The merge status info.
  */
-api.getMergeStatus = async ({ledgerNodeId}) => {
+exports.getMergeStatus = async ({ledgerNodeId}) => {
   // see if there are any childless events to be merged and if the node
   // is too far behind in gossip to merge
   const childlessKey = _cacheKey.childless(ledgerNodeId);
@@ -223,7 +228,18 @@ api.getMergeStatus = async ({ledgerNodeId}) => {
   return {gossipBehind: gossipBehind !== null, childlessHashes};
 };
 
-api.setEventGossip = async (
+/**
+ * Store an event and meta data for gossip purposes.
+ *
+ * @param event {Object} - The event.
+ * @param eventHash {string} - The event hash.
+ * @param [expire=600] {Number} - Expire the event after the specified ms.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
+ * @param meta {Object} - The event meta data.
+ *
+ * @returns {Promise} resolves once the operation completes.
+ */
+exports.setEventGossip = async (
   {event, eventHash, expire = 600, ledgerNodeId, meta}) => {
   const eventKey = _cacheKey.eventGossip({eventHash, ledgerNodeId});
   const eventString = JSON.stringify({event});
@@ -235,57 +251,57 @@ api.setEventGossip = async (
 };
 
 /**
- * Sets the current head for a creator ID in the cache. This head is stable,
+ * Set the current head for a creator ID in the cache. This head is stable,
  * meaning it refers to an event that is in storage.
  *
- * @param creatorId the ID of the creator to set the head for.
- * @param ledgerNodeId the ID of the ledger node to use.
- * @param eventHash the event hash for the head.
- * @param generation the generation for the head.
+ * @param creatorId {string} - The ID of the creator.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
+ * @param eventHash {string} - The event hash for the head.
+ * @param generation {Number} - The generation for the head.
  *
- * @return a Promise that resolves once the operation completes.
+ * @returns {Promise} resolves once the operation completes.
  */
-api.setHead = async (
+exports.setHead = async (
   {creatorId, ledgerNodeId, eventHash, generation}) => {
   const key = _cacheKey.head({creatorId, ledgerNodeId});
   await _setHead({key, eventHash, generation});
 };
 
 /**
- * Gets the current head from the cache. This head is stable, meaning it refers
+ * Get the current head from the cache. This head is stable, meaning it refers
  * to an event that is in storage.
  *
- * @param creatorId the ID of the creator to get the head for.
- * @param ledgerNodeId the ID of the ledger node to check.
+ * @param creatorId {string} - The ID of the creator.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
  *
- * @return a Promise that resolves to the head or `null` if none found.
+ * @returns {Promise} resolves to the head or `null` if none found.
  */
-api.getHead = async ({creatorId, ledgerNodeId}) => {
+exports.getHead = async ({creatorId, ledgerNodeId}) => {
   const key = _cacheKey.head({creatorId, ledgerNodeId});
   return _getHead({key});
 };
 
 /**
- * Sets the genesis head from the cache.
+ * Set the event hash for the genesis merge event.
  *
- * @param eventHash the event hash for the genesis merge event.
- * @param ledgerNodeId the ID of the ledger node to update.
+ * @param eventHash {string} - The genesis merge event hash.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
  *
- * @return a Promise that resolves once the operation completes.
+ * @return {Promise} resolves once the operation completes.
  */
-api.setGenesisHead = async ({eventHash, ledgerNodeId}) => {
+exports.setGenesisHead = async ({eventHash, ledgerNodeId}) => {
   const key = _cacheKey.genesis(ledgerNodeId);
   await cache.client.set(key, eventHash);
 };
 
 /**
- * Gets the genesis head from the cache.
+ * Get the genesis merge event hash.
  *
- * @param ledgerNodeId the ID of the ledger node to check.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
  *
- * @return a Promise that resolves to the head or `null` if none found.
+ * @return {Promise<Object|null>} The head or `null` if none found.
  */
-api.getGenesisHead = async ({ledgerNodeId}) => {
+exports.getGenesisHead = async ({ledgerNodeId}) => {
   const key = _cacheKey.genesis(ledgerNodeId);
   const eventHash = await cache.client.get(key);
   if(eventHash) {
@@ -300,12 +316,12 @@ api.getGenesisHead = async ({ledgerNodeId}) => {
  * the head for a node. This head is useful during gossip, but not for merging
  * events because it is not stable enough.
  *
- * @param creatorId the ID of the creator to get the latest head for.
- * @param ledgerNodeId the ID of the ledger node to check.
+ * @param creatorId {string} - The ID of the creator.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
  *
- * @return a Promise that resolves to the latest head or `null` if none found.
+ * @returns {Promise<Object>} The latest head or `null` if none found.
  */
-api.getUncommittedHead = async ({creatorId, ledgerNodeId}) => {
+exports.getUncommittedHead = async ({creatorId, ledgerNodeId}) => {
   const key = _cacheKey.latestPeerHead({creatorId, ledgerNodeId});
   return _getHead({key});
 };
@@ -316,12 +332,12 @@ api.getUncommittedHead = async ({creatorId, ledgerNodeId}) => {
  * an event relative to its creator node. A generation of `0` is the genesis
  * event and events count up from there, scoped to each node.
  *
- * @param eventHash the hash of the event to get the generation for.
- * @param ledgerNodeId the ID of the ledger node to use.
+ * @param eventHash {string} - The hash of the event.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
  *
- * @return a Promise that resolves to the generation for the event.
+ * @returns {Promise<Number|null>} The generation for the event.
  */
-api.getGeneration = async ({eventHash, ledgerNodeId}) => {
+exports.getGeneration = async ({eventHash, ledgerNodeId}) => {
   // first check cache
   const key = _cacheKey.headGeneration({eventHash, ledgerNodeId});
   const generation = await cache.client.get(key);
@@ -335,12 +351,12 @@ api.getGeneration = async ({eventHash, ledgerNodeId}) => {
 /**
  * Bulk sets the generation for every event in the given Map.
  *
- * @param generationMap a Map of eventHash => generation to set.
- * @param ledgerNodeId the ID of the ledger node to use.
+ * @param generationMap {Map} - A Map of eventHash => generation to set.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
  *
- * @return a Promise that resolves once the operation completes.
+ * @returns {Promise} resolves once the operation completes.
  */
-api.setGenerations = async ({generationMap, ledgerNodeId}) => {
+exports.setGenerations = async ({generationMap, ledgerNodeId}) => {
   if(generationMap.size === 0) {
     // nothing to do
     return;
@@ -357,16 +373,16 @@ api.setGenerations = async ({generationMap, ledgerNodeId}) => {
 /**
  * Bulk gets the generations for all events identified by the given hashes.
  *
- * @param eventHashes the hashes of the events to get the generations for.
- * @param ledgerNodeId the ID of the ledger node to use.
+ * @param eventHashes {string[]} - The hashes of the events.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
  *
- * @return a Promise that resolves to an object with:
+ * @returns {Promise<Object>} An object with:
  *         generationMap: a Map of eventHash => generation where the entries
  *           will preserve the order of `eventHashes`; any missing generation
  *           will be `null`.
  *         notFound: an array of eventHashes that were not found.
  */
-api.getGenerations = async ({eventHashes, ledgerNodeId}) => {
+exports.getGenerations = async ({eventHashes, ledgerNodeId}) => {
   // create keys in order (ensures event hash order is preserved)
   const keys = eventHashes.map(eventHash =>
     _cacheKey.headGeneration({eventHash, ledgerNodeId}));
@@ -390,19 +406,18 @@ api.getGenerations = async ({eventHashes, ledgerNodeId}) => {
 
 /**
  * Compute the difference between the given event hashes and those that are
- * in the event cache, i.e. return which event hashes are NOT in the cache.
+ * in the event cache.
  *
- * @param eventHashes the hashes of events to look for.
- * @param ledgerNodeId the ID of the ledger node to check.
+ * @param eventHashes {string[]} - The hashes of the events.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
  *
- * @return a Promise that resolves to an array with the events that are
- *         not in the cache.
+ * @returns {Promise<string[]>} The event hashes that are *not* in the cache.
  */
-api.difference = async ({eventHashes, ledgerNodeId}) => {
+exports.difference = async ({eventHashes, ledgerNodeId}) => {
   if(eventHashes.length === 0) {
     return [];
   }
-  // get a random key to use for the diff operation
+  // get a random key to temporarily store the results of the diff operation
   const diffKey = _cacheKey.diff(uuid());
   // get key for event queue
   const eventQueueSetKey = _cacheKey.eventQueueSet(ledgerNodeId);
@@ -438,14 +453,14 @@ api.difference = async ({eventHashes, ledgerNodeId}) => {
  * algorithm. The `event` value only has summary info like tree and parent
  * hashes and does not include operations.
  *
- * @param ledgerNodeId the ID of the ledger node to check.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
  *
- * @return a Promise that resolves to an object with:
+ * @returns {Promise<Object>} An object with:
  *           events - an array of events with a data model customized for
  *             the consensus algorithm.
  *           eventMap - a map of event hash => event (with custom data model).
  */
-api.getRecentHistory = async ({ledgerNodeId}) => {
+exports.getRecentHistory = async ({ledgerNodeId}) => {
   const events = [];
   const eventMap = {};
 

--- a/lib/cache/gossip.js
+++ b/lib/cache/gossip.js
@@ -1,39 +1,61 @@
 /*!
- * Copyright (c) 2017-2018 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2017-2019 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 
 const cache = require('bedrock-redis');
 const _cacheKey = require('./cache-key');
 
-const api = {};
-module.exports = api;
-
 /**
- * Called when a node receives a notification from another peer.
+ * Record a notification received from another peer. The notification indicates
+ * that the peer has new events available for gossip.
  *
- * @param peerId the ID of the sender of the notification.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
+ * @param peerId {string} the ID of the sender of the notification.
  *
- * @return {Promise} once the operation completes.
+ * @returns {Promise} resolves once the operation completes.
  */
-api.addNotification = async ({ledgerNodeId, peerId}) => {
+exports.addNotification = async ({ledgerNodeId, peerId}) => {
   const key = _cacheKey.gossipNotification(ledgerNodeId);
   // a set is used here because it only allows unique values
   return cache.client.sadd(key, peerId);
 };
 
-api.getGossipNotification = async ({ledgerNodeId}) => {
+/**
+ * Get a single peer ID from the set of peer notifications.
+ *
+ * @param ledgerNodeId {string} - The ID of the ledger node.
+ *
+ * @returns {Promise<string>} A peer ID.
+ */
+exports.getGossipNotification = async ({ledgerNodeId}) => {
   const key = _cacheKey.gossipNotification(ledgerNodeId);
   return cache.client.spop(key);
 };
 
-api.getPeerStatus = async ({creatorId, ledgerNodeId}) => {
+/**
+ * Get peer status information.
+ *
+ * @param creatorId {string} - The ID of the creator/peer.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
+ *
+ * @returns {Promise<Object>} Peer status information.
+ */
+exports.getPeerStatus = async ({creatorId, ledgerNodeId}) => {
   const key = _cacheKey.gossipPeerStatus({creatorId, ledgerNodeId});
   return cache.client.hmget(
     key, 'backoff', 'lastContactDate', 'lastContactResult');
 };
 
-api.gossipBehind = async ({ledgerNodeId, remove = false}) => {
+/**
+ * Set or remove the gossip behind flag.
+ *
+ * @param ledgerNodeId {string} - The ID of the ledger node.
+ * @param [remove=false] {Boolean} - Remove the flag.
+ *
+ * @returns {Promise} resolves once the operation completes.
+ */
+exports.gossipBehind = async ({ledgerNodeId, remove = false}) => {
   const key = _cacheKey.gossipBehind(ledgerNodeId);
   if(remove) {
     return cache.client.del(key);
@@ -41,7 +63,18 @@ api.gossipBehind = async ({ledgerNodeId, remove = false}) => {
   return cache.client.set(key, '');
 };
 
-api.notifyFlag = async ({ledgerNodeId, remove = false, add = false}) => {
+/**
+ * Get, set, or remove the outstanding gossip notification flag. This flag
+ * is used to ensure that outgoing gossip notifications are resulting in
+ * gossip sessions being initiated from peers.
+ *
+ * @param ledgerNodeId {string} - The ID of the ledger node.
+ * @param [add=false] {Boolean} - Add the flag.
+ * @param [remove=false] {Boolean} - Remove the flag.
+ *
+ * @returns {Promise<string|null>} An empty string if the flag is set or null.
+ */
+exports.notifyFlag = async ({ledgerNodeId, remove = false, add = false}) => {
   const key = _cacheKey.gossipNotifyFlag(ledgerNodeId);
   if(remove) {
     return cache.client.del(key);
@@ -52,7 +85,19 @@ api.notifyFlag = async ({ledgerNodeId, remove = false, add = false}) => {
   return cache.client.get(key);
 };
 
-api.setPeerStatus = async (
+/**
+ * Set peer status information.
+ *
+ * @param backoff {Number} - The backoff period for the peer in ms.
+ * @param creatorId {string} - The ID of the creator/peer.
+ * @param lastContactDate {Number} - The last contact date in ms elapsed since
+ *   the UNIX epoch.
+ * @param lastContactResult {string} - The result of the last contact.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
+ *
+ * @returns {Promise} resolves once the operation completes.
+ */
+exports.setPeerStatus = async (
   {backoff, creatorId, lastContactDate, lastContactResult, ledgerNodeId}) => {
   const key = _cacheKey.gossipPeerStatus({creatorId, ledgerNodeId});
   return cache.client.multi().hmset(

--- a/lib/cache/index.js
+++ b/lib/cache/index.js
@@ -19,4 +19,5 @@ api.consensus = require('./consensus');
 api.events = require('./events');
 api.gossip = require('./gossip');
 api.operations = require('./operations');
+api.prime = require('./prime');
 api.voters = require('./voters');

--- a/lib/cache/operations.js
+++ b/lib/cache/operations.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2017-2018 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2017-2019 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 
@@ -9,21 +9,16 @@ const _cacheKey = require('./cache-key');
 const operationsConfig = require('bedrock')
   .config['ledger-consensus-continuity'].operations;
 
-const api = {};
-module.exports = api;
-
 /**
  * Adds an operation to the cache.
  *
- * @param operation the operation to cache.
- * @param operationHash the hash for the operation.
- * @param recordId the `database.hash` of the ID of the record for the
- *          operation.
- * @param ledgerNodeId the ID of the ledger node to update.
+ * @param operation {Object} - The operation data.
+ * @param meta {Object} - The operation meta data.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
  *
- * @return {Promise} resolves once the operation completes.
+ * @returns {Promise} resolves once the operation completes.
  */
-api.add = async ({ledgerNodeId, operation, meta}) => {
+exports.add = async ({ledgerNodeId, operation, meta}) => {
   const {basisBlockHeight, operationHash} = meta;
   const opHashKey = _cacheKey.operationHash({ledgerNodeId, operationHash});
   const opKey = _cacheKey.operation(
@@ -41,7 +36,15 @@ api.add = async ({ledgerNodeId, operation, meta}) => {
     .exec();
 };
 
-api.exists = async ({ledgerNodeId, operationHash}) => {
+/**
+ * Check for the existence of an operation in the cache.
+ *
+ * @param ledgerNodeId {string} - The ID of the ledger node.
+ * @param operationHash {string} - The hash of the operation.
+ *
+ * @returns {Promise<Boolean>} True if the operation exists, otherwise false.
+ */
+exports.exists = async ({ledgerNodeId, operationHash}) => {
   const opHashKey = _cacheKey.operationHash({ledgerNodeId, operationHash});
   // watch the opKey whether it exists or not
   await cache.client.watch(opHashKey);

--- a/lib/cache/prime.js
+++ b/lib/cache/prime.js
@@ -1,0 +1,126 @@
+/*!
+ * Copyright (c) 2017-2019 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const _blocks = require('./blocks');
+const _cacheKey = require('./cache-key');
+const cache = require('bedrock-redis');
+const logger = require('../logger');
+
+exports.primeAll = async ({ledgerNode}) => {
+  logger.debug('Priming the cache...', {ledgerNodeId: ledgerNode.id});
+  await exports.primeBlockHeight({ledgerNode});
+  logger.debug(
+    'Successfully primed block height.', {ledgerNodeId: ledgerNode.id});
+  await exports.primeOutstandingMergeEvents({ledgerNode});
+  logger.debug(
+    'Successfully primed outstanding merge events.',
+    {ledgerNodeId: ledgerNode.id});
+  await exports.primeChildlessEvents({ledgerNode});
+  logger.debug(
+    'Successfully primed childless events.', {ledgerNodeId: ledgerNode.id});
+  logger.debug('Successfully primed the cache.', {ledgerNodeId: ledgerNode.id});
+};
+
+exports.primeBlockHeight = async ({ledgerNode}) => {
+  const ledgerNodeId = ledgerNode.id;
+  const {eventBlock: {block: {blockHeight}}} = await ledgerNode.storage
+    .blocks.getLatestSummary();
+  await _blocks.setBlockHeight({blockHeight, ledgerNodeId});
+};
+
+exports.primeChildlessEvents = async ({ledgerNode}) => {
+  const ledgerNodeId = ledgerNode.id;
+  const childlessKey = _cacheKey.childless(ledgerNodeId);
+  const childless = await exports.getChildlessEvents({ledgerNode});
+  const txn = cache.client.multi();
+  txn.del(childlessKey);
+  if(childless.length > 0) {
+    txn.sadd(childlessKey, childless);
+  }
+  await txn.exec();
+};
+
+exports.primeOutstandingMergeEvents = async ({ledgerNode}) => {
+  const ledgerNodeId = ledgerNode.id;
+  const outstandingMergeKey = _cacheKey.outstandingMerge(ledgerNodeId);
+  // get events from mongodb
+  const mergeEvents = await exports.getOutstandingMergeEvents({ledgerNode});
+  await exports.removeOutstandingMergeEventKeys({ledgerNodeId});
+  const txn = cache.client.multi();
+  txn.del(outstandingMergeKey);
+  // add all outstanding merge events to the cache
+  if(mergeEvents.length > 0) {
+    const keys = mergeEvents.map(({meta: {eventHash}}) =>
+      _cacheKey.outstandingMergeEvent({eventHash, ledgerNodeId}));
+    txn.sadd(outstandingMergeKey, keys);
+    for(const [index, event] of mergeEvents.entries()) {
+      txn.set(keys[index], JSON.stringify(event));
+    }
+  }
+  await txn.exec();
+};
+
+exports.getChildlessEvents = async ({ledgerNode}) => {
+  const ledgerNodeId = ledgerNode.id;
+  const {id: creatorId} = await ledgerNode.consensus._voters.get(
+    {ledgerNodeId});
+  const {eventHash: localHeadHash} = await ledgerNode.consensus.
+    _events.getHead({creatorId, ledgerNode, useCache: false});
+  const result = await ledgerNode.storage.events.collection.find({
+    'meta.consensus': false
+  }).project({
+    _id: 0,
+    'meta.eventHash': 1,
+    'event.parentHash': 1,
+  }).toArray();
+  const eventsMap = new Map();
+  for(const e of result) {
+    eventsMap.set(e.meta.eventHash, {
+      parentHash: e.event.parentHash,
+      _children: 0,
+    });
+  }
+  // compute the number of children for each event
+  for(const [, event] of eventsMap) {
+    for(const p of event.parentHash) {
+      const parent = eventsMap.get(p);
+      if(parent) {
+        parent._children++;
+      }
+    }
+  }
+  const childless = [];
+  for(const [eventHash, event] of eventsMap) {
+    if(event._children === 0 && eventHash !== localHeadHash) {
+      childless.push(eventHash);
+    }
+  }
+  return childless;
+};
+
+exports.getOutstandingMergeEvents = async ({ledgerNode}) =>
+  ledgerNode.storage.events.collection.find({
+    'meta.continuity2017.type': 'm',
+    'meta.consensus': false
+  }).project({
+    _id: 0,
+    'event.parentHash': 1,
+    'event.treeHash': 1,
+    // FIXME: determine if event.type is actually used, if not eliminate it
+    'event.type': 1,
+    'meta.eventHash': 1,
+    'meta.continuity2017.creator': 1,
+  }).toArray();
+
+exports.removeOutstandingMergeEventKeys = async ({ledgerNodeId}) => {
+  // this is a sample eventHash used to produce a sample key
+  const eventHash = 'zQmRkvkWf3ToMhkzFbWmyfpyFDEUEjbBLWJUj7JwT14D7ex';
+  const sampleKey = _cacheKey.outstandingMergeEvent({eventHash, ledgerNodeId});
+  const keyPrefix = sampleKey.substr(0, sampleKey.lastIndexOf('|') + 1);
+  const eventKeysInCache = await cache.client.keys(`${keyPrefix}*`);
+  if(eventKeysInCache.length > 0) {
+    await cache.client.del(eventKeysInCache);
+  }
+};

--- a/lib/cache/voters.js
+++ b/lib/cache/voters.js
@@ -1,35 +1,32 @@
 /*!
- * Copyright (c) 2017-2018 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2017-2019 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 
 const cache = require('bedrock-redis');
 const _cacheKey = require('./cache-key');
 
-const api = {};
-module.exports = api;
-
 /**
- * Adds a voter ID to the cache for a given ledger node.
+ * Adds a voter ID to the cache.
  *
- * @param voterId the voter ID to add to the cache.
- * @param ledgerNodeId the ID of the ledger node to update.
+ * @param voterId {string} - The voter ID.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
  *
- * @return a Promise that resolves once the operation completes.
+ * @returns {Promise} resolves once the operation completes.
  */
-api.add = async ({voterId, ledgerNodeId}) => {
+exports.add = async ({voterId, ledgerNodeId}) => {
   const key = _cacheKey.voter(ledgerNodeId);
   return cache.client.set(key, voterId);
 };
 
 /**
- * Gets a voter ID from the cache for a given ledger node.
+ * Gets a voter ID from the cache.
  *
- * @param ledgerNodeId the ID of the ledger node to get the voter ID for.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
  *
- * @return a Promise that resolves to the voter ID or `null` if not found.
+ * @returns {Promise<string|null>} The voter ID or `null` if not found.
  */
-api.get = async ({ledgerNodeId}) => {
+exports.get = async ({ledgerNodeId}) => {
   const key = _cacheKey.voter(ledgerNodeId);
   return cache.client.get(key);
 };
@@ -37,12 +34,12 @@ api.get = async ({ledgerNodeId}) => {
 /**
  * Sets the ledger node ID for a voter ID.
  *
- * @param voterId the voter ID.
- * @param ledgerNodeId the ID of the ledger node.
+ * @param voterId {string} - The voter ID.
+ * @param ledgerNodeId {string} - The ID of the ledger node.
  *
- * @return a Promise that resolves once the operation completes.
+ * @returns {Promise} resolves once the operation completes.
  */
-api.setLedgerNodeId = async ({voterId, ledgerNodeId}) => {
+exports.setLedgerNodeId = async ({voterId, ledgerNodeId}) => {
   const key = _cacheKey.ledgerNode(voterId);
   return cache.client.set(key, ledgerNodeId);
 };
@@ -50,11 +47,11 @@ api.setLedgerNodeId = async ({voterId, ledgerNodeId}) => {
 /**
  * Gets the ledger node ID for a voter ID.
  *
- * @param voterId the ID of the voter to get the ledger node ID for.
+ * @param voterId - The voter ID.
  *
- * @return a Promise that resolves to the ledger node ID or `null` if not found.
+ * @returns {Promise<string|null>} The ledger node ID or `null` if not found.
  */
-api.getLedgerNodeId = async ({voterId}) => {
+exports.getLedgerNodeId = async ({voterId}) => {
   const key = _cacheKey.ledgerNode(voterId);
   return cache.client.get(key);
 };

--- a/lib/consensus-worker.js
+++ b/lib/consensus-worker.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2018 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2018-2019 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 
@@ -9,7 +9,7 @@ const consensus = require('./consensus');
 workerpool.worker({
   findConsensus: ({
     ledgerNodeId, history, blockHeight, electors,
-    recoveryElectors, recoveryGenerationThreshold, recoveryDecisionThreshold,
+    recoveryElectors, recoveryGenerationThreshold, mode,
     logger
   }) => {
     // rebuild events map so that linking history will work properly; i.e.
@@ -21,7 +21,7 @@ workerpool.worker({
     }
     return consensus.findConsensus({
       ledgerNodeId, history, blockHeight, electors,
-      recoveryElectors, recoveryGenerationThreshold, recoveryDecisionThreshold,
+      recoveryElectors, recoveryGenerationThreshold, mode,
       logger
     });
   }

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -688,14 +688,7 @@ function _findMergeEventProofCandidates({
         ancestryMap: _buildAncestryMap(mergeEvent)
       };
       if(isRecoveryElector) {
-        mergeEvent._recovery = {
-          noProgressCounter: 0,
-          electorsSeen: new Set(),
-          recoveryElectorsSeen: new Set(),
-          lastElectorsSeen: 0,
-          mraDecisionProposals: 0,
-          mraEndorsedRecoveryProposals: 0
-        };
+        mergeEvent._recovery = {noProgressCounter: 0};
       }
     }
   }
@@ -724,6 +717,12 @@ function _findMergeEventProofCandidates({
   let supermajorityForEndorsement = supermajority;
   if(mode !== 'first' && recoveryElectors.length > 0) {
     // use recovery electors for endorsement in batch mode
+    /* Note: Any other modes that might be created in the future must be
+    carefully vetted to ensure that optimizations made elsewhere would not
+    be making false assumptions. For example, detecting endorsed recovery
+    proposals in the ancestry of a voting event assume that an RE with
+    an endorsed recovery proposal must have made a Y event and would therefore
+    be a voting ancestor. */
     electorsForEndorsement = recoveryElectors;
     supermajorityForEndorsement = api.supermajority(recoveryElectors.length);
   }
@@ -1231,173 +1230,6 @@ function _useMostRecentAncestorEvent({
   index[elector] = younger;
 }
 
-function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
-  /* Rules:
-
-  Note: `2r+1` is the minimum number of recovery electors that must be
-  functional to enter recovery mode. Every time `2r+1` recovery electors
-  participate in a merge event's ancestry since the last time `2r+1`
-  participated, it constitutes a new recovery check.
-
-  1. Check the ancestry of `event` to add any recovery electors or decision
-     electors that participated since the event's `treeParent` to sets
-     tracking their participation. A "decision elector" must be participating
-     in voting, non-byzantine, and if it is also a recovery elector, it must
-     not have a recovery proposal in order to be counted as making progress
-     towards a decision. Note that any endorsed recovery proposals on the
-     event's most recent ancestors will also be tallied for later use when
-     deciding whether to reject a decision proposal in `_computeSupport`.
-  2. If < `2r+1` recovery electors have participated since the last recovery
-     check, then return because the next recovery check hasn't been reached.
-     Otherwise, >= `2r+1` recovery electors have participated, so run a new
-     recovery check...
-  3. If zero new decision electors have participated since the last recovery
-     check then increment the `noProgressCounter`.
-  4. Otherwise, if >= `2f+1` decision electors have participated since the
-     last time the set tracking decision elector participation was reset,
-     then reset the `noProgressCounter` to `0` and clear the set tracking
-     participating decision electors.
-  5. Otherwise, update last electors seen.
-  6. Clear the set tracking participating recovery electors.
-
-  */
-
-  /*
-  1. Check the ancestry of `event` to add any recovery electors or decision
-     electors that participated since the event's `treeParent`.
-  */
-
-  // track total endorsed recovery proposals from most recent ancestors
-  let endorsedRecoveryProposals = 0;
-
-  // find newly seen electors since `event._treeParent`
-  let newEvents;
-  if(event._treeParent) {
-    newEvents = [];
-    // go through event's most recent ancestors (mapped by creator) and see if
-    // the event is different from the event's parent's most recent ancestor,
-    // indicating a new event from that creator has been merged after the
-    // event's parent
-    const {mostRecentAncestors} = event._index;
-    const {mostRecentAncestors: parentAncestors} = event._treeParent._index;
-    for(const elector in mostRecentAncestors) {
-      const ancestorEvent = mostRecentAncestors[elector];
-      const parentAncestorEvent = parentAncestors[elector];
-      if(ancestorEvent !== parentAncestorEvent) {
-        // event came after tree parent
-        newEvents.push(ancestorEvent);
-      } else if(ancestorEvent &&
-        _hasEndorsedRecoveryProposal(ancestorEvent)) {
-        endorsedRecoveryProposals++;
-      }
-    }
-  } else {
-    // the event has no parent, so all most recent ancestors are new
-    newEvents = Object.values(event._index.mostRecentAncestors);
-  }
-
-  const {electorsSeen, recoveryElectorsSeen} = event._recovery;
-  const recoverySet = new Set(recoveryElectors.map(e => e.id));
-
-  // go through all new events; updating recovery and decision electors seen
-  // based on all events that are from non-byzantine electors
-  for(const newEvent of newEvents) {
-    if(!newEvent) {
-      // byzantine node detected, do not count it
-      continue;
-    }
-
-    const creator = _getCreator(newEvent);
-
-    // if creator is a recovery elector, add it as seen regardless of whether
-    // or not it can vote (has a Y in its history) because its inability to
-    // create a Y could be related to a need to enter recovery mode
-    if(recoverySet.has(creator)) {
-      recoveryElectorsSeen.add(creator);
-      // do not count any decision elector that has proposed recovery as
-      // progress toward a decision (continue early so it won't get counted)
-      if(_hasEndorsedRecoveryProposal(newEvent)) {
-        endorsedRecoveryProposals++;
-        continue;
-      }
-    }
-
-    // however, do not count any elector that cannot vote (has not made a Y)
-    // as a decision elector...
-
-    // need to make sure that `newEvent` comes at or after its creator's Y
-    const creatorYs = yByElector[creator];
-    if(!creatorYs) {
-      // `newEvent` does not come from a voting elector
-      continue;
-    }
-
-    // if `newEvent` descends from creator's Y then it counts as helping
-    // advance consensus...
-
-    // common case (non-byzantine creator)
-    if(creatorYs.length === 0) {
-      if(creatorYs[0]._generation <= newEvent._generation) {
-        electorsSeen.add(creator);
-      }
-      continue;
-    }
-
-    // creator has forked but `event` has not seen it yet; can only use
-    // `newEvent` if it occurs after one of the Ys
-    let creatorY = newEvent;
-    while(creatorY) {
-      if(creatorYs.includes(creatorY)) {
-        // `newEvent` occurs after a Y event (so it is a voting event)
-        electorsSeen.add(creator);
-        break;
-      }
-      creatorY = creatorY._treeParent;
-    }
-  }
-
-  // store most recent ancestor endorsed recovery proposals for later use
-  event._recovery.mraEndorsedRecoveryProposals = endorsedRecoveryProposals;
-
-  /*
-  2. If < `2r+1` recovery electors have participated since the last recovery
-     check, then return because the next recovery check hasn't been reached.
-  */
-  const recoverySupermajority = api.supermajority(recoveryElectors.length);
-  if(recoveryElectorsSeen.size < recoverySupermajority) {
-    return;
-  }
-
-  /*
-  3. If zero new decision electors have participated since the last recovery
-     check then increment the `noProgressCounter`.
-  */
-  const supermajority = api.supermajority(electors.length);
-  if(event._recovery.lastElectorsSeen === electorsSeen.size) {
-    event._recovery.noProgressCounter++;
-  } else if(electorsSeen.size >= supermajority) {
-    /*
-    4. Otherwise, if >= `2f+1` decision electors have participated since the
-       last time the set tracking decision elector participation was reset,
-       then reset the `noProgressCounter` to `0` and clear the set tracking
-       participating decision electors.
-    */
-    event._recovery.noProgressCounter = 0;
-    event._recovery.lastElectorsSeen = 0;
-    electorsSeen.clear();
-  } else {
-    /*
-    5. Otherwise, update last electors seen.
-    */
-    event._recovery.lastElectorsSeen = electorsSeen.size;
-  }
-
-  /*
-  6. Clear the set tracking participating recovery electors.
-  */
-  recoveryElectorsSeen.clear();
-}
-
 function _computeMostRecentVotes({event, yElectorSet, yByElector}) {
   const _votes = event._votes = {};
   for(const yElector of yElectorSet) {
@@ -1581,26 +1413,10 @@ function _tallyBranches({
 
         if(!event._recovery) {
           // shallow copy tree parent's recovery info
-          const {electorsSeen, recoveryElectorsSeen} =
-            event._treeParent._recovery;
           event._recovery = {
             ...event._treeParent._recovery,
-            electorsSeen: new Set(electorsSeen),
-            recoveryElectorsSeen: new Set(recoveryElectorsSeen),
-            mraDecisionProposals: 0,
-            mraEndorsedRecoveryProposals: 0,
             computed: false
           };
-          if(!event._recovery.skip) {
-            // update recovery info based on new most recent ancestors
-            _updateRecoveryInfo(
-              {electors, recoveryElectors, yByElector, event});
-          }
-        } else if(event._recovery && !event._recovery.skip &&
-          !event._treeParent) {
-          // update recovery info for first event on recovery elector
-          _updateRecoveryInfo(
-            {electors, recoveryElectors, yByElector, event});
         }
       }
 
@@ -1659,39 +1475,62 @@ function _computeRecovery({
 
   /* Rules:
 
-  1. Iterate over most recent ancestor events from all electors and
+  1. Update event's `noProgressCounter`. If at an event on the event's branch's
+     recovery endorsement chain, reset the counter and calculate the next event
+     on the chain, otherwise increment it.
+  2. Iterate over most recent ancestor events from all electors and
      tally decision proposals, endorsed recovery proposals, and "met no
-     progress threshold" from most recent ancestors, using the event when
+     progress threshold"s from most recent ancestors, using `event` when
      processing its own branch (instead of its tree parent). The count for
      "met no progress threshold" is incremented when an event has a recovery
      proposal or its `noProgressCounter` is greater than or equal to the
      `recoveryGenerationThreshold`.
-  2. If event's branch has an existing recovery proposal decide if it should
+  3. If event's branch has an existing recovery proposal decide if it should
      be rejected. Reject it if either the "met no progress threshold" is
-     < `2r+1` or if the tallied decision proposals is larger than event's tree
-     parent's tally. Adjust the endorsed recovery proposal count if necessary.
-  3. Store tallied decision proposals for future comparisons.
+     < `2r+1` or if the tallied decision proposals >= `f+1`. Adjust the
+     endorsed recovery proposal count if necessary.
   4. If a recovery proposal endorse point has been reached; mark any matching
      recovery proposal as endorsed. Adjust the endorsed recovery proposal
      count if necessary.
   5. If >= `r+1` endorsed recovery proposals, enter recovery mode.
-  6. Otherwise, if the event's branch has no recovery proposal and no decision
-     proposal and the "met no progress threshold" tally is >= `2r+1` and there
-     are < `f+1` decision proposals (endorsed or not, same or different from
-     one another), then create a recovery proposal on the event and compute its
-     future endorse point.
+  6. Otherwise, if the event's branch has no recovery proposal, no decision
+     proposal, the "met no progress threshold" tally is >= `2r+1`, and there
+     are < `f+1` decision proposals, then create a recovery proposal on the
+     event and compute its future endorse point.
   */
 
-  /* Note: There is no need to update
-  `event._recovery.mraEndorsedRecoveryProposals` if recovery proposals are
-  endorsed or rejected because that state variable is only consumed during
-  `computeSupport` which has already run for this event. Leaving it as-is is
-  more useful for debugging purposes. */
+  /*
+  1. Update event's `noProgressCounter`. If at an event on the event's branch's
+     recovery endorsement chain, reset the counter and calculate the next event
+     on the chain, otherwise increment it.
+  */
+  const {_recovery: recovery} = event;
+  const supermajority = api.supermajority(electors.length);
+  if(!event._treeParent) {
+    // first event, compute next time to reset no progress counter
+    recovery.progressCheck = event;
+    _computeProgressEndorsement({ledgerNodeId, event, electors, supermajority});
+  } else if(event._endorsesProgress && recovery.progressCheck) {
+    // endorse point reached... only process if progress check matches
+    if(event._endorsesProgress.includes(recovery.progressCheck)) {
+      // mark endorsed, reset no progress counter and compute next
+      // progress check
+      recovery.progressCheck._progressEndorsed = true;
+      recovery.noProgressCounter = 0;
+      recovery.progressCheck = event;
+      _computeProgressEndorsement({
+        ledgerNodeId, event, electors, supermajority
+      });
+    }
+  } else {
+    // not a progress check so increment counter
+    recovery.noProgressCounter++;
+  }
 
   /*
-  1. Iterate over most recent ancestor events from all electors and
+  2. Iterate over most recent ancestor events from all electors and
      tally decision proposals, endorsed recovery proposals, and "met no
-     progress threshold" from most recent ancestors, using the event when
+     progress threshold"s from most recent ancestors, using `event` when
      processing its own branch (instead of its tree parent). The count for
      "met no progress threshold" is incremented when an event has a recovery
      proposal or its `noProgressCounter` is greater than or equal to the
@@ -1731,28 +1570,25 @@ function _computeRecovery({
   }
 
   /*
-  2. If event's branch has an existing recovery proposal decide if it should
+  3. If event's branch has an existing recovery proposal decide if it should
      be rejected. Reject it if either the "met no progress threshold" is
-     < `2r+1` or if the tallied decision proposals is larger than event's tree
-     parent's tally.
+     < `2r+1` or if the tallied decision proposals >= `f+1`.
   */
-  const {_recovery: recovery} = event;
+  const f = api.maximumFailures(electors.length);
   const recoverySupermajority = api.supermajority(recoveryElectors.length);
   if(recovery.proposal &&
     ((meetThreshold < recoverySupermajority) ||
-    (event._treeParent && event._treeParent._recovery &&
-      decisionProposals > event._treeParent._recovery.mraDecisionProposals))) {
+    (decisionProposals >= (f + 1)))) {
     // reject recovery proposal, adjusting counts as needed
     if(_hasEndorsedRecoveryProposal(event)) {
       endorsedRecoveryProposals--;
     }
+    // FIXME: only decrement if
+    // `noProgressCounter >= recoveryGenerationThreshold` if above check
+    // changes to remove `ancestorEvent._recoveryProposal`
+    meetThreshold--;
     delete recovery.proposal;
   }
-
-  /*
-  3. Store tallied decision proposals for future comparisons.
-  */
-  event._recovery.mraDecisionProposals = decisionProposals;
 
   /*
   4. If a recovery proposal endorse point has been reached; mark any matching
@@ -1778,13 +1614,11 @@ function _computeRecovery({
   }
 
   /*
-  6. Otherwise, if the event's branch has no recovery proposal and no decision
-     proposal and the "met no progress threshold" tally is >= `2r+1` and there
-     are < `f+1` decision proposals (endorsed or not, same or different from
-     one another), then create a recovery proposal on the event and compute its
-     future endorse point.
+  6. Otherwise, if the event's branch has no recovery proposal, no decision
+     proposal, the "met no progress threshold" tally is >= `2r+1`, and there
+     are < `f+1` decision proposals, then create a recovery proposal on the
+     event and compute its future endorse point.
   */
-  const f = api.maximumFailures(electors.length);
   if(!recovery.proposal && !event._proposal &&
     meetThreshold >= recoverySupermajority && (decisionProposals < (f + 1))) {
     recovery.proposal = event;
@@ -1877,6 +1711,19 @@ function _computeSupport({
   const recoverySupermajority = api.supermajority(recoveryElectors.length);
   const recoverySet = new Set(recoveryElectors.map(e => e.id));
 
+  // while tallying votes, determine if any recovery electors have made an
+  // endorsed recovery proposal
+
+  /* Note: The only `mode`s currently supported for selecting Y events
+  create a mathematical certainty that any RE that has made an endorsed
+  recovery proposal *MUST* have also made a Y event and therefore must be
+  in the event's voting ancestry ... or be byzantine and not counted anyway.
+  This is because Y events are either the first event on the RE (which by
+  definition can't be endorsed) or the first endorsement via `2r+1` recovery
+  electors. This means a second loop over MRAs is not required to detect
+  an endorsed recovery proposal in `event`'s ancestry. */
+  let hasMraEndorsedRecoveryProposal = false;
+
   // TODO: optimize
   /*logger.verbose('Continuity2017 _computeSupport finding votes seen...',
     {ledgerNode: ledgerNodeId, eventHash: event.eventHash});*/
@@ -1884,10 +1731,11 @@ function _computeSupport({
   /*const startTime = Date.now();
   logger.debug('Start sync _computeSupport vote tally proper');*/
   const tally = [];
-  _.values(event._votes).forEach(e => {
+  for(const elector in event._votes) {
+    const e = event._votes[elector];
     if(e === false || !e._supporting) {
       // do not count byzantine votes or votes without support (initial Ys)
-      return;
+      continue;
     }
 
     // find existing result to update that matches support set
@@ -1919,10 +1767,13 @@ function _computeSupport({
     if(_hasEndorsedProposal(e)) {
       tallyResult.endorsedProposalCount++;
     }
-    if(recoverySet.has(_getCreator(e))) {
+    if(recoverySet.has(elector)) {
       tallyResult.recoveryElectorCount++;
+      if(!hasMraEndorsedRecoveryProposal && _hasEndorsedRecoveryProposal(e)) {
+        hasMraEndorsedRecoveryProposal = true;
+      }
     }
-  });
+  }
   /*logger.debug('End sync _computeSupport vote tally proper', {
     duration: Date.now() - startTime
   });*/
@@ -2080,8 +1931,7 @@ function _computeSupport({
 
     // if recovery mode is enabled, reject proposal if any most recent ancestor
     // has an endorsed recovery proposal
-    if(!reject && event._recovery && event._recovery.proposal &&
-      event._recovery.mraEndorsedRecoveryProposals > 0) {
+    if(!reject && recoverySet.size > 0 && hasMraEndorsedRecoveryProposal) {
       reject = true;
     }
 
@@ -2234,6 +2084,16 @@ function _computeProposalEndorsement({
     recoveryElectors, recoverySupermajority,
     type,
     endorsementKey: '_proposalEndorsement', endorsesKey: '_endorsesProposal'
+  });
+}
+
+function _computeProgressEndorsement({
+  ledgerNodeId, event, electors, supermajority
+}) {
+  return _computeEndorsement({
+    ledgerNodeId, event, electors, supermajority,
+    type: 'elector',
+    endorsementKey: '_progressEndorsement', endorsesKey: '_endorsesProgress'
   });
 }
 

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -669,9 +669,12 @@ function _findMergeEventProofCandidates({
       // pass `x._index.ancestryMap` as the ancestry map to short-circuit
       // searches as it includes all ancestors of X -- which should not be
       // searched when finding a Y because they cannot lead to X
-      const results = _findEndorsementMergeEvent(
-        {ledgerNodeId, x, electors, supermajority,
-          ancestryMap: x._index.ancestryMap});
+      // TODO: decide if we want Y here to require recovery electors when
+      // using recovery mode
+      const results = _findEndorsementMergeEvent({
+        ledgerNodeId, x, electors, supermajority,
+        ancestryMap: x._index.ancestryMap
+      });
       if(results) {
         const mergeEvents = [];
         for(const result of results) {
@@ -715,6 +718,9 @@ function _findMergeEventProofCandidates({
  * @param x the event in history to begin searching at.
  * @param electors all current electors.
  * @param supermajority the number that constitutes a supermajority of electors.
+ * @param [recoveryElectors] an optional set of recovery electors.
+ * @param [recoverySupermajority] the number that constitutes a supermajority
+ *          of recovery electors.
  * @param descendants an optional map of event hash to descendants that is
  *          populated as they are found.
  * @param ancestryMap an optional map of event hash to ancestors of `x` that is
@@ -723,9 +729,11 @@ function _findMergeEventProofCandidates({
  * @return `null` or an array of the earliest endorsement merge event(s)
  *           coupled with descendants maps: {mergeEvent, descendants}.
  */
-function _findEndorsementMergeEvent(
-  {ledgerNodeId, x, electors, supermajority, descendants = {},
-    ancestryMap = _buildAncestryMap(x)}) {
+function _findEndorsementMergeEvent({
+  ledgerNodeId, x, electors, supermajority,
+  recoveryElectors, recoverySupermajority,
+  descendants = {}, ancestryMap = _buildAncestryMap(x)
+}) {
   //console.log('EVENT', x.eventHash);
 
   if(supermajority === 1) {
@@ -737,6 +745,10 @@ function _findEndorsementMergeEvent(
     // no tree children, so return nothing
     return null;
   }
+
+  // TODO: if `recoveryElectors` then build a recoveryElectorSet as well
+  // and check for `recoverySupermajority` by modifying
+  // `_hasSufficientEndorsements()` to also accept these two params
 
   const electorSet = new Set(electors.map(e => e.id));
   const results = [];
@@ -1479,8 +1491,8 @@ function _tallyBranches({
         logger.debug('Start sync _findConsensusMergeEventProof: ' +
           '_computeSupport');*/
         const result = _computeSupport({
-          ledgerNodeId, event, blockHeight, electors, recoveryElectors,
-          recoveryDecisionThreshold, logger
+          ledgerNodeId, event, blockHeight,
+          electors, recoveryElectors, logger
         });
         /*logger.debug('End sync _findConsensusMergeEventProof: ' +
           '_computeSupport', {
@@ -1628,8 +1640,8 @@ function _computeRecovery({
 }
 
 function _computeSupport({
-  ledgerNodeId, event, blockHeight, electors, recoveryElectors,
-  recoveryDecisionThreshold, logger = noopLogger
+  ledgerNodeId, event, blockHeight, electors,
+  recoveryElectors, logger = noopLogger
 }) {
   // support already chosen for event
   if(event._supporting !== undefined) {
@@ -1646,7 +1658,7 @@ function _computeSupport({
        largest of those.
     2. Otherwise, union *endorsed* proposals.
   If no proposal:
-    1. If >= f+1 *endorsed* proposals, support the largest.
+    1. If >= f+1 proposals (endorsed or not), support the largest of those.
     2. Otherwise, union support.
 
   Rejecting proposals/Deciding:
@@ -1655,11 +1667,11 @@ function _computeSupport({
        each of those sets is a larger set and has been endorsed, reject.
     3. If >= f+1 endorsed proposals, decide.
        CAVEAT: If `recoveryElectors.length > 0`, then a decision can only be
-       made when `recoveryDecisionThreshold` decision events, each created by
-       a recovery elector that does not have a pending "recovery mode proposal"
-       have been found. If this caveat applies but is not met, simply continue
-       on until some future event satisfies the requirements or, alternatively,
-       recovery mode is entered.
+       made when `r+1` (where `r` is the acceptable number of failed recovery
+       electors) of the `r+1` endorsed proposals came from recovery electors.
+       If this caveat applies but is not met, simply continue on until some
+       future event satisfies the requirements or, alternatively, recovery
+       mode (i.e., a new set of electors must be chosen) is entered.
 
   Creating a new proposal:
 
@@ -1679,6 +1691,8 @@ function _computeSupport({
   // compute maximum failures `f` and supermajority `2f+1` thresholds
   const f = api.maximumFailures(electors.length);
   const supermajority = api.supermajority(electors.length);
+  const r = api.maximumFailures(recoveryElectors.length);
+  const recoverySupermajority = api.supermajority(recoveryElectors.length);
 
   // TODO: optimize
   /*logger.verbose('Continuity2017 _computeSupport finding votes seen...',
@@ -1722,10 +1736,10 @@ function _computeSupport({
   /*logger.debug('End sync _computeSupport vote tally proper', {
     duration: Date.now() - startTime
   });*/
-  /*console.log('tally', tally.map(r => ({
-    set: r.set.map(r=>r._generation),
-    count: r.count,
-    pc: r.proposalCount
+  /*console.log('tally', tally.map(t => ({
+    set: t.set.map(e => e._generation),
+    count: t.count,
+    pc: t.proposalCount
   })));*/
 
   // TODO: remove me
@@ -1776,6 +1790,10 @@ function _computeSupport({
   */
   if(proposal) {
     // determine if there are f+1 smaller proposals *other* than `proposal`
+    // Note: once a set is a proposal a theorem proves subset relations
+    // happen such that proposal sizes are unique (any proposed set of size
+    // N will have the same elements as any other proposed set of size N, so
+    // it is safe to compare set length only here)
     const total = tally
       .filter(tallyResult =>
         tallyResult.proposalCount > 0 &&
@@ -1794,12 +1812,12 @@ function _computeSupport({
     }
   } else {
     /* Choose support when there is no existing proposal:
-      1. If >= f+1 *endorsed* proposals, support the largest.
+      1. If >= f+1 proposals (endorsed or not), support the largest of those.
       2. Otherwise, union support.
     */
-    // determine if there are f+1 endorsed proposals
+    // determine if there are f+1 proposals (endorsed or not)
     const total = tally.reduce((aggregator, tallyResult) => {
-      return aggregator + tallyResult.endorsedProposalCount;
+      return aggregator + tallyResult.proposalCount;
     }, 0);
     if(total >= (f + 1)) {
       nextChoice = tally[0];
@@ -1842,27 +1860,12 @@ function _computeSupport({
     event._lastSwitch = event;
     // increment next choice count
     nextChoice.count++;
-    // TODO: optimize to only compute endorsers when necessary
-    // compute endorser
-    const ancestryMap = _buildAncestryMap(event);
-    const endorsement = _findEndorsementMergeEvent(
-      {ledgerNodeId, x: event, electors, supermajority,
-        descendants: {}, ancestryMap});
-    if(endorsement) {
-      // `endorsement` will be an array as byzantine nodes may fork, but
-      // if that's the case it doesn't matter which one we pick, the endorse
-      // point will not be used as the event will be detected as byzantine
-      // prior to its use, so just pick the first one
-      const endorser = event._endorser = endorsement[0].mergeEvent;
-      if(endorser._endorses) {
-        endorser._endorses.push(event);
-      } else {
-        endorser._endorses = [event];
-      }
-      /*console.log(
-        'created endorse point for', event._generation,
-        'at', event._endorser._generation);*/
-    }
+    // TODO: optimize away unnecessary endorser computations if possible
+    // compute endorser for event (if not already computed)
+    _computeEndorser({
+      ledgerNodeId, event, electors, supermajority,
+      recoveryElectors, recoverySupermajority
+    });
   }
 
   /*
@@ -1898,18 +1901,20 @@ function _computeSupport({
   }
 
   /*console.log('SUPPORT at ', event.eventHash, 'IS FOR',
-    nextChoice.set.map(r=>r._generation));*/
+    nextChoice.set.map(e => e._generation));*/
 
   /*
   If at least `f+1` of endorsed proposals support the same set, then consensus
-  has been reached. Otherwise, continue on and hope the next event will decide...
+  has been reached (modulo recovery mode caveat). Otherwise, continue on and
+  hope the next event will decide...
   */
   if(nextChoice.endorsedProposalCount >= (f + 1)) {
     // TODO: can we optimize such that once `_decision` is set ... skip all
     // the tallying and just check `_consensusReached` at the top of the
     // function? ...what else needs to be propagated for this to work?
     const consensusReached = _consensusReached({
-      event, recoveryElectors, recoveryDecisionThreshold, nextChoice});
+      event, recoveryElectors, nextChoice
+    });
     if(consensusReached) {
       // consensus reached
       return nextChoice.set;
@@ -1924,23 +1929,11 @@ function _computeSupport({
     // no proposal yet, use current event
     proposal = event;
     if(!event._endorser) {
-      // compute endorser
-      const ancestryMap = _buildAncestryMap(event);
-      const endorsement = _findEndorsementMergeEvent(
-        {ledgerNodeId, x: event, electors, supermajority,
-          descendants: {}, ancestryMap});
-      if(endorsement) {
-        // `endorsement` will be an array as byzantine nodes may fork, but
-        // since we're searching our own history and we assume we aren't
-        // byzantine, we don't have to worry about the array having more than
-        // one entry, so just pick the first one
-        const endorser = event._endorser = endorsement[0].mergeEvent;
-        if(endorser._endorses) {
-          endorser._endorses.push(event);
-        } else {
-          endorser._endorses = [event];
-        }
-      }
+      // compute endorser for event (if not already computed)
+      _computeEndorser({
+        ledgerNodeId, event, electors, supermajority,
+        recoveryElectors, recoverySupermajority
+      });
     }
   }
 
@@ -1963,7 +1956,11 @@ function _computeSupport({
 function _hasEndorsedProposal(event) {
   const proposal = event._proposal;
   if(proposal && proposal._endorsed) {
-    return event._generation >= proposal._endorser._generation;
+    for(const endorser of proposal._endorser) {
+      if(event._generation >= endorser._generation) {
+        return true;
+      }
+    }
   }
   return false;
 }
@@ -1971,7 +1968,11 @@ function _hasEndorsedProposal(event) {
 function _hasEndorsedSwitch(event) {
   const lastSwitch = event._lastSwitch;
   if(lastSwitch && lastSwitch._endorsed) {
-    return event._generation >= lastSwitch._endorser._generation;
+    for(const endorser of lastSwitch._endorser) {
+      if(event._generation >= endorser._generation) {
+        return true;
+      }
+    }
   }
   return false;
 }
@@ -1997,6 +1998,41 @@ function _compareSupportSet(set1, set2) {
   const a = set1.map(r => r.eventHash);
   const b = set2.map(r => r.eventHash);
   return a.length === b.length && _.difference(a, b).length === 0;
+}
+
+function _computeEndorser({
+  ledgerNodeId, event, electors, supermajority,
+  recoveryElectors, recoverySupermajority
+}) {
+  if(event._endorser) {
+    // already computed
+    return;
+  }
+
+  // compute endorser
+  const ancestryMap = _buildAncestryMap(event);
+  const endorsement = _findEndorsementMergeEvent({
+    ledgerNodeId, x: event, electors, supermajority,
+    recoveryElectors, recoverySupermajority,
+    descendants: {}, ancestryMap});
+  if(endorsement) {
+    // `endorsement` will be an array as byzantine nodes may fork, but
+    // the endorse point(s) will fail in a fork scenario because the fork
+    // event will be detected by at least one properly functioning node
+    const allEndorsers = [];
+    for(const {mergeEvent: endorser} of endorsement) {
+      if(endorser._endorses) {
+        endorser._endorses.push(event);
+      } else {
+        endorser._endorses = [event];
+      }
+      /*console.log(
+        'created endorse point for', event._generation,
+        'at', endorser._generation);*/
+      allEndorsers.push(endorser);
+    }
+    event._endorser = allEndorsers;
+  }
 }
 
 function _findUnionProposalSet(event, proposal) {
@@ -2026,8 +2062,7 @@ function _findUnionProposalSet(event, proposal) {
   return union;
 }
 
-function _consensusReached({
-  event, recoveryElectors, recoveryDecisionThreshold, nextChoice}) {
+function _consensusReached({event, recoveryElectors, nextChoice}) {
   // can only decide if no recovery electors are specified or if they
   // are and we've detected decisions on enough recovery electors that
   // do not have recovery proposals
@@ -2064,11 +2099,12 @@ function _consensusReached({
     [creator]: event
   };
   let decisionCount = 0;
+  const supermajority = api.supermajority(recoveryElectors.length);
   for(const {id: elector} of recoveryElectors) {
     const ancestorEvent = ancestry[elector];
     if(ancestorEvent && ancestorEvent._recovery.decision) {
       decisionCount++;
-      if(decisionCount >= recoveryDecisionThreshold) {
+      if(decisionCount >= supermajority) {
         // decision threshold crossed; consensus reached
         return true;
       }

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -771,6 +771,9 @@ function _findMergeEventProofCandidates({
  * @param x the event in history to begin searching at.
  * @param electors all current electors.
  * @param supermajority the number that constitutes a supermajority of electors.
+ * @param [recoveryElectors] an optional set of recovery electors.
+ * @param [recoverySupermajority] the number that constitutes a supermajority
+ *          of recovery electors.
  * @param descendants an optional map of event hash to descendants that is
  *          populated as they are found.
  * @param ancestryMap an optional map of event hash to ancestors of `x` that is
@@ -781,6 +784,7 @@ function _findMergeEventProofCandidates({
  */
 function _findEndorsementMergeEvent({
   ledgerNodeId, x, electors, supermajority,
+  recoveryElectors = [], recoverySupermajority = 0,
   descendants = {}, ancestryMap = _buildAncestryMap(x)
 }) {
   //console.log('EVENT', x.eventHash);
@@ -796,6 +800,7 @@ function _findEndorsementMergeEvent({
   }
 
   const electorSet = new Set(electors.map(e => e.id));
+  const recoverySet = new Set(recoveryElectors.map(e => e.id));
   const results = [];
   let next = x._treeChildren.map(treeDescendant => ({
     treeDescendant,
@@ -817,7 +822,8 @@ function _findEndorsementMergeEvent({
 
       // see if there are a supermajority of endorsements of `x` now
       if(_hasSufficientEndorsements({
-        x, descendants, electorSet, supermajority
+        x, descendants, electorSet, supermajority,
+        recoverySet, recoverySupermajority
       })) {
         //console.log('supermajority of endorsements found at generation',
         //  treeDescendant._generation);
@@ -1428,11 +1434,16 @@ function _descendsFrom(younger, older) {
 }
 
 function _hasSufficientEndorsements({
-  x, descendants, electorSet, supermajority
+  x, descendants, electorSet, supermajority,
+  recoverySet, recoverySupermajority
 }) {
   // always count `x` as self-endorsed
   const xCreator = _getCreator(x);
   const endorsements = new Set([xCreator]);
+  const recoveryEndorsements = new Set();
+  if(recoverySet.has(xCreator)) {
+    recoveryEndorsements.add(xCreator);
+  }
   let next = [x];
   //console.log('checking for sufficient endorsements...');
   while(next.length > 0) {
@@ -1444,15 +1455,27 @@ function _hasSufficientEndorsements({
         // `event` is in the computed path of descendants
         for(const e of d) {
           const creator = _getCreator(e);
+          let added = false;
           if(electorSet.has(creator)) {
             endorsements.add(creator);
+            added = true;
             //console.log(
             // 'total', endorsements.size, 'supermajority', supermajority);
             //console.log('electors', electorSet);
             //console.log('endorsements', endorsements);
-            if(endorsements.size >= supermajority) {
-              return true;
-            }
+          }
+          if(recoverySet.has(creator)) {
+            recoveryEndorsements.add(creator);
+            added = true;
+            //console.log(
+            //  'total recovery endorsements',
+            //  recoveryEndorsements.size, 'supermajority', supermajority);
+            //console.log('recoveryElectors', recoveryElectorSet);
+            //console.log('recoveryEndorsements', recoveryEndorsements);
+          }
+          if(added && endorsements.size >= supermajority &&
+            recoveryEndorsements.size >= recoverySupermajority) {
+            return true;
           }
         }
         next.push(...d);
@@ -1596,7 +1619,7 @@ function _tallyBranches({
       // if event is from a recovery elector, compute its recovery info
       if(event._recovery) {
         _computeRecovery({
-          ledgerNodeId, event, blockHeight,
+          ledgerNodeId, event, blockHeight, electors,
           recoveryElectors, recoveryGenerationThreshold, logger});
       }
 
@@ -1608,8 +1631,14 @@ function _tallyBranches({
   return null;
 }
 
+// TODO: consider merging this function's implementation with `_computeSupport`
+// to reduce number of loops when recovery mode is supported (this would be
+// an optimization, it should not change the computed results, will have to
+// be careful to make sure counting decision proposals (only count tree
+// parent's), etc. to avoid changing anything erroneously when writing this
+// optimization -- unit tests MUST cover it to check for correctness
 function _computeRecovery({
-  ledgerNodeId, event, blockHeight,
+  ledgerNodeId, event, blockHeight, electors,
   recoveryElectors, recoveryGenerationThreshold
 }) {
   if(event._recovery.computed) {
@@ -1632,16 +1661,12 @@ function _computeRecovery({
      progress threshold" is incremented when an event has a recovery proposal
      or its `noProgressCounter` is greater than or equal to the
      `recoveryGenerationThreshold`.
-  3. If a recovery proposal exists on event's branch and >= `r+1` decision
-     proposals (endorsed or not, same or different from one another) exist,
-     then reject the recovery proposal and, if it was endorsed by the current
-     event, decrement the tally counter for endorsed recovery proposals.
-  4. If >= `2r+1` endorsed recovery proposals, enter recovery mode.
-  5. Otherwise, if event's branch has a decision proposal and >= r+1 endorsed
+  3. If >= `2r+1` endorsed recovery proposals, enter recovery mode.
+  4. Otherwise, if event's branch has a decision proposal and >= r+1 endorsed
      recovery proposals exist, reject the decision proposal.
-  6. If the event's branch has no recovery proposal and no decision proposal
+  5. If the event's branch has no recovery proposal and no decision proposal
      and the "met no progress threshold" tally is >= `2r+1` and there are
-     < `r+1` decision proposals (endorsed or not, same or different from one
+     < `f+1` decision proposals (endorsed or not, same or different from one
      another), then create a recovery proposal on the event and compute its
      future endorse point.
   */
@@ -1651,9 +1676,9 @@ function _computeRecovery({
      endorsed.
   */
   const {_recovery: recovery} = event;
-  if(event._endorses) {
+  if(event._endorsesRecovery) {
     // endorse point reached
-    event._endorses.forEach(e => e._endorsed = true);
+    event._endorsesRecovery.forEach(e => e._recoveryEndorsed = true);
   }
 
   /*
@@ -1695,24 +1720,7 @@ function _computeRecovery({
   }
 
   /*
-  3. If a recovery proposal exists on event's branch and >= `r+1` decision
-     proposals (endorsed or not, same or different from one another) exist,
-     then reject the recovery proposal and, if it was endorsed by the current
-     event, decrement the tally counter for endorsed recovery proposals.
-  */
-  const rPlusOne = api.maximumFailures(recoveryElectors.length) + 1;
-  const decisionShouldBeMade = decisionProposals >= rPlusOne;
-  if(recovery.proposal && decisionShouldBeMade) {
-    // adjust tally if necessary and reject recovery proposal because a
-    // decision should be made instead
-    if(event._endorses && event._endorses.includes(recovery.proposal)) {
-      endorsedRecoveryProposals--;
-    }
-    delete recovery.proposal;
-  }
-
-  /*
-  4. If >= `2r+1` endorsed recovery proposals, enter recovery mode.
+  3. If >= `2r+1` endorsed recovery proposals, enter recovery mode.
   */
   const recoverySupermajority = api.supermajority(recoveryElectors.length);
   if(endorsedRecoveryProposals >= recoverySupermajority) {
@@ -1723,25 +1731,30 @@ function _computeRecovery({
   }
 
   /*
-  5. Otherwise, if event's branch has a decision proposal and >= r+1 endorsed
-     recovery proposals exist, reject the decision proposal.
+  4. Otherwise, if event's branch has a decision proposal and >= 1
+     endorsed recovery proposals exist, reject the decision proposal.
   */
-  if(event._proposal && endorsedRecoveryProposals >= rPlusOne) {
+  if(event._proposal && endorsedRecoveryProposals >= 1) {
     // reject decision proposal because recovery mode should be entered instead
+
+    // Note: This decision proposal has not been used in any calculations up
+    // to this point unless it was also present on the event's tree parent,
+    // so this is safe to delete without any other corrections needed.
     delete event._proposal;
   }
 
   /*
-  6. If the event's branch has no recovery proposal and no decision proposal
+  5. If the event's branch has no recovery proposal and no decision proposal
      and the "met no progress threshold" tally is >= `2r+1` and there are
-     < `r+1` decision proposals (endorsed or not, same or different from one
+     < `f+1` decision proposals (endorsed or not, same or different from one
      another), then create a recovery proposal on the event and compute its
      future endorse point.
   */
+  const f = api.maximumFailures(electors.length);
   if(!recovery.proposal && !event._proposal &&
-    meetThreshold >= recoverySupermajority && !decisionShouldBeMade) {
+    meetThreshold >= recoverySupermajority && (decisionProposals < (f + 1))) {
     recovery.proposal = event;
-    _computeEndorser({
+    _computeRecoveryEndorser({
       ledgerNodeId, event, recoveryElectors, recoverySupermajority
     });
   }
@@ -1765,36 +1778,53 @@ function _computeSupport({
   byzantine and there is nothing to compute, its vote has been revoked.
 
   If proposal:
-    1. If >= f+1 *other* smaller proposals (endorsed or not), support the
+    1. If >= `f+1` *other* smaller proposals (endorsed or not), support the
        largest of those.
     2. Otherwise, union *endorsed* proposals.
   If no proposal:
-    1. If >= f+1 proposals (endorsed or not), support the largest of those.
+    1. If >= `f+1` proposals (endorsed or not), support the largest of those.
     2. Otherwise, union support.
 
   Rejecting proposals/Deciding:
     1. If support is not for the proposal, reject.
-    2. Otherwise, if >= f+1 support something other than the proposal and
+    2. Otherwise, if >= `f+1` support something other than the proposal and
        each of those sets is a larger set and has been endorsed, reject.
-    3. If >= f+1 endorsed proposals, decide.
+    3. If >= `f+1` endorsed proposals, decide.
        The requirement of `f+1` endorsed proposals ensures that the system
        cannot fork into two different decisions.
-       CAVEAT: If `recoveryElectors.length > 0`, then a decision can only be
-       made when `r+1` (where `r` is the acceptable number of failed recovery
-       electors) of the `f+1` endorsed proposals came from recovery electors.
-       This ensures that the system cannot fork into both a decision and into
-       recovery mode. If this caveat applies but is not met, simply continue on
-       until some future event satisfies the requirements or, alternatively,
-       recovery mode (i.e., a new set of electors must be chosen) is entered.
 
   Creating a new proposal:
 
-    1. If no existing proposal (or rejected it) and >= 2f+1 nodes support our
+    1. If no existing proposal (or rejected it) and >= `2f+1` nodes support our
        next choice (endorsement not required), propose it.
-       CAVEAT: If `recoveryElectors.length > 0` and a recovery proposal has
-       been made on the event's branch, do not create the proposal.
-       Note: This proposal will be immediately rejected when recovery rules are
-       applied if there are >= r+1 recovery proposals in the system.
+       CAVEAT: If `recoveryElectors.length > 0` then >= `2r+1` recovery
+       electors must also support the next choice (where `r` is the
+       acceptable number of failed recovery electors). If a recovery proposal
+       has been made on the event's branch, do not create the proposal.
+       Note: A decision proposal will be subsequently rejected when recovery
+       rules are applied if there is an endorsed recovery proposal in the
+       system.
+  */
+
+  /* Endorsement rules:
+
+  1. An event endorses an earlier event if the events are on the same branch
+     and if the endorser event is the first event since the earlier event that
+     includes >= `2f+1` electors in its ancestry that have the earlier event
+     in their ancestry.
+  2. A switch in support is endorsed at its endorser event if no other
+     switches in support occur between it and the endorser event.
+  3. A proposal is endorsed at its endorser event if the endorser event
+     would also be a proposal for the same set.
+
+  CAVEAT: If `recoveryElectors.length > 0` then:
+
+  1. A proposal endorsement additionally requires >= `2r+1` recovery electors
+     to have the proposal in their ancestry (not merely >= `2f+1`).
+  2. A recovery proposal is endorsed at its endorser event if the endorser
+     event's ancestry includes >= `2r+1` recovery electors (instead of >=
+     `2f+1` decision electors) that have the recovery proposal in their
+     ancestry.
   */
 
   const creator = _getCreator(event);
@@ -1829,8 +1859,9 @@ function _computeSupport({
     const endorsed = _hasEndorsedSwitch(e);
     const proposal = e._proposal;
     const endorsedProposal = _hasEndorsedProposal(e);
+    const isRecoveryElector = recoverySet.has(_getCreator(e));
     const recoveryElectorEndorsedProposal = endorsedProposal &&
-      recoverySet.has(_getCreator(e));
+      isRecoveryElector;
     if(tallyResult) {
       // ensure same instance of set is used for faster comparisons
       e._supporting = tallyResult.set;
@@ -1847,6 +1878,9 @@ function _computeSupport({
       if(recoveryElectorEndorsedProposal) {
         tallyResult.recoveryElectorEndorsedProposalCount++;
       }
+      if(isRecoveryElector) {
+        tallyResult.recoveryElectorCount++;
+      }
     } else {
       tally.push({
         set: e._supporting,
@@ -1855,7 +1889,8 @@ function _computeSupport({
         proposalCount: proposal ? 1 : 0,
         endorsedProposalCount: endorsedProposal ? 1 : 0,
         recoveryElectorEndorsedProposalCount:
-          recoveryElectorEndorsedProposal ? 1 : 0
+          recoveryElectorEndorsedProposal ? 1 : 0,
+        recoveryElectorCount: isRecoveryElector ? 1 : 0
       });
     }
   });
@@ -1955,7 +1990,8 @@ function _computeSupport({
           endorsed: 0,
           proposalCount: 0,
           endorsedProposalCount: 0,
-          recoveryElectorEndorsedProposalCount: 0
+          recoveryElectorEndorsedProposalCount: 0,
+          recoveryElectorCount: 0
         };
       }
     }
@@ -1970,10 +2006,24 @@ function _computeSupport({
 
   // check if vote has changed
   if(previousChoice !== nextChoice) {
+    const lastSwitch = event._treeParent && event._treeParent._lastSwitch;
+    if(lastSwitch && !lastSwitch._switchEndorsed &&
+      lastSwitch._switchEndorser) {
+      // reject future endorsement of support as support has changed
+      if(!lastSwitch._switchEndorsed && lastSwitch._switchEndorser) {
+        for(const endorser of lastSwitch._switchEndorser) {
+          endorser._endorsesSwitch = endorser._endorsesSwitch
+            .filter(e => e !== lastSwitch);
+        }
+      }
+    }
     // set last time switched
     event._lastSwitch = event;
     // increment next choice count
     nextChoice.count++;
+    if(recoverySet.has(creator)) {
+      nextChoice.recoveryElectorCount++;
+    }
   }
 
   /*
@@ -1995,32 +2045,34 @@ function _computeSupport({
     }
 
     if(reject) {
+      // reject future endorsement of proposal
+      if(!proposal._proposalEndorsed && proposal._proposalEndorser) {
+        for(const endorser of proposal._proposalEndorser) {
+          endorser._endorsesProposal = endorser._endorsesProposal
+            .filter(e => e !== proposal);
+        }
+      }
       proposal = null;
     }
   }
 
-  // Note: While "endorsement" (specifically, the `_endorses` flag) is shared
-  // with recovery mode computations, recovery computations always happen
-  // *after* this above tally code is run, which ensures that it is not
-  // possible to count an endorsed proposal that has been rejected. If the
-  // proposal is rejected, it will not be added to the current event and would
-  // not be tallied in any subsequent call on a new event that has the
-  // current event in its ancestry. We do not need to add code to adjust the
-  // tally for a decision proposal rejection.
-  if(event._endorses) {
+  if(event._endorsesProposal) {
     // endorse point reached...
-    // Note: `proposal` might be marked as endorsed even though we rejected
-    // it because a reference to it could be in `event._endorses`; but the
-    // `notRejectedAndNotEndorsedBefore` flag prevents us from counting it if
-    // it was rejected. The proposal will never be counted again after this if
-    // it was rejected because it will not be attached to the event (and
-    // therefore will not be seen on the branch at any point at or beyond its
-    // endorser).
-    const notRejectedAndNotEndorsedBefore = proposal && !proposal._endorsed;
-    event._endorses.forEach(e => e._endorsed = true);
+
+    // FIXME: above code path might remove need for this message
+    /* Note: `proposal` might be marked as endorsed even though we rejected it
+    because a reference to it could be in `event._endorsesProposal`; but the
+    `notRejectedAndNotEndorsedBefore` flag prevents us from counting it if
+    it was rejected. The proposal will never be counted again after this if
+    it was rejected because it will not be attached to the current `event`
+    and therefore will not be seen on the branch at any point at or beyond its
+    endorser. */
+    const notRejectedAndNotEndorsedBefore =
+      proposal && !proposal._proposalEndorsed;
+    event._endorsesProposal.forEach(e => e._proposalEndorsed = true);
     // if proposal existed and was not endorsed before but now is
     // endorsed, ensure counts are updated...
-    if(notRejectedAndNotEndorsedBefore && proposal._endorsed) {
+    if(notRejectedAndNotEndorsedBefore && proposal._proposalEndorsed) {
       nextChoice.endorsedProposalCount++;
       if(recoverySet.has(creator)) {
         nextChoice.recoveryElectorEndorsedProposalCount++;
@@ -2033,31 +2085,30 @@ function _computeSupport({
 
   /*
   If at least `f+1` of endorsed proposals support the same set, then consensus
-  has been reached (unless in recovery mode, in which case if `r+1` of those
-  proposals are from recovery electors then consensus has been reached).
-  Otherwise, continue on and hope the next event will decide...
+  has been reached. Otherwise, continue on and hope the next event will
+  decide...
   */
   if(nextChoice.endorsedProposalCount >= (f + 1)) {
-    if(recoveryElectors.length === 0 ||
-      (nextChoice.recoveryElectorEndorsedProposalCount >= (r + 1))) {
-      // consensus reached, all done!
-      return nextChoice.set;
-    }
+    // consensus reached, all done!
+    return nextChoice.set;
   }
 
-  // compute if the next choice has a supermajority
-  const hasSupermajority = nextChoice.count >= supermajority;
+  // compute if the next choice has a supermajority (and if in recovery mode,
+  // require a recovery supermajority as well)
+  const hasSupermajority = (nextChoice.count >= supermajority &&
+    (recoveryElectors.length === 0 ||
+      nextChoice.recoveryElectorCount >= recoverySupermajority));
   // If the next choice has a supermajority and has no existing (unrejected)
   // proposal, so create a new one. CAVEAT: If `recoveryElectors > 0` and
-  // event has a recovery proposal in its ancestry, do not create proposal.
+  // event has a recovery proposal in its ancestry, do not create proposal;
+  // also require a supermajority of recovery electors to support as well.
   // Note: This proposal will be immediately rejected when recovery rules are
-  // applied if there are >= r+1 recovery proposals in the system.
+  // applied if an endorsed recovery proposal is in the system.
   if(hasSupermajority && !proposal &&
     !(event._recovery && event._recovery.proposal)) {
     // no proposal yet, use current event
     proposal = event;
-    // compute endorser for proposal
-    _computeEndorser({
+    _computeProposalEndorser({
       ledgerNodeId, event, electors, supermajority,
       recoveryElectors, recoverySupermajority
     });
@@ -2071,11 +2122,24 @@ function _computeSupport({
   // propagate node's last switch
   if(!event._lastSwitch) {
     event._lastSwitch = event._treeParent._lastSwitch;
+    if(event._endorsesSwitch) {
+      // endorse point reached, same support as parent
+
+      /* Note: Safe to mark the switch endorsed at the end of this function
+      because it is only used in the tally when comparing against *other* sets
+      that do not match this event's support. Furthermore, if the event's
+      tree parent had different support, than the support would not be endorsed
+      by this event, so that potential "other set" could not be endorsed
+      in that comparison. */
+      const endorsedBefore = event._lastSwitch._switchEndorsed;
+      event._endorsesSwitch.forEach(e => e._switchEndorsed = true);
+      if(!endorsedBefore && event._lastSwitch.switchEndorsed) {
+        console.log('endorsed switch!');
+      }
+    }
   } else {
-    // compute switch endorser for event (if not already computed)
-    _computeEndorser({
-      ledgerNodeId, event, electors, supermajority,
-      recoveryElectors, recoverySupermajority
+    _computeSwitchEndorser({
+      ledgerNodeId, event, electors, supermajority
     });
   }
 
@@ -2087,8 +2151,8 @@ function _computeSupport({
 
 function _hasEndorsedProposal(event) {
   const proposal = event._proposal;
-  if(proposal && proposal._endorsed) {
-    for(const endorser of proposal._endorser) {
+  if(proposal && proposal._proposalEndorsed) {
+    for(const endorser of proposal._proposalEndorser) {
       if(event._generation >= endorser._generation) {
         return true;
       }
@@ -2099,8 +2163,8 @@ function _hasEndorsedProposal(event) {
 
 function _hasEndorsedSwitch(event) {
   const lastSwitch = event._lastSwitch;
-  if(lastSwitch && lastSwitch._endorsed) {
-    for(const endorser of lastSwitch._endorser) {
+  if(lastSwitch && lastSwitch._switchEndorsed) {
+    for(const endorser of lastSwitch._switchEndorser) {
       if(event._generation >= endorser._generation) {
         return true;
       }
@@ -2111,8 +2175,8 @@ function _hasEndorsedSwitch(event) {
 
 function _hasEndorsedRecoveryProposal(event) {
   const proposal = event._recovery && event._recovery.proposal;
-  if(proposal && proposal._endorsed) {
-    for(const endorser of proposal._endorser) {
+  if(proposal && proposal._recoveryEndorsed) {
+    for(const endorser of proposal._recoveryEndorser) {
       if(event._generation >= endorser._generation) {
         return true;
       }
@@ -2138,11 +2202,42 @@ function _compareEventHashes(r1, r2) {
   return r1.eventHash === r2.eventHash;
 }
 
-function _computeEndorser({
+function _computeSwitchEndorser({
+  ledgerNodeId, event, electors, supermajority
+}) {
+  return _computeEndorser({
+    ledgerNodeId, event, electors, supermajority,
+    endorserKey: '_switchEndorser', endorsesKey: '_endorsesSwitch'
+  });
+}
+
+function _computeProposalEndorser({
   ledgerNodeId, event, electors, supermajority,
   recoveryElectors = [], recoverySupermajority = 0
 }) {
-  if(event._endorser) {
+  return _computeEndorser({
+    ledgerNodeId, event, electors, supermajority,
+    recoveryElectors, recoverySupermajority,
+    endorserKey: '_proposalEndorser', endorsesKey: '_endorsesProposal'
+  });
+}
+
+function _computeRecoveryEndorser({
+  ledgerNodeId, event, recoveryElectors, recoverySupermajority
+}) {
+  return _computeEndorser({
+    ledgerNodeId, event,
+    electors: recoveryElectors, supermajority: recoverySupermajority,
+    endorserKey: '_recoveryEndorser', endorsesKey: '_endorsesRecovery'
+  });
+}
+
+function _computeEndorser({
+  ledgerNodeId, event, electors, supermajority,
+  recoveryElectors = [], recoverySupermajority = 0,
+  endorserKey, endorsesKey
+}) {
+  if(event[endorserKey]) {
     // already computed
     return;
   }
@@ -2157,6 +2252,7 @@ function _computeEndorser({
   const ancestryMap = event._index.ancestryMap || _buildAncestryMap(event);
   const endorsement = _findEndorsementMergeEvent({
     ledgerNodeId, x: event, electors, supermajority,
+    recoveryElectors, recoverySupermajority,
     descendants: {}, ancestryMap});
   if(endorsement) {
     // `endorsement` will be an array as byzantine nodes may fork, but
@@ -2164,17 +2260,17 @@ function _computeEndorser({
     // event will be detected by at least one properly functioning node
     const allEndorsers = [];
     for(const {mergeEvent: endorser} of endorsement) {
-      if(endorser._endorses) {
-        endorser._endorses.push(event);
+      if(endorser[endorsesKey]) {
+        endorser[endorsesKey].push(event);
       } else {
-        endorser._endorses = [event];
+        endorser[endorsesKey] = [event];
       }
       /*console.log(
         'created endorse point for', event._generation,
         'at', endorser._generation);*/
       allEndorsers.push(endorser);
     }
-    event._endorser = allEndorsers;
+    event[endorserKey] = allEndorsers;
   }
 }
 

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -500,7 +500,7 @@ function _findMergeEventProof({
   // at least `12f+6` total merge events must have passed in order for a
   // decision to be made
   const f = api.maximumFailures(electors.length);
-  const minMergeEvents = (electors.length === 1) ? 1 : (12 * f + 6);
+  const minMergeEvents = (electors.length === 1) ? 1 : (11 * f + 7);
   const totalMergeEvents = history.events.length;
 
   // in recovery mode, enough recovery electors must participate
@@ -517,6 +517,8 @@ function _findMergeEventProof({
   // 2. Voters form a supermajority (2f+1) AND...
   // 2.1. Either not using recovery mode OR...
   // 2.2. There are enough possible recovery deciders to meet the threshold.
+  // TODO: another check to ensure that at least one Y event has at least 2f+1
+  // votes (descending events) ... otherwise clearly the support can't be there
   const voters = Object.keys(yByElector);
   const supermajority = api.supermajority(electors.length);
   const recoverySupermajority = api.supermajority(recoveryElectors.length);
@@ -773,9 +775,6 @@ function _findMergeEventProofCandidates({
  * @param x the event in history to begin searching at.
  * @param electors all current electors.
  * @param supermajority the number that constitutes a supermajority of electors.
- * @param [recoveryElectors] an optional set of recovery electors.
- * @param [recoverySupermajority] the number that constitutes a supermajority
- *          of recovery electors.
  * @param descendants an optional map of event hash to descendants that is
  *          populated as they are found.
  * @param ancestryMap an optional map of event hash to ancestors of `x` that is
@@ -786,7 +785,6 @@ function _findMergeEventProofCandidates({
  */
 function _findEndorsementMergeEvent({
   ledgerNodeId, x, electors, supermajority,
-  recoveryElectors = [], recoverySupermajority = 0,
   descendants = {}, ancestryMap = _buildAncestryMap(x)
 }) {
   //console.log('EVENT', x.eventHash);
@@ -802,7 +800,6 @@ function _findEndorsementMergeEvent({
   }
 
   const electorSet = new Set(electors.map(e => e.id));
-  const recoverySet = new Set(recoveryElectors.map(e => e.id));
   const results = [];
   let next = x._treeChildren.map(treeDescendant => ({
     treeDescendant,
@@ -824,8 +821,7 @@ function _findEndorsementMergeEvent({
 
       // see if there are a supermajority of endorsements of `x` now
       if(_hasSufficientEndorsements({
-        x, descendants, electorSet, supermajority,
-        recoverySet, recoverySupermajority
+        x, descendants, electorSet, supermajority
       })) {
         //console.log('supermajority of endorsements found at generation',
         //  treeDescendant._generation);
@@ -1223,14 +1219,16 @@ function _useMostRecentAncestorEvent({
 }
 
 function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
-  // FIXME: the `decision` part of this likely doesn't make sense ... probably
-  // dropping that state var due to `r+1` check being what is required for
-  // a decision ...
+  // forward existing proposal on the event's branch
+  if(!event._recovery.proposal &&
+    event._treeParent && event._treeParent._recovery.proposal) {
+    event._recovery.proposal = event._treeParent._recovery.proposal;
+  }
 
-  // if either a decision has been seen or a recovery proposal has been created
-  // on the event's branch already, return, there's nothing more to do here,
-  // just waiting for other branches to either decide or propose recovery mode
-  if(event._recovery.decision || event._recovery.proposal) {
+  // if a recovery proposal has been created on the event's branch already,
+  // return, there's nothing more to do here, just waiting for other branches
+  // to either decide or propose recovery mode
+  if(event._recovery.proposal) {
     return;
   }
 
@@ -1243,16 +1241,14 @@ function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
 
   1. Check the ancestry of `event` to add any recovery electors or decision
      electors that participated since the event's `treeParent` to sets
-     tracking their participation.
+     tracking their participation. A "decision elector" must have be
+     participating in voting and non-byzantine.
   2. If < `2r+1` recovery electors have participated since the last recovery
      check, then return because the next recovery check hasn't been reached.
      Otherwise, >= `2r+1` recovery electors have participated, so run a new
      recovery check...
   3. If zero new decision electors have participated since the last recovery
      check then increment the `noProgressCounter`.
-     // FIXME: might need to do more than just look for new participation in
-     // our own history, rather might need to look at each participating
-     // event's latest ancestors vs. what they were during the last recovery
   4. Otherwise, if >= `2f+1` decision electors have participated since the
      last time the set tracking decision elector participation was reset,
      then reset the `noProgressCounter` to `0` and clear the set tracking
@@ -1438,16 +1434,11 @@ function _descendsFrom(younger, older) {
 }
 
 function _hasSufficientEndorsements({
-  x, descendants, electorSet, supermajority,
-  recoverySet, recoverySupermajority
+  x, descendants, electorSet, supermajority
 }) {
   // always count `x` as self-endorsed
   const xCreator = _getCreator(x);
   const endorsements = new Set([xCreator]);
-  const recoveryEndorsements = new Set();
-  if(recoverySet.has(xCreator)) {
-    recoveryEndorsements.add(xCreator);
-  }
   let next = [x];
   //console.log('checking for sufficient endorsements...');
   while(next.length > 0) {
@@ -1459,27 +1450,15 @@ function _hasSufficientEndorsements({
         // `event` is in the computed path of descendants
         for(const e of d) {
           const creator = _getCreator(e);
-          let added = false;
           if(electorSet.has(creator)) {
             endorsements.add(creator);
-            added = true;
             //console.log(
             // 'total', endorsements.size, 'supermajority', supermajority);
             //console.log('electors', electorSet);
             //console.log('endorsements', endorsements);
-          }
-          if(recoverySet.has(creator)) {
-            recoveryEndorsements.add(creator);
-            added = true;
-            //console.log(
-            //  'total recovery endorsements',
-            //  recoveryEndorsements.size, 'supermajority', supermajority);
-            //console.log('recoveryElectors', recoveryElectorSet);
-            //console.log('recoveryEndorsements', recoveryEndorsements);
-          }
-          if(added && endorsements.size >= supermajority &&
-            recoveryEndorsements.size >= recoverySupermajority) {
-            return true;
+            if(endorsements.size >= supermajority) {
+              return true;
+            }
           }
         }
         next.push(...d);
@@ -1658,9 +1637,9 @@ function _computeRecovery({
      endorsed.
   */
   const {_recovery: recovery} = event;
-  if(event._endorsesRecovery) {
+  if(event._endorses) {
     // endorse point reached
-    event._endorsesRecovery.forEach(e => e._recoveryEndorsed = true);
+    event._endorses.forEach(e => e._endorsed = true);
   }
 
   /*
@@ -1684,7 +1663,7 @@ function _computeRecovery({
         continue;
       }
       const {proposal} = ancestorEvent._recovery;
-      if(proposal && proposal._recoveryEndorsed) {
+      if(proposal && proposal._endorsed) {
         endorsedRecoveryProposals++;
         if(endorsedRecoveryProposals >= rPlusOne) {
           // enter recovery mode
@@ -1708,7 +1687,7 @@ function _computeRecovery({
   const recoverySupermajority = api.supermajority(recoveryElectors.length);
   if(!recovery.proposal && meetThreshold >= recoverySupermajority) {
     recovery.proposal = event;
-    _computeRecoveryEndorser({
+    _computeEndorser({
       ledgerNodeId, event, recoveryElectors, recoverySupermajority
     });
   }
@@ -1744,12 +1723,15 @@ function _computeSupport({
     2. Otherwise, if >= f+1 support something other than the proposal and
        each of those sets is a larger set and has been endorsed, reject.
     3. If >= f+1 endorsed proposals, decide.
+       The requirement of `f+1` endorsed proposals ensures that the system
+       cannot fork into two different decisions.
        CAVEAT: If `recoveryElectors.length > 0`, then a decision can only be
        made when `r+1` (where `r` is the acceptable number of failed recovery
-       electors) of the `r+1` endorsed proposals came from recovery electors.
-       If this caveat applies but is not met, simply continue on until some
-       future event satisfies the requirements or, alternatively, recovery
-       mode (i.e., a new set of electors must be chosen) is entered.
+       electors) of the `f+1` endorsed proposals came from recovery electors.
+       This ensures that the system cannot fork into both a decision and into
+       recovery mode. If this caveat applies but is not met, simply continue on
+       until some future event satisfies the requirements or, alternatively,
+       recovery mode (i.e., a new set of electors must be chosen) is entered.
 
   Creating a new proposal:
 
@@ -1961,23 +1943,15 @@ function _computeSupport({
 
   if(event._endorses) {
     // endorse point reached
+    const notEndorsedBefore = proposal && !proposal._endorsed;
     event._endorses.forEach(e => e._endorsed = true);
-  }
-
-  // endorse points for proposals *may* be different from simple endorsement
-  // when recovery electors have been specified because an endorsed proposal
-  // must have been endorsed by not only `2f+1` electors but also `2r+1`
-  // recovery electors
-  if(event._endorsesProposal) {
-    // endorse point reached
-    if(proposal && !proposal._endorsedProposal &&
-      event._endorsesProposal.includes(proposal)) {
+    // if proposal is now endorsed, ensure counts are updated
+    if(notEndorsedBefore && proposal._endorsed) {
       nextChoice.endorsedProposalCount++;
       if(recoverySet.has(creator)) {
         nextChoice.recoveryElectorEndorsedProposalCount++;
       }
     }
-    event._endorsesProposal.forEach(e => e._endorsedProposal = true);
   }
 
   /*console.log('SUPPORT at ', event.eventHash, 'IS FOR',
@@ -2005,7 +1979,7 @@ function _computeSupport({
     // no proposal yet, use current event
     proposal = event;
     // compute endorser for proposal
-    _computeProposalEndorser({
+    _computeEndorser({
       ledgerNodeId, event, electors, supermajority,
       recoveryElectors, recoverySupermajority
     });
@@ -2020,8 +1994,11 @@ function _computeSupport({
   if(!event._lastSwitch) {
     event._lastSwitch = event._treeParent._lastSwitch;
   } else {
-    // compute endorser for event (if not already computed)
-    _computeEndorser({ledgerNodeId, event, electors, supermajority});
+    // compute switch endorser for event (if not already computed)
+    _computeEndorser({
+      ledgerNodeId, event, electors, supermajority,
+      recoveryElectors, recoverySupermajority
+    });
   }
 
   // support next choice
@@ -2032,8 +2009,8 @@ function _computeSupport({
 
 function _hasEndorsedProposal(event) {
   const proposal = event._proposal;
-  if(proposal && proposal._endorsedProposal) {
-    for(const endorser of proposal._proposalEndorser) {
+  if(proposal && proposal._endorsed) {
+    for(const endorser of proposal._endorser) {
       if(event._generation >= endorser._generation) {
         return true;
       }
@@ -2071,68 +2048,25 @@ function _compareEventHashes(r1, r2) {
   return r1.eventHash === r2.eventHash;
 }
 
-function _computeEndorser({ledgerNodeId, event, electors, supermajority}) {
-  return _computeEndorserType({
-    ledgerNodeId, event, electors, supermajority,
-    endorserKey: '_endorser', endorsesKey: '_endorses'
-  });
-}
-
-function _computeProposalEndorser({
+function _computeEndorser({
   ledgerNodeId, event, electors, supermajority,
-  recoveryElectors, recoverySupermajority
+  recoveryElectors = [], recoverySupermajority = 0
 }) {
-  // TODO: optimization - if `event.lastSwitch === event`, then `_endorser`
-  // will not have been set yet and if `_computeEndorserType` were updated to
-  // return *both* the endorse point using only decision electors (`electors`)
-  // *and* the endorse point that *also* includes recovery electors, then
-  // we could avoid having to walk the event's descendants multiple times
-  _computeEndorserType({
-    ledgerNodeId, event, electors, supermajority,
-    recoveryElectors, recoverySupermajority,
-    endorserKey: '_proposalEndorser', endorsesKey: '_endorsesProposal'
-  });
-
-  // optimization: if `recoveryElectors` is zero length and `event` is also the
-  // `lastSwitch`, then reuse the `_proposalEndorser` to create `_endorser`
-  if(recoveryElectors.length === 0 && event._proposalEndorser &&
-    !event._endorser && event._lastSwitch === event) {
-    event._endorser = event._proposalEndorser;
-    for(const endorser of event._endorser) {
-      if(endorser._endorses) {
-        endorser._endorses.push(event);
-      } else {
-        endorser._endorses = [event];
-      }
-    }
-  }
-}
-
-function _computeRecoveryEndorser({
-  ledgerNodeId, event, recoveryElectors, recoverySupermajority
-}) {
-  return _computeEndorserType({
-    ledgerNodeId, event, electors: recoveryElectors,
-    supermajority: recoverySupermajority,
-    endorserKey: '_recoveryEndorser', endorsesKey: '_endorsesRecovery'
-  });
-}
-
-function _computeEndorserType({
-  ledgerNodeId, event, electors, supermajority,
-  recoveryElectors, recoverySupermajority,
-  endorserKey, endorsesKey
-}) {
-  if(event[endorserKey]) {
+  if(event._endorser) {
     // already computed
     return;
+  }
+
+  // if recovery mode is enabled, use recovery electors for endorsement
+  if(recoveryElectors.length > 0) {
+    electors = recoveryElectors;
+    supermajority = recoverySupermajority;
   }
 
   // compute endorser
   const ancestryMap = event._index.ancestryMap || _buildAncestryMap(event);
   const endorsement = _findEndorsementMergeEvent({
     ledgerNodeId, x: event, electors, supermajority,
-    recoveryElectors, recoverySupermajority,
     descendants: {}, ancestryMap});
   if(endorsement) {
     // `endorsement` will be an array as byzantine nodes may fork, but
@@ -2140,17 +2074,17 @@ function _computeEndorserType({
     // event will be detected by at least one properly functioning node
     const allEndorsers = [];
     for(const {mergeEvent: endorser} of endorsement) {
-      if(endorser[endorsesKey]) {
-        endorser[endorsesKey].push(event);
+      if(endorser._endorses) {
+        endorser._endorses.push(event);
       } else {
-        endorser[endorsesKey] = [event];
+        endorser._endorses = [event];
       }
       /*console.log(
         'created endorse point for', event._generation,
         'at', endorser._generation);*/
       allEndorsers.push(endorser);
     }
-    event[endorserKey] = allEndorsers;
+    event._endorser = allEndorsers;
   }
 }
 

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -1621,10 +1621,10 @@ function _computeRecovery({
      endorsed.
   2. If >= `r+1` endorsed recovery proposals, enter recovery mode.
   3. Otherwise, if no recovery proposal on `event` and >= `2r+1` recovery
-     electors have `noProgressCounter` >= `recoveryGenerationThreshold` (or
-     they already have a recovery proposal) and no decision proposal exists
-     on event's branch, then create a recovery proposal and compute its future
-     endorse point.
+     electors have no decision proposal and their
+     `noProgressCounter` >= `recoveryGenerationThreshold` (or they already have
+     a recovery proposal) and no decision proposal exists on event's branch,
+     then create a recovery proposal and compute its future endorse point.
   */
 
   /*
@@ -1666,9 +1666,10 @@ function _computeRecovery({
           throw err;
         }
       }
-      if((ancestorEvent._recovery.noProgressCounter ||
-        ancestorEvent._recovery.prosposal) >=
-        recoveryGenerationThreshold) {
+      if(!ancestorEvent._proposal &&
+        (ancestorEvent._recovery.prosposal ||
+        ancestorEvent._recovery.noProgressCounter >=
+          recoveryGenerationThreshold)) {
         meetThreshold++;
       }
     }
@@ -1676,9 +1677,10 @@ function _computeRecovery({
 
   /*
   3. Otherwise, if no recovery proposal on `event` and >= `2r+1` recovery
-     electors have `noProgressCounter` >= `recoveryGenerationThreshold` and
-     no decision proposal exists on event's branch, then create a recovery
-     proposal and compute its future endorse point.
+     electors have no decision proposal and their
+     `noProgressCounter` >= `recoveryGenerationThreshold` (or they already have
+     a recovery proposal) and no decision proposal exists on event's branch,
+     then create a recovery proposal and compute its future endorse point.
   */
   const recoverySupermajority = api.supermajority(recoveryElectors.length);
   if(!recovery.proposal && meetThreshold >= recoverySupermajority &&

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -2009,12 +2009,10 @@ function _computeSupport({
     const lastSwitch = event._treeParent && event._treeParent._lastSwitch;
     if(lastSwitch && !lastSwitch._switchEndorsed &&
       lastSwitch._switchEndorser) {
-      // reject future endorsement of support as support has changed
-      if(!lastSwitch._switchEndorsed && lastSwitch._switchEndorser) {
-        for(const endorser of lastSwitch._switchEndorser) {
-          endorser._endorsesSwitch = endorser._endorsesSwitch
-            .filter(e => e !== lastSwitch);
-        }
+      // delete future endorse point of support as support has changed
+      for(const endorser of lastSwitch._switchEndorser) {
+        endorser._endorsesSwitch = endorser._endorsesSwitch
+          .filter(e => e !== lastSwitch);
       }
     }
     // set last time switched
@@ -2023,6 +2021,15 @@ function _computeSupport({
     nextChoice.count++;
     if(recoverySet.has(creator)) {
       nextChoice.recoveryElectorCount++;
+    }
+  } else if(event._endorsesSwitch) {
+    // endorse point reached, same support as parent, mark last switch
+    // as endorsed if it has not been removed from endorses list
+    const lastSwitch = event._treeParent._lastSwitch;
+    if(!lastSwitch._switchEndorsed &&
+      event._endorsesSwitch.includes(lastSwitch)) {
+      lastSwitch._switchEndorsed = true;
+      nextChoice.endorsedCount++;
     }
   }
 
@@ -2045,34 +2052,20 @@ function _computeSupport({
     }
 
     if(reject) {
-      // reject future endorsement of proposal
-      if(!proposal._proposalEndorsed && proposal._proposalEndorser) {
-        for(const endorser of proposal._proposalEndorser) {
-          endorser._endorsesProposal = endorser._endorsesProposal
-            .filter(e => e !== proposal);
-        }
-      }
       proposal = null;
     }
   }
 
-  if(event._endorsesProposal) {
-    // endorse point reached...
+  if(event._endorsesProposal && proposal && !proposal._proposalEndorsed) {
+    // proposal endorse point reached...
 
-    // FIXME: above code path might remove need for this message
-    /* Note: `proposal` might be marked as endorsed even though we rejected it
-    because a reference to it could be in `event._endorsesProposal`; but the
-    `notRejectedAndNotEndorsedBefore` flag prevents us from counting it if
-    it was rejected. The proposal will never be counted again after this if
-    it was rejected because it will not be attached to the current `event`
-    and therefore will not be seen on the branch at any point at or beyond its
-    endorser. */
-    const notRejectedAndNotEndorsedBefore =
-      proposal && !proposal._proposalEndorsed;
-    event._endorsesProposal.forEach(e => e._proposalEndorsed = true);
-    // if proposal existed and was not endorsed before but now is
-    // endorsed, ensure counts are updated...
-    if(notRejectedAndNotEndorsedBefore && proposal._proposalEndorsed) {
+    /* Note: Only mark proposal endorsed if it matches. This prevents
+    having to remove the proposal if it was rejected and allows for debugging
+    to see that a proposal was not marked endorsed at its endorse point
+    because it was rejected. */
+    if(event._endorsesProposal.includes(proposal)) {
+      proposal._proposalEndorsed = true;
+      // ensure counts are updated...
       nextChoice.endorsedProposalCount++;
       if(recoverySet.has(creator)) {
         nextChoice.recoveryElectorEndorsedProposalCount++;
@@ -2093,17 +2086,17 @@ function _computeSupport({
     return nextChoice.set;
   }
 
-  // compute if the next choice has a supermajority (and if in recovery mode,
-  // require a recovery supermajority as well)
+  /*
+  If the next choice has a supermajority and has no existing (unrejected)
+  proposal, create a new one. CAVEAT: If `recoveryElectors > 0` and
+  event has a recovery proposal in its ancestry, do not create proposal;
+  also require a supermajority of recovery electors to support as well.
+  Note: This proposal will be immediately rejected when recovery rules are
+  applied if an endorsed recovery proposal is in the system.
+  */
   const hasSupermajority = (nextChoice.count >= supermajority &&
     (recoveryElectors.length === 0 ||
       nextChoice.recoveryElectorCount >= recoverySupermajority));
-  // If the next choice has a supermajority and has no existing (unrejected)
-  // proposal, so create a new one. CAVEAT: If `recoveryElectors > 0` and
-  // event has a recovery proposal in its ancestry, do not create proposal;
-  // also require a supermajority of recovery electors to support as well.
-  // Note: This proposal will be immediately rejected when recovery rules are
-  // applied if an endorsed recovery proposal is in the system.
   if(hasSupermajority && !proposal &&
     !(event._recovery && event._recovery.proposal)) {
     // no proposal yet, use current event
@@ -2122,24 +2115,10 @@ function _computeSupport({
   // propagate node's last switch
   if(!event._lastSwitch) {
     event._lastSwitch = event._treeParent._lastSwitch;
-    if(event._endorsesSwitch) {
-      // endorse point reached, same support as parent
-
-      /* Note: Safe to mark the switch endorsed at the end of this function
-      because it is only used in the tally when comparing against *other* sets
-      that do not match this event's support. Furthermore, if the event's
-      tree parent had different support, than the support would not be endorsed
-      by this event, so that potential "other set" could not be endorsed
-      in that comparison. */
-      const endorsedBefore = event._lastSwitch._switchEndorsed;
-      event._endorsesSwitch.forEach(e => e._switchEndorsed = true);
-      if(!endorsedBefore && event._lastSwitch.switchEndorsed) {
-        console.log('endorsed switch!');
-      }
-    }
   } else {
+    // must have just switched, so compute endorser
     _computeSwitchEndorser({
-      ledgerNodeId, event, electors, supermajority
+      ledgerNodeId, event, electors, supermajority, recoveryElectors
     });
   }
 
@@ -2203,22 +2182,24 @@ function _compareEventHashes(r1, r2) {
 }
 
 function _computeSwitchEndorser({
-  ledgerNodeId, event, electors, supermajority
+  ledgerNodeId, event, electors, supermajority, recoveryElectors
 }) {
   return _computeEndorser({
     ledgerNodeId, event, electors, supermajority,
-    endorserKey: '_switchEndorser', endorsesKey: '_endorsesSwitch'
+    endorserKey: '_switchEndorser', endorsesKey: '_endorsesSwitch',
+    shareEndorser: recoveryElectors.length === 0
   });
 }
 
 function _computeProposalEndorser({
   ledgerNodeId, event, electors, supermajority,
-  recoveryElectors = [], recoverySupermajority = 0
+  recoveryElectors, recoverySupermajority
 }) {
   return _computeEndorser({
     ledgerNodeId, event, electors, supermajority,
     recoveryElectors, recoverySupermajority,
-    endorserKey: '_proposalEndorser', endorsesKey: '_endorsesProposal'
+    endorserKey: '_proposalEndorser', endorsesKey: '_endorsesProposal',
+    shareEndorser: recoveryElectors.length === 0
   });
 }
 
@@ -2228,36 +2209,46 @@ function _computeRecoveryEndorser({
   return _computeEndorser({
     ledgerNodeId, event,
     electors: recoveryElectors, supermajority: recoverySupermajority,
-    endorserKey: '_recoveryEndorser', endorsesKey: '_endorsesRecovery'
+    endorserKey: '_recoveryEndorser', endorsesKey: '_endorsesRecovery',
+    shareEndorser: false
   });
 }
 
 function _computeEndorser({
   ledgerNodeId, event, electors, supermajority,
   recoveryElectors = [], recoverySupermajority = 0,
-  endorserKey, endorsesKey
+  endorserKey, endorsesKey, shareEndorser
 }) {
-  if(event[endorserKey]) {
+  if(event[endorserKey] !== undefined) {
     // already computed
     return;
   }
 
-  // if recovery mode is enabled, use recovery electors for endorsement
-  if(recoveryElectors.length > 0) {
-    electors = recoveryElectors;
-    supermajority = recoverySupermajority;
+  let endorsement;
+  if(shareEndorser && event._endorser !== undefined) {
+    // `._endorser` keeps track of previously computed endorse points
+    // (an optimization that is possible for non-recovery mode since
+    // endorsement requirements are the same for switches and proposals)
+    // ... if `event._endorser` is an array, reproduce `endorsement` to
+    // match spec below, otherwise, leave endorsement as undefined because
+    // we've previously detected there aren't any endorse points in the DAG
+    if(event._endorser !== false) {
+      // generate `endorsement` to match spec below
+      endorsement = event._endorser.map(e => ({mergeEvent: e}));
+    }
+  } else {
+    // endorser must be computed
+    const ancestryMap = event._index.ancestryMap || _buildAncestryMap(event);
+    endorsement = _findEndorsementMergeEvent({
+      ledgerNodeId, x: event, electors, supermajority,
+      recoveryElectors, recoverySupermajority,
+      descendants: {}, ancestryMap});
   }
 
-  // compute endorser
-  const ancestryMap = event._index.ancestryMap || _buildAncestryMap(event);
-  const endorsement = _findEndorsementMergeEvent({
-    ledgerNodeId, x: event, electors, supermajority,
-    recoveryElectors, recoverySupermajority,
-    descendants: {}, ancestryMap});
   if(endorsement) {
-    // `endorsement` will be an array as byzantine nodes may fork, but
-    // the endorse point(s) will fail in a fork scenario because the fork
-    // event will be detected by at least one properly functioning node
+    // `endorsement` will be an array as byzantine nodes may fork, but forks
+    // will get detected via endorse point(s) due to overlap of at least
+    // one functioning node
     const allEndorsers = [];
     for(const {mergeEvent: endorser} of endorsement) {
       if(endorser[endorsesKey]) {
@@ -2271,6 +2262,18 @@ function _computeEndorser({
       allEndorsers.push(endorser);
     }
     event[endorserKey] = allEndorsers;
+  } else {
+    // no endorser in DAG
+    event[endorserKey] = false;
+  }
+
+  // if sharing endorser is enabled, copy to `._endorser` for optimized reuse
+  if(shareEndorser && event._endorser === undefined) {
+    if(event[endorserKey]) {
+      event._endorser = event[endorserKey].slice();
+    } else {
+      event._endorser = false;
+    }
   }
 }
 

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -1649,17 +1649,19 @@ function _computeSupport({
     1. If >= f+1 *endorsed* proposals, support the largest.
     2. Otherwise, union support.
 
+  Deciding:
+    1. If >= f+1 endorsed proposals, decide.
+       CAVEAT: If `recoveryElectors.length > 0`, then a decision can only be
+       made when `recoveryDecisionThreshold` decision events, each created by
+       a recovery elector that does not have a pending "recovery mode proposal"
+       have been found. If this caveat applies but is not met, simply continue
+       on until some future event satisfies the requirements or, alternatively,
+       recovery mode is entered.
+
   Rejecting proposals/Deciding:
     1. If support is not for the proposal, reject.
     2. Otherwise, if >= f+1 support something other than the proposal and
        each of those sets is a larger set and has been endorsed, reject.
-    3. If not rejected, see if >= f+1 endorsed proposals for the same thing
-       we support, decide. CAVEAT: If `recoveryElectors.length > 0`, then
-       a decision can only be made when `recoveryDecisionThreshold` decision
-       events, each created by a recovery elector that does not have a pending
-       "recovery mode proposal" have been found. If this caveat applies but is
-       not met, simply continue on until some future event satisfies the
-       requirements or, alternatively, recovery mode is entered.
 
   Creating a new proposal:
 
@@ -1878,6 +1880,22 @@ function _computeSupport({
     nextChoice.set.map(r=>r._generation));*/
 
   /*
+  If at least `f+1` of endorsed proposals support the same set, then consensus
+  has been reached. Otherwise, continue on and hope the next event will decide...
+  */
+  if(nextChoice.endorsedProposalCount >= (f + 1)) {
+    // TODO: can we optimize such that once `_decision` is set ... skip all
+    // the tallying and just check `_consensusReached` at the top of the
+    // function? ...what else needs to be propagated for this to work?
+    const consensusReached = _consensusReached({
+      event, recoveryElectors, recoveryDecisionThreshold, nextChoice});
+    if(consensusReached) {
+      // consensus reached
+      return nextChoice.set;
+    }
+  }
+
+  /*
   If you have an existing proposal, check rejection/decision.
   */
   if(proposal) {
@@ -1897,23 +1915,6 @@ function _computeSupport({
 
     if(reject) {
       proposal = null;
-    }
-  }
-
-  /*
-  If existing proposal intact and at least `f+1` of endorsed proposals
-  support the same set, then consensus has been reached. Otherwise, continue
-  on and hope the next event will decide...
-  */
-  if(proposal && nextChoice.endorsedProposalCount >= (f + 1)) {
-    // TODO: can we optimize such that once `_decision` is set ... skip all
-    // the tallying and just check `_consensusReached` at the top of the
-    // function? ...what else needs to be propagated for this to work?
-    const consensusReached = _consensusReached({
-      event, recoveryElectors, recoveryDecisionThreshold, nextChoice});
-    if(consensusReached) {
-      // consensus reached
-      return nextChoice.set;
     }
   }
 

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -1771,17 +1771,8 @@ function _computeSupport({
     proposal = event._treeParent._proposal;
   }
 
-  // sort tally results by proposal count (if there is an existing proposal)
-  // or by *endorsed* proposal count (if no existing proposal), breaking
-  // sort ties using set size
-  const countType = proposal ? 'proposalCount' : 'endorsedProposalCount';
-  tally.sort((a, b) => {
-    const diff = b[countType] - a[countType];
-    if(diff !== 0) {
-      return diff;
-    }
-    return b.set.length - a.set.length;
-  });
+  // sort tally results by set size
+  tally.sort((a, b) => b.set.length - a.set.length);
 
   /* Choose support when there's an existing proposal:
     1. If >= f+1 *other* smaller proposals (endorsed or not), support the
@@ -1794,18 +1785,16 @@ function _computeSupport({
     // happen such that proposal sizes are unique (any proposed set of size
     // N will have the same elements as any other proposed set of size N, so
     // it is safe to compare set length only here)
-    const total = tally
-      .filter(tallyResult =>
-        tallyResult.proposalCount > 0 &&
-        tallyResult.set.length < proposal._supporting.length)
-      .reduce((aggregator, tallyResult) => {
-        return aggregator + tallyResult.proposalCount;
-      }, 0);
+    const otherProposals = tally
+      .filter(result =>
+        result.proposalCount > 0 &&
+        result.set.length < proposal._supporting.length);
+    const total = otherProposals.reduce(
+      (aggregator, result) => aggregator + result.proposalCount, 0);
     if(total >= (f + 1)) {
-      nextChoice = tally[0];
-    }
-
-    if(!nextChoice) {
+      // support the largest of the other sets (which has been sorted to first)
+      nextChoice = otherProposals[0];
+    } else {
       // TODO: optimize to find largest endorsed proposal faster
       const union = _findUnionProposalSet(event, proposal);
       nextChoice = _.find(tally, _findSetInTally(union));
@@ -1816,14 +1805,12 @@ function _computeSupport({
       2. Otherwise, union support.
     */
     // determine if there are f+1 proposals (endorsed or not)
-    const total = tally.reduce((aggregator, tallyResult) => {
-      return aggregator + tallyResult.proposalCount;
-    }, 0);
+    const proposals = tally.filter(result => result.proposalCount > 0);
+    const total = proposals.reduce(
+      (aggregator, result) => aggregator + result.proposalCount, 0);
     if(total >= (f + 1)) {
-      nextChoice = tally[0];
-    }
-
-    if(!nextChoice) {
+      nextChoice = proposals[0];
+    } else {
       // compute the union of all support
       const union = _.uniq([].concat(
         ..._.values(event._votes)

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -485,8 +485,7 @@ function _findMergeEventProof({
     return {consensus: []};
   }
 
-  const {xByElector} = candidates;
-  let {yByElector} = candidates;
+  const {xByElector, yByElector} = candidates;
 
   // if recovery mode can't be entered, skip tracking it... we will still
   // ensure that decisions can only be made with the appropriate recovery
@@ -505,7 +504,7 @@ function _findMergeEventProof({
 
   // determine if a decision can even possibly be made yet...
 
-  // at least `12f+6` total merge events must have passed in order for a
+  // at least `11f+7` total merge events must have passed in order for a
   // decision to be made
   const f = api.maximumFailures(electors.length);
   const minMergeEvents = (electors.length === 1) ? 1 : (11 * f + 7);
@@ -531,26 +530,16 @@ function _findMergeEventProof({
   const supermajority = api.supermajority(electors.length);
   const recoverySupermajority = api.supermajority(recoveryElectors.length);
   const canDecide = (
+    // FIXME: recoveryGenerationThreshold *must* be larger than minMergeEvents
+    // ...throw an error above if this is not true
     totalMergeEvents >= minMergeEvents &&
     voters.length >= supermajority &&
     (recoveryElectors.length === 0 ||
       possibleRecoveryDeciders >= recoverySupermajority));
-  if(!canDecide) {
-    // only return early if entering recovery mode is also not possible
-    if(!canEnterRecoveryMode) {
-      return {consensus: []};
-    }
 
-    // clear `yByElector` as there is no point in calculating votes ...
-    // as it is known that there were insufficient participants to produce
-    // a decision ... thus we proceed by only checking for recovery mode
-    for(const elector in yByElector) {
-      const mergeEvents = yByElector[elector];
-      for(const mergeEvent of mergeEvents) {
-        delete mergeEvent._x;
-      }
-    }
-    yByElector = {};
+  // only return early if can't decide OR recover
+  if(!(canDecide || canEnterRecoveryMode)) {
+    return {consensus: []};
   }
 
   //startTime = Date.now();
@@ -847,7 +836,8 @@ function _findEndorsementMergeEvent({
       //console.log('total descendants so far', ancestors.map(r=>({
       //  creator: _getCreator(r),
       //  generation: r._generation,
-      //  hash: r.eventHash
+      //  hash: r.eventHash,
+      //  children: r._treeChildren && r._treeChildren.length
       //})));
       //console.log();
 
@@ -1255,8 +1245,8 @@ function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
      last time the set tracking decision elector participation was reset,
      then reset the `noProgressCounter` to `0` and clear the set tracking
      participating decision electors.
-  5. Update last electors seen and clear the set tracking participating
-     recovery electors.
+  5. Otherwise, update last electors seen.
+  6. Clear the set tracking participating recovery electors.
 
   */
 
@@ -1368,13 +1358,16 @@ function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
     event._recovery.noProgressCounter = 0;
     event._recovery.lastElectorsSeen = 0;
     electorsSeen.clear();
+  } else {
+    /*
+    5. Otherwise, update last electors seen.
+    */
+    event._recovery.lastElectorsSeen = electorsSeen.size;
   }
 
   /*
-  5. Update last electors seen and clear the set tracking participating
-     recovery electors.
+  6. Clear the set tracking participating recovery electors.
   */
-  event._recovery.lastElectorsSeen = electorsSeen.size;
   recoveryElectorsSeen.clear();
 }
 
@@ -1630,8 +1623,9 @@ function _computeRecovery({
      endorsed.
   2. If >= `r+1` endorsed recovery proposals, enter recovery mode.
   3. Otherwise, if no recovery proposal on `event` and >= `2r+1` recovery
-     electors have `noProgressCounter` >= `recoveryGenerationThreshold`, then
-     create a recovery proposal and compute its future endorse point.
+     electors have `noProgressCounter` >= `recoveryGenerationThreshold` (or
+     they already have a recovery proposal), then create a recovery proposal
+     and compute its future endorse point.
   */
 
   /*
@@ -1664,8 +1658,7 @@ function _computeRecovery({
         // byzantine node detected, skip
         continue;
       }
-      const {proposal} = ancestorEvent._recovery;
-      if(proposal && proposal._endorsed) {
+      if(_hasEndorsedRecoveryProposal(ancestorEvent)) {
         endorsedRecoveryProposals++;
         if(endorsedRecoveryProposals >= rPlusOne) {
           // enter recovery mode
@@ -1674,7 +1667,8 @@ function _computeRecovery({
           throw err;
         }
       }
-      if(ancestorEvent._recovery.noProgressCounter >=
+      if((ancestorEvent._recovery.noProgressCounter ||
+        ancestorEvent._recovery.prosposal) >=
         recoveryGenerationThreshold) {
         meetThreshold++;
       }
@@ -2025,6 +2019,18 @@ function _hasEndorsedSwitch(event) {
   const lastSwitch = event._lastSwitch;
   if(lastSwitch && lastSwitch._endorsed) {
     for(const endorser of lastSwitch._endorser) {
+      if(event._generation >= endorser._generation) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+function _hasEndorsedRecoveryProposal(event) {
+  const proposal = event._recovery && event._recovery.proposal;
+  if(proposal && proposal._endorsed) {
+    for(const endorser of proposal._endorser) {
       if(event._generation >= endorser._generation) {
         return true;
       }

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -692,7 +692,9 @@ function _findMergeEventProofCandidates({
           noProgressCounter: 0,
           electorsSeen: new Set(),
           recoveryElectorsSeen: new Set(),
-          lastElectorsSeen: 0
+          lastElectorsSeen: 0,
+          mraDecisionProposals: 0,
+          mraRecoveryProposals: 0
         };
       }
     }
@@ -1242,7 +1244,9 @@ function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
      tracking their participation. A "decision elector" must be participating
      in voting, non-byzantine, and if it is also a recovery elector, it must
      not have a recovery proposal in order to be counted as making progress
-     towards a decision.
+     towards a decision. Note that any recovery proposals on the event's
+     most recent ancestors will also be tallied for later use when deciding
+     whether to reject a decision proposal in `_computeSupport`.
   2. If < `2r+1` recovery electors have participated since the last recovery
      check, then return because the next recovery check hasn't been reached.
      Otherwise, >= `2r+1` recovery electors have participated, so run a new
@@ -1263,6 +1267,9 @@ function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
      electors that participated since the event's `treeParent`.
   */
 
+  // track total recovery proposals from most recent ancestors
+  let mraRecoveryProposals = 0;
+
   // find newly seen electors since `event._treeParent`
   let newEvents;
   if(event._treeParent) {
@@ -1279,6 +1286,9 @@ function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
       if(ancestorEvent !== parentAncestorEvent) {
         // event came after tree parent
         newEvents.push(ancestorEvent);
+      } else if(ancestorEvent && ancestorEvent._recovery &&
+        ancestorEvent._recovery.proposal) {
+        mraRecoveryProposals++;
       }
     }
   } else {
@@ -1307,6 +1317,7 @@ function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
       // do not count any decision elector that has proposed recovery as
       // progress toward a decision (continue early so it won't get counted)
       if(newEvent._recovery.proposal) {
+        mraRecoveryProposals++;
         continue;
       }
     }
@@ -1344,6 +1355,9 @@ function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
       creatorY = creatorY._treeParent;
     }
   }
+
+  // store most recent ancestor recovery proposals for later use
+  event._recovery.mraRecoveryProposals = mraRecoveryProposals;
 
   /*
   2. If < `2r+1` recovery electors have participated since the last recovery
@@ -1573,6 +1587,8 @@ function _tallyBranches({
             ...event._treeParent._recovery,
             electorsSeen: new Set(electorsSeen),
             recoveryElectorsSeen: new Set(recoveryElectorsSeen),
+            mraDecisionProposals: 0,
+            mraRecoveryProposals: 0,
             computed: false
           };
           if(!event._recovery.skip) {
@@ -1643,46 +1659,41 @@ function _computeRecovery({
 
   /* Rules:
 
-  1. If a recovery proposal endorse point has been reached, mark its event as
-     endorsed.
-  2. Iterate over all most recent ancestor events from recovery electors and
+  1. Iterate over most recent ancestor events from all electors and
      tally decision proposals, endorsed recovery proposals, and "met no
-     progress threshold" from most recent ancestors, using the event's tree
-     parent (not itself) when processing its branch. The count for "met no
-     progress threshold" is incremented when an event has a recovery proposal
-     or its `noProgressCounter` is greater than or equal to the
+     progress threshold" from most recent ancestors, using the event when
+     processing its own branch (instead of its tree parent). The count for
+     "met no progress threshold" is incremented when an event has a recovery
+     proposal or its `noProgressCounter` is greater than or equal to the
      `recoveryGenerationThreshold`.
-  3. If >= `2r+1` endorsed recovery proposals, enter recovery mode.
-  4. Otherwise, if event's branch has a decision proposal and >= r+1 endorsed
-     recovery proposals exist, reject the decision proposal.
-  5. If the event's branch has no recovery proposal and no decision proposal
-     and the "met no progress threshold" tally is >= `2r+1` and there are
-     < `f+1` decision proposals (endorsed or not, same or different from one
-     another), then create a recovery proposal on the event and compute its
+  2. If event's branch has an existing recovery proposal decide if it should
+     be rejected. Reject it if either the "met no progress threshold" is
+     < `2r+1` or if the tallied decision proposals is larger than event's tree
+     parent's tally. Adjust the endorsed recovery proposal count if necessary.
+  3. Store tallied decision proposals for future comparisons.
+  4. If a recovery proposal endorse point has been reached; mark any matching
+     recovery proposal as endorsed. Adjust the endorsed recovery proposal
+     count if necessary.
+  5. If >= `r+1` endorsed recovery proposals, enter recovery mode.
+  6. Otherwise, if the event's branch has no recovery proposal and no decision
+     proposal and the "met no progress threshold" tally is >= `2r+1` and there
+     are < `f+1` decision proposals (endorsed or not, same or different from
+     one another), then create a recovery proposal on the event and compute its
      future endorse point.
   */
 
-  /*
-  1. If a recovery proposal endorse point has been reached, mark its event as
-     endorsed.
-  */
-  const {_recovery: recovery} = event;
-  if(event._endorsesRecovery) {
-    // endorse point reached
-    // Note: recovery proposals can't be rejected (either a decision is made
-    // or recovery mode is entered once a recovery proposal is created) so
-    // we don't have to be concerned about erroneously marking recovery
-    // proposals as endorsed
-    event._endorsesRecovery.forEach(e => e._recoveryEndorsed = true);
-  }
+  /* Note: There is no need to update `event._recovery.mraRecoveryProposals`
+  if recovery proposals are created or rejected because that state variable
+  is only consumed during `computeSupport` which has already run for this
+  event. Leaving it as-is is more useful for debugging purposes. */
 
   /*
-  2. Iterate over all most recent ancestor events from recovery electors and
+  1. Iterate over most recent ancestor events from all electors and
      tally decision proposals, endorsed recovery proposals, and "met no
-     progress threshold" from most recent ancestors, using the event's tree
-     parent (not itself) when processing its branch. The count for "met no
-     progress threshold" is incremented when an event has a recovery proposal
-     or its `noProgressCounter` is greater than or equal to the
+     progress threshold" from most recent ancestors, using the event when
+     processing its own branch (instead of its tree parent). The count for
+     "met no progress threshold" is incremented when an event has a recovery
+     proposal or its `noProgressCounter` is greater than or equal to the
      `recoveryGenerationThreshold`.
   */
   let decisionProposals = 0;
@@ -1690,19 +1701,23 @@ function _computeRecovery({
   let meetThreshold = 0;
   const recoverySet = new Set(recoveryElectors.map(e => e.id));
   const creator = _getCreator(event);
-  const {mostRecentAncestors} = event._index;
-  for(const recoveryElector in mostRecentAncestors) {
-    const ancestorEvent = mostRecentAncestors[recoveryElector];
+  const mostRecentAncestors = {
+    ...event._index.mostRecentAncestors,
+    [creator]: event
+  };
+  for(const elector in mostRecentAncestors) {
+    const ancestorEvent = mostRecentAncestors[elector];
     if(!ancestorEvent) {
       // byzantine node detected, skip
       continue;
     }
-    if(!recoverySet.has(recoveryElector)) {
-      // ancestor is not a recovery elector
-      continue;
-    }
+    // always count decision proposals, regardless of recovery elector status
     if(ancestorEvent._proposal) {
       decisionProposals++;
+    }
+    if(!recoverySet.has(elector)) {
+      // ancestor is not a recovery elector
+      continue;
     }
     if(_hasEndorsedRecoveryProposal(ancestorEvent)) {
       endorsedRecoveryProposals++;
@@ -1715,10 +1730,46 @@ function _computeRecovery({
   }
 
   /*
-  3. If >= `2r+1` endorsed recovery proposals, enter recovery mode.
+  2. If event's branch has an existing recovery proposal decide if it should
+     be rejected. Reject it if either the "met no progress threshold" is
+     < `2r+1` or if the tallied decision proposals is larger than event's tree
+     parent's tally.
   */
+  const {_recovery: recovery} = event;
   const recoverySupermajority = api.supermajority(recoveryElectors.length);
-  if(endorsedRecoveryProposals >= recoverySupermajority) {
+  if(recovery.proposal &&
+    ((meetThreshold < recoverySupermajority) ||
+    (event._treeParent && event._treeParent._recovery &&
+      decisionProposals > event._treeParent._recovery.mraDecisionProposals))) {
+    // reject recovery proposal, adjusting counts as needed
+    if(_hasEndorsedRecoveryProposal(event)) {
+      endorsedRecoveryProposals--;
+    }
+    delete recovery.proposal;
+  }
+
+  /*
+  3. Store tallied decision proposals for future comparisons.
+  */
+  event._recovery.mraDecisionProposals = decisionProposals;
+
+  /*
+  4. If a recovery proposal endorse point has been reached; mark any matching
+     recovery proposal as endorsed.
+  */
+  if(event._endorsesRecovery && recovery.proposal) {
+    // endorse point reached... only mark endorsed if it matches
+    if(event._endorsesRecovery.includes(recovery.proposal)) {
+      recovery.proposal._recoveryEndorsed = true;
+      endorsedRecoveryProposals++;
+    }
+  }
+
+  /*
+  5. If >= `r+1` endorsed recovery proposals, enter recovery mode.
+  */
+  const r = api.maximumFailures(recoveryElectors.length);
+  if(endorsedRecoveryProposals >= (r + 1)) {
     // enter recovery mode
     const err = new Error('New electors required.');
     err.name = 'NewElectorsRequiredError';
@@ -1726,23 +1777,10 @@ function _computeRecovery({
   }
 
   /*
-  4. Otherwise, if event's branch has a decision proposal and >= 1
-     endorsed recovery proposals exist, reject the decision proposal.
-  */
-  if(event._proposal && endorsedRecoveryProposals >= 1) {
-    // reject decision proposal because recovery mode should be entered instead
-
-    // Note: This decision proposal has not been used in any calculations up
-    // to this point unless it was also present on the event's tree parent,
-    // so this is safe to delete without any other corrections needed.
-    delete event._proposal;
-  }
-
-  /*
-  5. If the event's branch has no recovery proposal and no decision proposal
-     and the "met no progress threshold" tally is >= `2r+1` and there are
-     < `f+1` decision proposals (endorsed or not, same or different from one
-     another), then create a recovery proposal on the event and compute its
+  6. Otherwise, if the event's branch has no recovery proposal and no decision
+     proposal and the "met no progress threshold" tally is >= `2r+1` and there
+     are < `f+1` decision proposals (endorsed or not, same or different from
+     one another), then create a recovery proposal on the event and compute its
      future endorse point.
   */
   const f = api.maximumFailures(electors.length);
@@ -1850,36 +1888,44 @@ function _computeSupport({
       // do not count byzantine votes or votes without support (initial Ys)
       return;
     }
-    const tallyResult = _.find(tally, _findSetInTally(e._supporting));
-    const endorsed = _hasEndorsedSwitch(e);
-    const proposal = e._proposal;
-    const endorsedProposal = _hasEndorsedProposal(e);
-    const isRecoveryElector = recoverySet.has(_getCreator(e));
-    if(tallyResult) {
+
+    // do not count result from a branch with an endorsed recovery proposal;
+    // it blocks support because that node favors recovery, not a decision
+    if(_hasEndorsedRecoveryProposal(e)) {
+      return;
+    }
+
+    // find existing result to update that matches support set
+    let tallyResult = _.find(tally, _findSetInTally(e._supporting));
+    if(!tallyResult) {
+      // no matching result found, initialize new result
+      tallyResult = {
+        set: e._supporting,
+        count: 0,
+        endorsedCount: 0,
+        proposalCount: 0,
+        endorsedProposalCount: 0,
+        recoveryElectorCount: 0
+      };
+      tally.push(tallyResult);
+    } else {
       // ensure same instance of set is used for faster comparisons
       e._supporting = tallyResult.set;
-      tallyResult.count++;
-      if(endorsed) {
-        tallyResult.endorsedCount++;
-      }
-      if(proposal) {
-        tallyResult.proposalCount++;
-      }
-      if(endorsedProposal) {
-        tallyResult.endorsedProposalCount++;
-      }
-      if(isRecoveryElector) {
-        tallyResult.recoveryElectorCount++;
-      }
-    } else {
-      tally.push({
-        set: e._supporting,
-        count: 1,
-        endorsedCount: endorsed ? 1 : 0,
-        proposalCount: proposal ? 1 : 0,
-        endorsedProposalCount: endorsedProposal ? 1 : 0,
-        recoveryElectorCount: isRecoveryElector ? 1 : 0
-      });
+    }
+
+    // update counts
+    tallyResult.count++;
+    if(_hasEndorsedSwitch(e)) {
+      tallyResult.endorsedCount++;
+    }
+    if(e._proposal) {
+      tallyResult.proposalCount++;
+    }
+    if(_hasEndorsedProposal(e)) {
+      tallyResult.endorsedProposalCount++;
+    }
+    if(recoverySet.has(_getCreator(e))) {
+      tallyResult.recoveryElectorCount++;
     }
   });
   /*logger.debug('End sync _computeSupport vote tally proper', {
@@ -1988,25 +2034,33 @@ function _computeSupport({
   }
 
   /*
-    Get the previous choice. If the previous choice is different from the new
-    choice, update the next choice count and calculate an endorse point.
+    If the previous supporting is different from the new support, update the
+    next choice count if there is no endorsed recovery proposal on the branch.
+    If the support has not changed, determine if the switch/support is ready
+    to be endorsed (and mark as endorsed if appropriate).
   */
-  const previousChoice = event._votes[creator] ? _.find(
-    tally, _findSetInTally(event._votes[creator]._supporting)) : null;
+  const previousVoteEvent = event._votes[creator];
+  let switched = true;
+  let hasEndorsedRecoveryProposal = false;
+  if(previousVoteEvent) {
+    switched = !(previousVoteEvent._supporting && _compareSupportSet(
+      nextChoice.set, previousVoteEvent._supporting));
+    hasEndorsedRecoveryProposal = _hasEndorsedRecoveryProposal(
+      previousVoteEvent);
+  }
 
-  // check if vote has changed
-  if(previousChoice !== nextChoice) {
+  if(switched) {
     // set last time switched
     // Note: This will cause any `_lastSwitch` on the branch that had a
     // future endorsement to not ever be marked as endorsed because it will not
-    // be brought forward through branch ancestry; i.e., there is no need
-    // to modify `event._treeParent._lastSwitch._electorEndorsement` and
-    // leaving it is useful for debugging purposes
+    // be brought forward through branch ancestry
     event._lastSwitch = event;
-    // increment next choice count
-    nextChoice.count++;
-    if(recoverySet.has(creator)) {
-      nextChoice.recoveryElectorCount++;
+    // increment next choice counts if branch has no endorsed recovery proposal
+    if(!hasEndorsedRecoveryProposal) {
+      nextChoice.count++;
+      if(recoverySet.has(creator)) {
+        nextChoice.recoveryElectorCount++;
+      }
     }
   } else if(event._endorsesSwitch) {
     // endorse point reached, if last switch has been brought forward through
@@ -2015,7 +2069,10 @@ function _computeSupport({
     if(!lastSwitch._switchEndorsed &&
       event._endorsesSwitch.includes(lastSwitch)) {
       lastSwitch._switchEndorsed = true;
-      nextChoice.endorsedCount++;
+      // only update count if branch has no endorsed recovery proposal
+      if(!hasEndorsedRecoveryProposal) {
+        nextChoice.endorsedCount++;
+      }
     }
   }
 
@@ -2037,6 +2094,13 @@ function _computeSupport({
       reject = total >= (f + 1);
     }
 
+    // if recovery mode is enabled, reject proposal if any most recent ancestor
+    // has a recovery proposal
+    if(!reject && event._recovery && event._recovery.proposal &&
+      event._recovery.mraRecoveryProposals > 0) {
+      reject = true;
+    }
+
     if(reject) {
       proposal = null;
     }
@@ -2051,7 +2115,8 @@ function _computeSupport({
     because it was rejected. */
     if(event._endorsesProposal.includes(proposal)) {
       proposal._proposalEndorsed = true;
-      // ensure count is updated
+      // ensure count is updated (note that a decision proposal precludes a
+      // recovery proposal so no need to check for one here before updating
       nextChoice.endorsedProposalCount++;
     }
   }

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -1,7 +1,7 @@
 /*!
  * Web Ledger Continuity2017 consensus election functions.
  *
- * Copyright (c) 2017-2018 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2017-2019 Digital Bazaar, Inc. All rights reserved.
  */
 /* eslint-disable no-unused-vars */
 'use strict';

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -694,7 +694,7 @@ function _findMergeEventProofCandidates({
           recoveryElectorsSeen: new Set(),
           lastElectorsSeen: 0,
           mraDecisionProposals: 0,
-          mraRecoveryProposals: 0
+          mraEndorsedRecoveryProposals: 0
         };
       }
     }
@@ -1244,9 +1244,9 @@ function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
      tracking their participation. A "decision elector" must be participating
      in voting, non-byzantine, and if it is also a recovery elector, it must
      not have a recovery proposal in order to be counted as making progress
-     towards a decision. Note that any recovery proposals on the event's
-     most recent ancestors will also be tallied for later use when deciding
-     whether to reject a decision proposal in `_computeSupport`.
+     towards a decision. Note that any endorsed recovery proposals on the
+     event's most recent ancestors will also be tallied for later use when
+     deciding whether to reject a decision proposal in `_computeSupport`.
   2. If < `2r+1` recovery electors have participated since the last recovery
      check, then return because the next recovery check hasn't been reached.
      Otherwise, >= `2r+1` recovery electors have participated, so run a new
@@ -1267,8 +1267,8 @@ function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
      electors that participated since the event's `treeParent`.
   */
 
-  // track total recovery proposals from most recent ancestors
-  let mraRecoveryProposals = 0;
+  // track total endorsed recovery proposals from most recent ancestors
+  let endorsedRecoveryProposals = 0;
 
   // find newly seen electors since `event._treeParent`
   let newEvents;
@@ -1286,9 +1286,9 @@ function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
       if(ancestorEvent !== parentAncestorEvent) {
         // event came after tree parent
         newEvents.push(ancestorEvent);
-      } else if(ancestorEvent && ancestorEvent._recovery &&
-        ancestorEvent._recovery.proposal) {
-        mraRecoveryProposals++;
+      } else if(ancestorEvent &&
+        _hasEndorsedRecoveryProposal(ancestorEvent)) {
+        endorsedRecoveryProposals++;
       }
     }
   } else {
@@ -1316,8 +1316,8 @@ function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
       recoveryElectorsSeen.add(creator);
       // do not count any decision elector that has proposed recovery as
       // progress toward a decision (continue early so it won't get counted)
-      if(newEvent._recovery.proposal) {
-        mraRecoveryProposals++;
+      if(_hasEndorsedRecoveryProposal(newEvent)) {
+        endorsedRecoveryProposals++;
         continue;
       }
     }
@@ -1356,8 +1356,8 @@ function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
     }
   }
 
-  // store most recent ancestor recovery proposals for later use
-  event._recovery.mraRecoveryProposals = mraRecoveryProposals;
+  // store most recent ancestor endorsed recovery proposals for later use
+  event._recovery.mraEndorsedRecoveryProposals = endorsedRecoveryProposals;
 
   /*
   2. If < `2r+1` recovery electors have participated since the last recovery
@@ -1588,7 +1588,7 @@ function _tallyBranches({
             electorsSeen: new Set(electorsSeen),
             recoveryElectorsSeen: new Set(recoveryElectorsSeen),
             mraDecisionProposals: 0,
-            mraRecoveryProposals: 0,
+            mraEndorsedRecoveryProposals: 0,
             computed: false
           };
           if(!event._recovery.skip) {
@@ -1682,10 +1682,11 @@ function _computeRecovery({
      future endorse point.
   */
 
-  /* Note: There is no need to update `event._recovery.mraRecoveryProposals`
-  if recovery proposals are created or rejected because that state variable
-  is only consumed during `computeSupport` which has already run for this
-  event. Leaving it as-is is more useful for debugging purposes. */
+  /* Note: There is no need to update
+  `event._recovery.mraEndorsedRecoveryProposals` if recovery proposals are
+  endorsed or rejected because that state variable is only consumed during
+  `computeSupport` which has already run for this event. Leaving it as-is is
+  more useful for debugging purposes. */
 
   /*
   1. Iterate over most recent ancestor events from all electors and
@@ -1889,12 +1890,6 @@ function _computeSupport({
       return;
     }
 
-    // do not count result from a branch with an endorsed recovery proposal;
-    // it blocks support because that node favors recovery, not a decision
-    if(_hasEndorsedRecoveryProposal(e)) {
-      return;
-    }
-
     // find existing result to update that matches support set
     let tallyResult = _.find(tally, _findSetInTally(e._supporting));
     if(!tallyResult) {
@@ -2035,32 +2030,23 @@ function _computeSupport({
 
   /*
     If the previous supporting is different from the new support, update the
-    next choice count if there is no endorsed recovery proposal on the branch.
-    If the support has not changed, determine if the switch/support is ready
-    to be endorsed (and mark as endorsed if appropriate).
+    next choice count. If the support has not changed, determine if the
+    switch/support is ready to be endorsed (and mark as endorsed if
+    appropriate).
   */
   const previousVoteEvent = event._votes[creator];
-  let switched = true;
-  let hasEndorsedRecoveryProposal = false;
-  if(previousVoteEvent) {
-    switched = !(previousVoteEvent._supporting && _compareSupportSet(
-      nextChoice.set, previousVoteEvent._supporting));
-    hasEndorsedRecoveryProposal = _hasEndorsedRecoveryProposal(
-      previousVoteEvent);
-  }
-
+  const switched = !(previousVoteEvent && previousVoteEvent._supporting &&
+    _compareSupportSet(nextChoice.set, previousVoteEvent._supporting));
   if(switched) {
     // set last time switched
     // Note: This will cause any `_lastSwitch` on the branch that had a
     // future endorsement to not ever be marked as endorsed because it will not
     // be brought forward through branch ancestry
     event._lastSwitch = event;
-    // increment next choice counts if branch has no endorsed recovery proposal
-    if(!hasEndorsedRecoveryProposal) {
-      nextChoice.count++;
-      if(recoverySet.has(creator)) {
-        nextChoice.recoveryElectorCount++;
-      }
+    // increment next choice
+    nextChoice.count++;
+    if(recoverySet.has(creator)) {
+      nextChoice.recoveryElectorCount++;
     }
   } else if(event._endorsesSwitch) {
     // endorse point reached, if last switch has been brought forward through
@@ -2069,10 +2055,8 @@ function _computeSupport({
     if(!lastSwitch._switchEndorsed &&
       event._endorsesSwitch.includes(lastSwitch)) {
       lastSwitch._switchEndorsed = true;
-      // only update count if branch has no endorsed recovery proposal
-      if(!hasEndorsedRecoveryProposal) {
-        nextChoice.endorsedCount++;
-      }
+      // update count
+      nextChoice.endorsedCount++;
     }
   }
 
@@ -2095,9 +2079,9 @@ function _computeSupport({
     }
 
     // if recovery mode is enabled, reject proposal if any most recent ancestor
-    // has a recovery proposal
+    // has an endorsed recovery proposal
     if(!reject && event._recovery && event._recovery.proposal &&
-      event._recovery.mraRecoveryProposals > 0) {
+      event._recovery.mraEndorsedRecoveryProposals > 0) {
       reject = true;
     }
 

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -36,9 +36,6 @@ api._findMergeEventProof = _findMergeEventProof;
  * @param [recoveryGenerationThreshold] the "no progress" merge event
  *          generation threshold required to enter recovery mode; this
  *          must be given if `recoveryElectors` is given.
- * @param [recoveryDecisionThreshold] the number of recovery electors
- *          that must see a decision before accepting it as final; this
- *          must be given if `recoveryElectors` is given.
  * @param logger the logger to use.
  *
  * @return `null` if no consensus was found or an object `result` if it has,
@@ -50,15 +47,13 @@ api._findMergeEventProof = _findMergeEventProof;
  */
 api.findConsensus = ({
   ledgerNodeId, history, blockHeight, electors,
-  recoveryElectors = [], recoveryGenerationThreshold, recoveryDecisionThreshold,
-  logger = noopLogger
+  recoveryElectors = [], recoveryGenerationThreshold, logger = noopLogger
 }) => {
   if(recoveryElectors.length > 0 &&
-    !(Number.isInteger(recoveryGenerationThreshold) &&
-    Number.isInteger(recoveryDecisionThreshold))) {
+    !Number.isInteger(recoveryGenerationThreshold)) {
     throw new Error(
-      '"recoveryGenerationThreshold" and "recoveryDecisionThreshold" must ' +
-      'be given when recovery electors are specified.');
+      '"recoveryGenerationThreshold" must be given recovery electors are ' +
+      'specified.');
   }
 
   // TODO: Note: once computed, merge event Y+X candidates for each
@@ -79,8 +74,7 @@ api.findConsensus = ({
   //startTime = Date.now();
   const proof = _findMergeEventProof({
     ledgerNodeId, history, tails, blockHeight, electors,
-    recoveryElectors, recoveryGenerationThreshold,
-    recoveryDecisionThreshold, logger
+    recoveryElectors, recoveryGenerationThreshold, logger
   });
   /*console.log('End sync _findMergeEventProof', {
     duration: Date.now() - startTime
@@ -375,9 +369,6 @@ function _getAncestorHashes({allXs, ledgerNodeId}) {
  * @param [recoveryGenerationThreshold] the "no progress" merge event
  *          generation threshold required to enter recovery mode; this
  *          must be given if `recoveryElectors` is given.
- * @param [recoveryDecisionThreshold] the number of recovery electors
- *          that must see a decision before accepting it as final; this
- *          must be given if `recoveryElectors` is given.
  * @param logger the logger to use.
  *
  * @return a map with `consensus` and `yCandidates`; the `consensus` key's
@@ -392,8 +383,7 @@ function _getAncestorHashes({allXs, ledgerNodeId}) {
  */
 function _findMergeEventProof({
   ledgerNodeId, history, tails, blockHeight, electors, recoveryElectors = [],
-  recoveryGenerationThreshold, recoveryDecisionThreshold = 0,
-  logger = noopLogger
+  recoveryGenerationThreshold, logger = noopLogger
 }) {
   if(electors.length === 1) {
     // if elector count is 1, then no recovery electors permitted
@@ -414,8 +404,8 @@ function _findMergeEventProof({
         count++;
       }
     }
-    const threshold = recoveryElectors.length - recoveryDecisionThreshold + 1;
-    canEnterRecoveryMode = (count >= threshold);
+    const recoverySupermajority = api.supermajority(recoveryElectors.length);
+    canEnterRecoveryMode = (count >= recoverySupermajority);
   }
 
   //let startTime = Date.now();
@@ -466,7 +456,7 @@ function _findMergeEventProof({
   // in recovery mode, enough recovery electors must participate
   let possibleRecoveryDeciders = 0;
   const recoverySet = new Set(recoveryElectors.map(e => e.id));
-  for(const elector in yByElector) {
+  for(const elector in xByElector) {
     if(recoverySet.size > 0 && recoverySet.has(elector)) {
       possibleRecoveryDeciders++;
     }
@@ -479,11 +469,12 @@ function _findMergeEventProof({
   // 2.2. There are enough possible recovery deciders to meet the threshold.
   const voters = Object.keys(yByElector);
   const supermajority = api.supermajority(electors.length);
+  const recoverySupermajority = api.supermajority(recoveryElectors.length);
   const canDecide = (
     totalMergeEvents >= minMergeEvents &&
     voters.length >= supermajority &&
     (recoveryElectors.length === 0 ||
-      possibleRecoveryDeciders >= recoveryDecisionThreshold));
+      possibleRecoveryDeciders >= recoverySupermajority));
   if(!canDecide) {
     // only return early if entering recovery mode is also not possible
     if(!canEnterRecoveryMode) {
@@ -507,8 +498,7 @@ function _findMergeEventProof({
   //logger.verbose('Start sync _findConsensusMergeEventProof');
   const ys = _findConsensusMergeEventProof(
     {ledgerNodeId, xByElector, yByElector, blockHeight,
-      electors, recoveryElectors, recoveryGenerationThreshold,
-      recoveryDecisionThreshold, logger});
+      electors, recoveryElectors, recoveryGenerationThreshold, logger});
   /*console.log('End sync _findConsensusMergeEventProof', {
     duration: Date.now() - startTime
   });*/
@@ -819,8 +809,7 @@ function _findEndorsementMergeEvent({
 
 function _findConsensusMergeEventProof({
   ledgerNodeId, xByElector, yByElector, blockHeight, electors,
-  recoveryElectors, recoveryGenerationThreshold, recoveryDecisionThreshold,
-  logger = noopLogger
+  recoveryElectors, recoveryGenerationThreshold, logger = noopLogger
 }) {
   /*logger.verbose(
     'Continuity2017 looking for consensus merge proof for ledger node ' +
@@ -842,8 +831,7 @@ function _findConsensusMergeEventProof({
   // go through each Y's branch looking for consensus
   const consensus = _tallyBranches({
     ledgerNodeId, xByElector, yByElector, blockHeight,
-    electors, recoveryElectors, recoveryGenerationThreshold,
-    recoveryDecisionThreshold, logger});
+    electors, recoveryElectors, recoveryGenerationThreshold, logger});
   /*console.log('End sync _findConsensusMergeEventProof: (Branches', {
     duration: Date.now() - startTime
   });*/
@@ -1414,8 +1402,7 @@ function _hasSufficientEndorsements(
 
 function _tallyBranches({
   ledgerNodeId, xByElector, yByElector, blockHeight, electors,
-  recoveryElectors, recoveryGenerationThreshold, recoveryDecisionThreshold,
-  logger = noopLogger
+  recoveryElectors, recoveryGenerationThreshold, logger = noopLogger
 }) {
   /* Algorithm:
 
@@ -1542,8 +1529,7 @@ function _tallyBranches({
       if(event._recovery) {
         _computeRecovery({
           ledgerNodeId, event, blockHeight,
-          recoveryElectors, recoveryGenerationThreshold,
-          recoveryDecisionThreshold, logger});
+          recoveryElectors, recoveryGenerationThreshold, logger});
       }
 
       // add tree children
@@ -1556,7 +1542,8 @@ function _tallyBranches({
 
 function _computeRecovery({
   ledgerNodeId, event, blockHeight,
-  recoveryElectors, recoveryGenerationThreshold, recoveryDecisionThreshold}) {
+  recoveryElectors, recoveryGenerationThreshold
+}) {
   if(event._recovery.computed) {
     return;
   }

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -1649,19 +1649,17 @@ function _computeSupport({
     1. If >= f+1 *endorsed* proposals, support the largest.
     2. Otherwise, union support.
 
-  Deciding:
-    1. If >= f+1 endorsed proposals, decide.
+  Rejecting proposals/Deciding:
+    1. If support is not for the proposal, reject.
+    2. Otherwise, if >= f+1 support something other than the proposal and
+       each of those sets is a larger set and has been endorsed, reject.
+    3. If >= f+1 endorsed proposals, decide.
        CAVEAT: If `recoveryElectors.length > 0`, then a decision can only be
        made when `recoveryDecisionThreshold` decision events, each created by
        a recovery elector that does not have a pending "recovery mode proposal"
        have been found. If this caveat applies but is not met, simply continue
        on until some future event satisfies the requirements or, alternatively,
        recovery mode is entered.
-
-  Rejecting proposals/Deciding:
-    1. If support is not for the proposal, reject.
-    2. Otherwise, if >= f+1 support something other than the proposal and
-       each of those sets is a larger set and has been endorsed, reject.
 
   Creating a new proposal:
 
@@ -1867,6 +1865,29 @@ function _computeSupport({
     }
   }
 
+  /*
+  If you have an existing proposal, check rejection.
+  */
+  if(proposal) {
+    // reject proposal if local support does not match
+    let reject = !_compareSupportSet(proposal._supporting, nextChoice.set);
+    if(!reject) {
+      // if `f+1` nodes support sets larger than existing proposal and their
+      // choice has been endorsed, reject
+      let total = 0;
+      for(const tallyResult of tally) {
+        if(tallyResult.set.length > nextChoice.set.length) {
+          total += tallyResult.endorsedCount;
+        }
+      }
+      reject = total >= (f + 1);
+    }
+
+    if(reject) {
+      proposal = null;
+    }
+  }
+
   if(event._endorses) {
     // endorse point reached
     if(proposal && !proposal._endorsed &&
@@ -1892,29 +1913,6 @@ function _computeSupport({
     if(consensusReached) {
       // consensus reached
       return nextChoice.set;
-    }
-  }
-
-  /*
-  If you have an existing proposal, check rejection/decision.
-  */
-  if(proposal) {
-    // reject proposal if local support does not match
-    let reject = !_compareSupportSet(proposal._supporting, nextChoice.set);
-    if(!reject) {
-      // if `f+1` nodes support sets larger than existing proposal and their
-      // choice has been endorsed, reject
-      let total = 0;
-      for(const tallyResult of tally) {
-        if(tallyResult.set.length > nextChoice.set.length) {
-          total += tallyResult.endorsedCount;
-        }
-      }
-      reject = total >= (f + 1);
-    }
-
-    if(reject) {
-      proposal = null;
     }
   }
 

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -70,10 +70,11 @@ api.findConsensus = ({
   mode = 'firstWithConsensusProof', logger = noopLogger
 }) => {
   if(recoveryElectors.length > 0 &&
-    !Number.isInteger(recoveryGenerationThreshold)) {
+    !(Number.isInteger(recoveryGenerationThreshold) &&
+    recoveryGenerationThreshold >= 5)) {
     throw new Error(
-      '"recoveryGenerationThreshold" must be given recovery electors are ' +
-      'specified.');
+      `"recoveryGenerationThreshold" (${recoveryGenerationThreshold}) ` +
+      'must be an integer >= 5 when recovery electors are specified. ');
   }
 
   // TODO: Note: once computed, merge event Y+X candidates for each
@@ -1475,9 +1476,15 @@ function _computeRecovery({
 
   /* Rules:
 
-  1. Update event's `noProgressCounter`. If at an event on the event's branch's
-     recovery endorsement chain, reset the counter and calculate the next event
-     on the chain, otherwise increment it.
+  1. Update event's `noProgressCounter`. If `event` is the first event on the
+     branch, calculate the next events for each of the decision endorsement and
+     recovery endorsement chains. Otherwise, determine if the event is on
+     either (or both) of the chains. If the event is on the recovery endorsement
+     chain, then increment the `noProgressCounter` and calculate the next
+     event on the recovery endorsement chain. If the event is on the decision
+     endorsement chain, then reset the `noProgressCounter` and calculate the
+     next event on the decision endorsement chain. Note that if event is on
+     both chains, the counter will be reset.
   2. Iterate over most recent ancestor events from all electors and
      tally decision proposals, endorsed recovery proposals, and
      "met no progress threshold"s from most recent ancestors, using `event`
@@ -1500,31 +1507,57 @@ function _computeRecovery({
   */
 
   /*
-  1. Update event's `noProgressCounter`. If at an event on the event's branch's
-     recovery endorsement chain, reset the counter and calculate the next event
-     on the chain, otherwise increment it.
+  1. Update event's `noProgressCounter`. If `event` is the first event on the
+     branch, calculate the next events for each of the decision endorsement and
+     recovery endorsement chains. Otherwise, determine if the event is on
+     either (or both) of the chains. If the event is on the recovery endorsement
+     chain, then increment the `noProgressCounter` and calculate the next
+     event on the recovery endorsement chain. If the event is on the decision
+     endorsement chain, then reset the `noProgressCounter` and calculate the
+     next event on the decision endorsement chain. Note that if event is on
+     both chains, the counter will be reset.
   */
   const {_recovery: recovery} = event;
   const supermajority = api.supermajority(electors.length);
+  const recoverySupermajority = api.supermajority(recoveryElectors.length);
   if(!event._treeParent) {
-    // first event, compute next time to reset no progress counter
+    // first event, compute next times to reset/increment no progress counter
     recovery.progressCheck = event;
+    recovery.noProgressCheck = event;
     _computeProgressEndorsement({ledgerNodeId, event, electors, supermajority});
-  } else if(event._endorsesProgress && recovery.progressCheck) {
-    // endorse point reached... only process if progress check matches
-    if(event._endorsesProgress.includes(recovery.progressCheck)) {
-      // mark endorsed, reset no progress counter and compute next
-      // progress check
-      recovery.progressCheck._progressEndorsed = true;
+    _computeNoProgressEndorsement(
+      {ledgerNodeId, event, recoveryElectors, recoverySupermajority});
+  } else {
+    // decide if progress check reached
+    const isProgressCheck = (event._endorsesProgress &&
+      recovery.progressCheck &&
+      event._endorsesProgress.includes(recovery.progressCheck));
+    // decide if no progress check reached
+    const isNoProgressCheck = (event._endorsesNoProgress &&
+      recovery.noProgressCheck &&
+      event._endorsesNoProgress.includes(recovery.noProgressCheck));
+
+    if(isNoProgressCheck) {
+      // mark endorsed, increment counter and calculate next no progress check
+      recovery.noProgressCounter++;
+      recovery.noProgressCheck._noProgressEndorsed = true;
+      recovery.noProgressCheck = event;
+      _computeNoProgressEndorsement(
+        {ledgerNodeId, event, recoveryElectors, recoverySupermajority});
+    }
+
+    if(isProgressCheck) {
+      // mark endorsed, reset counter (takes precedence over an incremented
+      // counter that may have just happened above because no progress and
+      // progress checks happened to coincide), and calculate next progress
+      // check
       recovery.noProgressCounter = 0;
+      recovery.progressCheck._progressEndorsed = true;
       recovery.progressCheck = event;
       _computeProgressEndorsement({
         ledgerNodeId, event, electors, supermajority
       });
     }
-  } else {
-    // not a progress check so increment counter
-    recovery.noProgressCounter++;
   }
 
   /*
@@ -1575,7 +1608,6 @@ function _computeRecovery({
      endorsed recovery proposal count if necessary.
   */
   const f = api.maximumFailures(electors.length);
-  const recoverySupermajority = api.supermajority(recoveryElectors.length);
   if(recovery.proposal &&
     ((meetThreshold < recoverySupermajority) ||
     (decisionProposals >= (f + 1)))) {
@@ -1616,7 +1648,7 @@ function _computeRecovery({
      event and compute its future endorse point.
   */
   if(!recovery.proposal && !event._proposal &&
-    meetThreshold >= recoverySupermajority &&
+    (meetThreshold >= recoverySupermajority) &&
     (decisionProposals < (f + 1))) {
     recovery.proposal = event;
     _computeRecoveryEndorsement({
@@ -1913,16 +1945,15 @@ function _computeSupport({
     // if recovery mode is enabled, reject proposal if most recent ancestors
     // have >= `r+1` recovery proposals
     if(!reject && recoverySet.size > 0) {
+      // TODO: Could be optimized away if entering recovery mode not possible
+
       // count recovery proposals from REs
       let recoveryProposals = 0;
       const {mostRecentAncestors} = event._index;
       const rPlusOne = r + 1;
-      for(const elector in mostRecentAncestors) {
-        if(!recoverySet.has(elector)) {
-          continue;
-        }
+      for(const elector of recoverySet) {
         const ancestorEvent = mostRecentAncestors[elector];
-        if(ancestorEvent._recovery.proposal) {
+        if(ancestorEvent && ancestorEvent._recovery.proposal) {
           recoveryProposals++;
           if(recoveryProposals >= rPlusOne) {
             reject = true;
@@ -2094,6 +2125,16 @@ function _computeProgressEndorsement({
   });
 }
 
+function _computeNoProgressEndorsement({
+  ledgerNodeId, event, recoveryElectors, recoverySupermajority
+}) {
+  return _computeEndorsement({
+    ledgerNodeId, event, recoveryElectors, recoverySupermajority,
+    type: 'recovery',
+    endorsementKey: '_noProgressEndorsement', endorsesKey: '_endorsesNoProgress'
+  });
+}
+
 function _computeRecoveryEndorsement({
   ledgerNodeId, event, recoveryElectors, recoverySupermajority
 }) {
@@ -2109,6 +2150,11 @@ function _computeEndorsement({
   recoveryElectors = [], recoverySupermajority = 0,
   type, endorsementKey, endorsesKey
 }) {
+  if(event[endorsementKey]) {
+    // already computed
+    return;
+  }
+
   let sharedEndorsementKey;
   if(type === 'recovery') {
     // recovery endorsement is *only* on recovery electors, so treat them
@@ -2123,7 +2169,20 @@ function _computeEndorsement({
   if(event[sharedEndorsementKey] !== undefined) {
     // reuse previously computed endorsements of the same type (with
     // the same `sharedEndorsementKey`)
-    event[endorsementKey] = event[sharedEndorsementKey];
+    const endorsement = event[sharedEndorsementKey];
+    if(endorsement === false) {
+      event[endorsementKey] = false;
+      return;
+    }
+    // ensure `endorsesKey` is updated
+    for(const e of endorsement) {
+      if(e[endorsesKey]) {
+        e[endorsesKey].push(event);
+      } else {
+        e[endorsesKey] = [event];
+      }
+    }
+    event[endorsementKey] = endorsement;
     return;
   }
 

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -1981,23 +1981,17 @@ function _findSetInTally(set) {
   if(!set) {
     return () => false;
   }
-  const a = set.map(r => r.eventHash);
-  return tallyResult => {
-    if(tallyResult.set === set) {
-      return true;
-    }
-    const b = tallyResult.set.map(r => r.eventHash);
-    return a.length === b.length && _.difference(a, b).length === 0;
-  };
+  return tallyResult => _compareSupportSet(tallyResult.set, set);
 }
 
 function _compareSupportSet(set1, set2) {
-  if(set1 === set2) {
-    return true;
-  }
-  const a = set1.map(r => r.eventHash);
-  const b = set2.map(r => r.eventHash);
-  return a.length === b.length && _.difference(a, b).length === 0;
+  return (set1 === set2) ||
+    (set1.length === set2.length &&
+    _.differenceWith(set1, set2, _compareEventHashes).length === 0);
+}
+
+function _compareEventHashes(r1, r2) {
+  return r1.eventHash === r2.eventHash;
 }
 
 function _computeEndorser({

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -1619,7 +1619,7 @@ function _computeRecovery({
 
   1. If a recovery proposal endorse point has been reached, mark its event as
      endorsed.
-  2. If >= `r+1` endorsed recovery proposals, enter recovery mode.
+  2. If >= `2r+1` endorsed recovery proposals, enter recovery mode.
   3. Otherwise, if no recovery proposal on `event` and >= `2r+1` recovery
      electors have no decision proposal and their
      `noProgressCounter` >= `recoveryGenerationThreshold` (or they already have
@@ -1638,12 +1638,12 @@ function _computeRecovery({
   }
 
   /*
-  2. If >= `r+1` endorsed recovery proposals, enter recovery mode.
+  2. If >= `2r+1` endorsed recovery proposals, enter recovery mode.
   */
   // tally all endorsed recovery proposals
   let endorsedRecoveryProposals = 0;
   let meetThreshold = 0;
-  const rPlusOne = api.maximumFailures(recoveryElectors.length) + 1;
+  const recoverySupermajority = api.supermajority(recoveryElectors.length);
   const recoverySet = new Set(recoveryElectors.map(e => e.id));
   // use most recent ancestors but use `event` for own branch
   const mostRecentAncestors = {
@@ -1659,7 +1659,7 @@ function _computeRecovery({
       }
       if(_hasEndorsedRecoveryProposal(ancestorEvent)) {
         endorsedRecoveryProposals++;
-        if(endorsedRecoveryProposals >= rPlusOne) {
+        if(endorsedRecoveryProposals >= recoverySupermajority) {
           // enter recovery mode
           const err = new Error('New electors required.');
           err.name = 'NewElectorsRequiredError';
@@ -1682,7 +1682,6 @@ function _computeRecovery({
      a recovery proposal) and no decision proposal exists on event's branch,
      then create a recovery proposal and compute its future endorse point.
   */
-  const recoverySupermajority = api.supermajority(recoveryElectors.length);
   if(!recovery.proposal && meetThreshold >= recoverySupermajority &&
     !event._proposal) {
     recovery.proposal = event;

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -686,6 +686,7 @@ function _findMergeEventProofCandidates({
         mergeEvent._recovery = {
           noProgressCounter: 0,
           electorsSeen: new Set(),
+          recoveryElectorsSeen: new Set(),
           lastElectorsSeen: 0
         };
       }
@@ -1269,7 +1270,7 @@ function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
       const ancestorEvent = mostRecentAncestors[elector];
       const parentAncestorEvent = parentAncestors[elector];
       if(ancestorEvent !== parentAncestorEvent) {
-        // event came after parent
+        // event came after tree parent
         newEvents.push(ancestorEvent);
       }
     }
@@ -1298,7 +1299,7 @@ function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
       recoveryElectorsSeen.add(creator);
       if(newEvent._recovery.proposal) {
         // do not count any decision elector that has proposed recovery as
-        // progress towards a decision
+        // progress toward a decision
         continue;
       }
     }
@@ -1572,6 +1573,11 @@ function _tallyBranches({
             _updateRecoveryInfo(
               {electors, recoveryElectors, yByElector, event});
           }
+        } else if(event._recovery && !event._recovery.skip &&
+          !event._treeParent) {
+          // update recovery info for first event on recovery elector
+          _updateRecoveryInfo(
+            {electors, recoveryElectors, yByElector, event});
         }
       }
 
@@ -1626,12 +1632,18 @@ function _computeRecovery({
 
   1. If a recovery proposal endorse point has been reached, mark its event as
      endorsed.
-  2. If >= `2r+1` endorsed recovery proposals, enter recovery mode.
-  3. Otherwise, if no recovery proposal on `event` and >= `2r+1` recovery
-     electors have no decision proposal and their
-     `noProgressCounter` >= `recoveryGenerationThreshold` (or they already have
-     a recovery proposal) and no decision proposal exists on event's branch,
-     then create a recovery proposal and compute its future endorse point.
+  2. Tally all endorsed recovery proposals and "met no progress threshold"
+     from most recent ancestors, using the event's tree parent (not itself)
+     when processing its branch. A "met no progress threshold" occurs when an
+     event has a recovery proposal, or it has no decision proposal but its
+     `noProgressCounter` is greater than or equal to the
+     `recoveryGenerationThreshold`.
+  3. If >= `2r+1` endorsed recovery proposals, enter recovery mode.
+  4. Otherwise, if event's branch has a decision proposal and >= r+1 endorsed
+     recovery proposals exist, reject the decision proposal.
+  5. If the event's branch has no recovery proposal and no decision proposal
+     and the "met no progress threshold" tally is >= `2r+1`, then create a
+     recovery proposal on the event and compute its future endorse point.
   */
 
   /*
@@ -1645,52 +1657,68 @@ function _computeRecovery({
   }
 
   /*
-  2. If >= `2r+1` endorsed recovery proposals, enter recovery mode.
+  2. Tally all endorsed recovery proposals and "met no progress threshold"
+     from most recent ancestors, using the event's tree parent (not itself)
+     when processing its branch. A "met no progress threshold" occurs when an
+     event has a recovery proposal, or it has no decision proposal but its
+     `noProgressCounter` is greater than or equal to the
+     `recoveryGenerationThreshold`.
   */
-  // tally all endorsed recovery proposals
   let endorsedRecoveryProposals = 0;
   let meetThreshold = 0;
   const recoverySupermajority = api.supermajority(recoveryElectors.length);
   const recoverySet = new Set(recoveryElectors.map(e => e.id));
-  // use most recent ancestors but use `event` for own branch
-  const mostRecentAncestors = {
-    ...event._index.mostRecentAncestors,
-    [_getCreator(event)]: event
-  };
-  for(const creator in mostRecentAncestors) {
-    if(recoverySet.has(creator)) {
-      const ancestorEvent = mostRecentAncestors[creator];
-      if(!ancestorEvent) {
-        // byzantine node detected, skip
-        continue;
-      }
-      if(_hasEndorsedRecoveryProposal(ancestorEvent)) {
-        endorsedRecoveryProposals++;
-        if(endorsedRecoveryProposals >= recoverySupermajority) {
-          // enter recovery mode
-          const err = new Error('New electors required.');
-          err.name = 'NewElectorsRequiredError';
-          throw err;
-        }
-      }
-      if(!ancestorEvent._proposal &&
-        (ancestorEvent._recovery.prosposal ||
-        ancestorEvent._recovery.noProgressCounter >=
-          recoveryGenerationThreshold)) {
-        meetThreshold++;
-      }
+  // use most recent ancestors (using tree parent for own branch unless it is
+  // the first event)
+  const creator = _getCreator(event);
+  const {mostRecentAncestors} = event._index;
+  for(const recoveryElector in mostRecentAncestors) {
+    const ancestorEvent = mostRecentAncestors[recoveryElector];
+    if(!ancestorEvent) {
+      // byzantine node detected, skip
+      continue;
+    }
+    if(!recoverySet.has(recoveryElector)) {
+      // ancestor is not a recovery elector
+      continue;
+    }
+    if(_hasEndorsedRecoveryProposal(ancestorEvent)) {
+      endorsedRecoveryProposals++;
+    }
+    if(!ancestorEvent._proposal &&
+      (ancestorEvent._recovery.proposal ||
+      ancestorEvent._recovery.noProgressCounter >=
+        recoveryGenerationThreshold)) {
+      meetThreshold++;
     }
   }
 
   /*
-  3. Otherwise, if no recovery proposal on `event` and >= `2r+1` recovery
-     electors have no decision proposal and their
-     `noProgressCounter` >= `recoveryGenerationThreshold` (or they already have
-     a recovery proposal) and no decision proposal exists on event's branch,
-     then create a recovery proposal and compute its future endorse point.
+  3. If >= `2r+1` endorsed recovery proposals, enter recovery mode.
   */
-  if(!recovery.proposal && meetThreshold >= recoverySupermajority &&
-    !event._proposal) {
+  if(endorsedRecoveryProposals >= recoverySupermajority) {
+    // enter recovery mode
+    const err = new Error('New electors required.');
+    err.name = 'NewElectorsRequiredError';
+    throw err;
+  }
+
+  /*
+  4. Otherwise, if event's branch has a decision proposal and >= r+1 endorsed
+     recovery proposals exist, reject the decision proposal.
+  */
+  const r = api.maximumFailures(recoveryElectors.length);
+  if(event._proposal && endorsedRecoveryProposals >= (r + 1)) {
+    delete event._proposal;
+  }
+
+  /*
+  5. If the event's branch has no recovery proposal and no decision proposal
+     and the "met no progress threshold" tally is >= `2r+1`, then create a
+     recovery proposal on the event and compute its future endorse point.
+  */
+  if(!recovery.proposal && !event._proposal &&
+    meetThreshold >= recoverySupermajority) {
     recovery.proposal = event;
     _computeEndorser({
       ledgerNodeId, event, recoveryElectors, recoverySupermajority
@@ -1948,12 +1976,24 @@ function _computeSupport({
     }
   }
 
+  // Note: While "endorsement" (specifically, the `_endorses` flag) is shared
+  // with recovery mode computations, recovery computations always happen
+  // *after* this code is run, which ensures that it is not possible to endorse
+  // a proposal that has been rejected. We do not need to add code to adjust
+  // the tally during rejection.
   if(event._endorses) {
     // endorse point reached
-    const notEndorsedBefore = proposal && !proposal._endorsed;
+    const notRejectedAndNotEndorsedBefore = proposal && !proposal._endorsed;
     event._endorses.forEach(e => e._endorsed = true);
-    // if proposal is now endorsed, ensure counts are updated
-    if(notEndorsedBefore && proposal._endorsed) {
+    // if proposal existed and was not endorsed before but now is
+    // endorsed, ensure counts are updated...
+    // Note: The proposal event might be marked as endorsed even though
+    // we rejected it; but the `notRejectedAndNotEndorsedBefore` flag prevents
+    // us from counting it if it was rejected. The proposal will never be
+    // counted again after this if it was rejected because it will not be
+    // attached to the event (and therefore will not be seen on the branch at
+    // any point at or beyond its endorser).
+    if(notRejectedAndNotEndorsedBefore && proposal._endorsed) {
       nextChoice.endorsedProposalCount++;
       if(recoverySet.has(creator)) {
         nextChoice.recoveryElectorEndorsedProposalCount++;

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -1479,7 +1479,7 @@ function _computeRecovery({
      recovery endorsement chain, reset the counter and calculate the next event
      on the chain, otherwise increment it.
   2. Iterate over most recent ancestor events from all electors and
-     tally endorsed decision proposals, endorsed recovery proposals, and
+     tally decision proposals, endorsed recovery proposals, and
      "met no progress threshold"s from most recent ancestors, using `event`
      when processing its own branch (instead of its tree parent). The count for
      "met no progress threshold" is incremented when an event's
@@ -1487,20 +1487,16 @@ function _computeRecovery({
      `recoveryGenerationThreshold`.
   3. If event's branch has an existing recovery proposal decide if it should
      be rejected. Reject it if either the "met no progress threshold" is
-     < `2r+1` or if the tallied endorsed decision proposals >= `f+1`. Note
-     that the decision proposals must be endorsed to create overlap with
-     `r+1` recovery proposals. Adjust the endorsed recovery proposal count if
-     necessary.
+     < `2r+1` or if the tallied decision proposals >= `f+1`. Adjust the
+     endorsed recovery proposal count if necessary.
   4. If a recovery proposal endorse point has been reached; mark any matching
      recovery proposal as endorsed. Adjust the endorsed recovery proposal
      count if necessary.
   5. If >= `r+1` endorsed recovery proposals, enter recovery mode.
   6. Otherwise, if the event's branch has no recovery proposal, no decision
      proposal, the "met no progress threshold" tally is >= `2r+1`, and there
-     are < `f+1` endorsed decision proposals, then create a recovery proposal
-     on the event and compute its future endorse point. Note that the decision
-     proposals need to be endorsed to create an overlap with `r+1` recovery
-     proposals.
+     are < `f+1` decision proposals, then create a recovery proposal on the
+     event and compute its future endorse point.
   */
 
   /*
@@ -1533,14 +1529,14 @@ function _computeRecovery({
 
   /*
   2. Iterate over most recent ancestor events from all electors and
-     tally endorsed decision proposals, endorsed recovery proposals, and
+     tally decision proposals, endorsed recovery proposals, and
      "met no progress threshold"s from most recent ancestors, using `event`
      when processing its own branch (instead of its tree parent). The count for
      "met no progress threshold" is incremented when an event's
      `noProgressCounter` is greater than or equal to the
      `recoveryGenerationThreshold`.
   */
-  let endorsedDecisionProposals = 0;
+  let decisionProposals = 0;
   let endorsedRecoveryProposals = 0;
   let meetThreshold = 0;
   const recoverySet = new Set(recoveryElectors.map(e => e.id));
@@ -1556,8 +1552,8 @@ function _computeRecovery({
       continue;
     }
     // always count decision proposals, regardless of recovery elector status
-    if(_hasEndorsedProposal(ancestorEvent)) {
-      endorsedDecisionProposals++;
+    if(ancestorEvent._proposal) {
+      decisionProposals++;
     }
     if(!recoverySet.has(elector)) {
       // ancestor is not a recovery elector
@@ -1575,16 +1571,14 @@ function _computeRecovery({
   /*
   3. If event's branch has an existing recovery proposal decide if it should
      be rejected. Reject it if either the "met no progress threshold" is
-     < `2r+1` or if the tallied endorsed decision proposals >= `f+1`. Note
-     that the decision proposals must be endorsed to create overlap with
-     `r+1` recovery proposals. Adjust the endorsed recovery proposal count if
-     necessary.
+     < `2r+1` or if the tallied decision proposals >= `f+1`. Adjust the
+     endorsed recovery proposal count if necessary.
   */
   const f = api.maximumFailures(electors.length);
   const recoverySupermajority = api.supermajority(recoveryElectors.length);
   if(recovery.proposal &&
     ((meetThreshold < recoverySupermajority) ||
-    (endorsedDecisionProposals >= (f + 1)))) {
+    (decisionProposals >= (f + 1)))) {
     // reject recovery proposal, adjusting counts as needed
     if(_hasEndorsedRecoveryProposal(event)) {
       endorsedRecoveryProposals--;
@@ -1618,14 +1612,12 @@ function _computeRecovery({
   /*
   6. Otherwise, if the event's branch has no recovery proposal, no decision
      proposal, the "met no progress threshold" tally is >= `2r+1`, and there
-     are < `f+1` endorsed decision proposals, then create a recovery proposal
-     on the event and compute its future endorse point. Note that the decision
-     proposals need to be endorsed to create an overlap with `r+1` recovery
-     proposals.
+     are < `f+1` decision proposals, then create a recovery proposal on the
+     event and compute its future endorse point.
   */
   if(!recovery.proposal && !event._proposal &&
     meetThreshold >= recoverySupermajority &&
-    (endorsedDecisionProposals < (f + 1))) {
+    (decisionProposals < (f + 1))) {
     recovery.proposal = event;
     _computeRecoveryEndorsement({
       ledgerNodeId, event, electors, recoveryElectors, recoverySupermajority
@@ -1716,19 +1708,6 @@ function _computeSupport({
   const recoverySupermajority = api.supermajority(recoveryElectors.length);
   const recoverySet = new Set(recoveryElectors.map(e => e.id));
 
-  // while tallying votes, determine if any recovery electors have made an
-  // endorsed recovery proposal
-
-  /* Note: The only `mode`s currently supported for selecting Y events
-  create a mathematical certainty that any RE that has made an endorsed
-  recovery proposal *MUST* have also made a Y event and therefore must be
-  in the event's voting ancestry ... or be byzantine and not counted anyway.
-  This is because Y events are either the first event on the RE (which by
-  definition can't be endorsed) or the first endorsement via `2r+1` recovery
-  electors. This means a second loop over MRAs is not required to detect
-  an endorsed recovery proposal in `event`'s ancestry. */
-  let hasMraEndorsedRecoveryProposal = false;
-
   // TODO: optimize
   /*logger.verbose('Continuity2017 _computeSupport finding votes seen...',
     {ledgerNode: ledgerNodeId, eventHash: event.eventHash});*/
@@ -1774,9 +1753,6 @@ function _computeSupport({
     }
     if(recoverySet.has(elector)) {
       tallyResult.recoveryElectorCount++;
-      if(!hasMraEndorsedRecoveryProposal && _hasEndorsedRecoveryProposal(e)) {
-        hasMraEndorsedRecoveryProposal = true;
-      }
     }
   }
   /*logger.debug('End sync _computeSupport vote tally proper', {
@@ -1934,10 +1910,26 @@ function _computeSupport({
       reject = total >= (f + 1);
     }
 
-    // if recovery mode is enabled, reject proposal if any most recent ancestor
-    // has an endorsed recovery proposal
-    if(!reject && recoverySet.size > 0 && hasMraEndorsedRecoveryProposal) {
-      reject = true;
+    // if recovery mode is enabled, reject proposal if most recent ancestors
+    // have >= `r+1` recovery proposals
+    if(!reject && recoverySet.size > 0) {
+      // count recovery proposals from REs
+      let recoveryProposals = 0;
+      const {mostRecentAncestors} = event._index;
+      const rPlusOne = r + 1;
+      for(const elector in mostRecentAncestors) {
+        if(!recoverySet.has(elector)) {
+          continue;
+        }
+        const ancestorEvent = mostRecentAncestors[elector];
+        if(ancestorEvent._recovery.proposal) {
+          recoveryProposals++;
+          if(recoveryProposals >= rPlusOne) {
+            reject = true;
+            break;
+          }
+        }
+      }
     }
 
     if(reject) {

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -55,12 +55,14 @@ api._findMergeEventProof = _findMergeEventProof;
  *            reached consensus in `eventHashes`.
  * @param logger the logger to use.
  *
- * @return `null` if no consensus was found or an object `result` if it has,
- *          where:
- *            result.eventHashes the hashes of events that have reached
- *              consensus.
- *            result.consensusProofHashes the hashes of events endorsing
- *              `result.eventHashes`.
+ * @return a result object with the following properties:
+ *           consensus: `true` if consensus has been found, `false` if` not.
+ *           eventHashes: the hashes of events that have reached consensus.
+ *           consensusProofHashes: the hashes of events endorsing `eventHashes`.
+ *           needsMergeEvent: `true` if consensus is `false` and another merge
+ *             event is needed from the node matching `ledgerNodeId`.
+ *           creators: the electors that participated in events that reached
+ *             consensus.
  */
 api.findConsensus = ({
   ledgerNodeId, history, blockHeight, electors,
@@ -102,7 +104,12 @@ api.findConsensus = ({
   });*/
   if(proof.consensus.length === 0) {
     //logger.verbose('findConsensus no proof found, exiting');
-    return null;
+    return {
+      consensus: false,
+      // TODO: calculate whether or not `ledgerNodeId` would be able to
+      // help reach consensus or if gossip is required
+      needsMergeEvent: true
+    };
   }
   //logger.verbose('findConsensus proof found, proceeding...');
   const creators = new Set();
@@ -127,6 +134,7 @@ api.findConsensus = ({
   const eventHashes = _getAncestorHashes({ledgerNodeId, allXs});
   // return event and consensus proof hashes and creators
   return {
+    consensus: true,
     eventHashes,
     consensusProofHashes,
     creators: [...creators]

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -713,6 +713,13 @@ function _findMergeEventProofCandidates({
   // Note: at most one per elector unless elector is byzantine (then >= 1)
   //startTime = Date.now();
   //logger.verbose('Start sync _findMergeEventProofCandidates: Y candidates');
+  let electorsForEndorsement = electors;
+  let supermajorityForEndorsement = supermajority;
+  if(mode !== 'first' && recoveryElectors.length > 0) {
+    // use recovery electors for endorsement in batch mode
+    electorsForEndorsement = recoveryElectors;
+    supermajorityForEndorsement = api.supermajority(recoveryElectors.length);
+  }
   for(const elector in xByElector) {
     for(const x of xByElector[elector]) {
       //console.log('FINDING Y FOR X', x, elector);
@@ -724,7 +731,9 @@ function _findMergeEventProofCandidates({
         // searches as it includes all ancestors of X -- which should not be
         // searched when finding a Y because they cannot lead to X
         results = _findEndorsementMergeEvent({
-          ledgerNodeId, x, electors, supermajority,
+          ledgerNodeId, x,
+          electors: electorsForEndorsement,
+          supermajority: supermajorityForEndorsement,
           ancestryMap: x._index.ancestryMap
         });
       }
@@ -771,9 +780,6 @@ function _findMergeEventProofCandidates({
  * @param x the event in history to begin searching at.
  * @param electors all current electors.
  * @param supermajority the number that constitutes a supermajority of electors.
- * @param [recoveryElectors] an optional set of recovery electors.
- * @param [recoverySupermajority] the number that constitutes a supermajority
- *          of recovery electors.
  * @param descendants an optional map of event hash to descendants that is
  *          populated as they are found.
  * @param ancestryMap an optional map of event hash to ancestors of `x` that is
@@ -784,7 +790,6 @@ function _findMergeEventProofCandidates({
  */
 function _findEndorsementMergeEvent({
   ledgerNodeId, x, electors, supermajority,
-  recoveryElectors = [], recoverySupermajority = 0,
   descendants = {}, ancestryMap = _buildAncestryMap(x)
 }) {
   //console.log('EVENT', x.eventHash);
@@ -800,7 +805,6 @@ function _findEndorsementMergeEvent({
   }
 
   const electorSet = new Set(electors.map(e => e.id));
-  const recoverySet = new Set(recoveryElectors.map(e => e.id));
   const results = [];
   let next = x._treeChildren.map(treeDescendant => ({
     treeDescendant,
@@ -822,8 +826,7 @@ function _findEndorsementMergeEvent({
 
       // see if there are a supermajority of endorsements of `x` now
       if(_hasSufficientEndorsements({
-        x, descendants, electorSet, supermajority,
-        recoverySet, recoverySupermajority
+        x, descendants, electorSet, supermajority
       })) {
         //console.log('supermajority of endorsements found at generation',
         //  treeDescendant._generation);
@@ -1434,16 +1437,11 @@ function _descendsFrom(younger, older) {
 }
 
 function _hasSufficientEndorsements({
-  x, descendants, electorSet, supermajority,
-  recoverySet, recoverySupermajority
+  x, descendants, electorSet, supermajority
 }) {
   // always count `x` as self-endorsed
   const xCreator = _getCreator(x);
   const endorsements = new Set([xCreator]);
-  const recoveryEndorsements = new Set();
-  if(recoverySet.has(xCreator)) {
-    recoveryEndorsements.add(xCreator);
-  }
   let next = [x];
   //console.log('checking for sufficient endorsements...');
   while(next.length > 0) {
@@ -1455,27 +1453,15 @@ function _hasSufficientEndorsements({
         // `event` is in the computed path of descendants
         for(const e of d) {
           const creator = _getCreator(e);
-          let added = false;
           if(electorSet.has(creator)) {
             endorsements.add(creator);
-            added = true;
             //console.log(
             // 'total', endorsements.size, 'supermajority', supermajority);
             //console.log('electors', electorSet);
             //console.log('endorsements', endorsements);
-          }
-          if(recoverySet.has(creator)) {
-            recoveryEndorsements.add(creator);
-            added = true;
-            //console.log(
-            //  'total recovery endorsements',
-            //  recoveryEndorsements.size, 'supermajority', supermajority);
-            //console.log('recoveryElectors', recoveryElectorSet);
-            //console.log('recoveryEndorsements', recoveryEndorsements);
-          }
-          if(added && endorsements.size >= supermajority &&
-            recoveryEndorsements.size >= recoverySupermajority) {
-            return true;
+            if(endorsements.size >= supermajority) {
+              return true;
+            }
           }
         }
         next.push(...d);
@@ -1758,8 +1744,8 @@ function _computeRecovery({
   if(!recovery.proposal && !event._proposal &&
     meetThreshold >= recoverySupermajority && (decisionProposals < (f + 1))) {
     recovery.proposal = event;
-    _computeRecoveryEndorser({
-      ledgerNodeId, event, recoveryElectors, recoverySupermajority
+    _computeRecoveryEndorsement({
+      ledgerNodeId, event, electors, recoveryElectors, recoverySupermajority
     });
   }
 
@@ -1813,22 +1799,22 @@ function _computeSupport({
   /* Endorsement rules:
 
   1. An event endorses an earlier event if the events are on the same branch
-     and if the endorser event is the first event since the earlier event that
-     includes >= `2f+1` electors in its ancestry that have the earlier event
-     in their ancestry.
-  2. A switch in support is endorsed at its endorser event if no other
-     switches in support occur between it and the endorser event.
-  3. A proposal is endorsed at its endorser event if the endorser event
+     and if the endorsement event is the first event since the earlier event
+     that includes >= `2f+1` electors in its ancestry that have the earlier
+     event in their ancestry.
+  2. A switch in support is endorsed at its endorsement event if no other
+     switches in support occur between it and the endorsement event.
+  3. A proposal is endorsed at its endorsement event if the endorsement event
      would also be a proposal for the same set.
 
   CAVEAT: If `recoveryElectors.length > 0` then:
 
-  1. A proposal endorsement additionally requires >= `2r+1` recovery electors
-     to have the proposal in their ancestry (not merely >= `2f+1`).
-  2. A recovery proposal is endorsed at its endorser event if the endorser
-     event's ancestry includes >= `2r+1` recovery electors (instead of >=
-     `2f+1` decision electors) that have the recovery proposal in their
-     ancestry.
+  1. A proposal endorsement requires >= `2r+1` recovery electors instead of
+     >= `2f+1` decision electors.
+  2. A recovery proposal is endorsed at its endorsement event if the
+     endorsement event's ancestry includes >= `2r+1` recovery electors
+     (instead of >= `2f+1` decision electors) that have the recovery proposal
+     in their ancestry.
   */
 
   const creator = _getCreator(event);
@@ -2007,10 +1993,10 @@ function _computeSupport({
   if(previousChoice !== nextChoice) {
     // set last time switched
     // Note: This will cause any `_lastSwitch` on the branch that had a
-    // future endorser to not ever be marked as endorsed because it will not
+    // future endorsement to not ever be marked as endorsed because it will not
     // be brought forward through branch ancestry; i.e., there is no need
-    // to modify `event._treeParent._lastSwitch._endorser` and leaving it
-    // is useful for debugging purposes
+    // to modify `event._treeParent._lastSwitch._electorEndorsement` and
+    // leaving it is useful for debugging purposes
     event._lastSwitch = event;
     // increment next choice count
     nextChoice.count++;
@@ -2093,7 +2079,7 @@ function _computeSupport({
     !(event._recovery && event._recovery.proposal)) {
     // no proposal yet, use current event
     proposal = event;
-    _computeProposalEndorser({
+    _computeProposalEndorsement({
       ledgerNodeId, event, electors, supermajority,
       recoveryElectors, recoverySupermajority
     });
@@ -2108,8 +2094,8 @@ function _computeSupport({
   if(!event._lastSwitch) {
     event._lastSwitch = event._treeParent._lastSwitch;
   } else {
-    // must have just switched, so compute endorser
-    _computeSwitchEndorser({
+    // must have just switched, so compute endorsement
+    _computeSwitchEndorsement({
       ledgerNodeId, event, electors, supermajority, recoveryElectors
     });
   }
@@ -2123,8 +2109,8 @@ function _computeSupport({
 function _hasEndorsedProposal(event) {
   const proposal = event._proposal;
   if(proposal && proposal._proposalEndorsed) {
-    for(const endorser of proposal._proposalEndorser) {
-      if(event._generation >= endorser._generation) {
+    for(const endorsement of proposal._proposalEndorsement) {
+      if(event._generation >= endorsement._generation) {
         return true;
       }
     }
@@ -2135,8 +2121,8 @@ function _hasEndorsedProposal(event) {
 function _hasEndorsedSwitch(event) {
   const lastSwitch = event._lastSwitch;
   if(lastSwitch && lastSwitch._switchEndorsed) {
-    for(const endorser of lastSwitch._switchEndorser) {
-      if(event._generation >= endorser._generation) {
+    for(const endorsement of lastSwitch._switchEndorsement) {
+      if(event._generation >= endorsement._generation) {
         return true;
       }
     }
@@ -2147,8 +2133,8 @@ function _hasEndorsedSwitch(event) {
 function _hasEndorsedRecoveryProposal(event) {
   const proposal = event._recovery && event._recovery.proposal;
   if(proposal && proposal._recoveryEndorsed) {
-    for(const endorser of proposal._recoveryEndorser) {
-      if(event._generation >= endorser._generation) {
+    for(const endorsement of proposal._recoveryEndorsement) {
+      if(event._generation >= endorsement._generation) {
         return true;
       }
     }
@@ -2173,101 +2159,88 @@ function _compareEventHashes(r1, r2) {
   return r1.eventHash === r2.eventHash;
 }
 
-function _computeSwitchEndorser({
+function _computeSwitchEndorsement({
   ledgerNodeId, event, electors, supermajority, recoveryElectors
 }) {
-  return _computeEndorser({
+  return _computeEndorsement({
     ledgerNodeId, event, electors, supermajority,
-    endorserKey: '_switchEndorser', endorsesKey: '_endorsesSwitch',
-    shareEndorser: recoveryElectors.length === 0
+    type: 'elector',
+    endorsementKey: '_switchEndorsement', endorsesKey: '_endorsesSwitch'
   });
 }
 
-function _computeProposalEndorser({
+function _computeProposalEndorsement({
   ledgerNodeId, event, electors, supermajority,
   recoveryElectors, recoverySupermajority
 }) {
-  return _computeEndorser({
+  // if recovery mode disabled, use electors, otherwise use recovery electors
+  const type = (recoveryElectors.length === 0) ? 'elector' : 'recovery';
+  return _computeEndorsement({
     ledgerNodeId, event, electors, supermajority,
     recoveryElectors, recoverySupermajority,
-    endorserKey: '_proposalEndorser', endorsesKey: '_endorsesProposal',
-    shareEndorser: recoveryElectors.length === 0
+    type,
+    endorsementKey: '_proposalEndorsement', endorsesKey: '_endorsesProposal'
   });
 }
 
-function _computeRecoveryEndorser({
+function _computeRecoveryEndorsement({
   ledgerNodeId, event, recoveryElectors, recoverySupermajority
 }) {
-  return _computeEndorser({
-    ledgerNodeId, event,
-    // recovery endorsement is *only* on recovery electors, so treat them
-    // like regular electors when looking for endorser
-    electors: recoveryElectors, supermajority: recoverySupermajority,
-    endorserKey: '_recoveryEndorser', endorsesKey: '_endorsesRecovery',
-    shareEndorser: false
+  return _computeEndorsement({
+    ledgerNodeId, event, recoveryElectors, recoverySupermajority,
+    type: 'recovery',
+    endorsementKey: '_recoveryEndorsement', endorsesKey: '_endorsesRecovery'
   });
 }
 
-function _computeEndorser({
+function _computeEndorsement({
   ledgerNodeId, event, electors, supermajority,
   recoveryElectors = [], recoverySupermajority = 0,
-  endorserKey, endorsesKey, shareEndorser
+  type, endorsementKey, endorsesKey
 }) {
-  if(event[endorserKey] !== undefined) {
-    // already computed
+  let sharedEndorsementKey;
+  if(type === 'recovery') {
+    // recovery endorsement is *only* on recovery electors, so treat them
+    // like regular electors when looking for endorsement
+    electors = recoveryElectors;
+    supermajority = recoverySupermajority;
+    sharedEndorsementKey = '_recoveryElectorEndorsement';
+  } else {
+    sharedEndorsementKey = '_electorEndorsement';
+  }
+
+  if(event[sharedEndorsementKey] !== undefined) {
+    // reuse previously computed endorsements of the same type (with
+    // the same `sharedEndorsementKey`)
+    event[endorsementKey] = event[sharedEndorsementKey];
     return;
   }
 
-  let endorsement;
-  if(shareEndorser && event._endorser !== undefined) {
-    // `._endorser` keeps track of previously computed endorse points
-    // (an optimization that is possible for non-recovery mode since
-    // endorsement requirements are the same for switches and proposals)
-    // ... if `event._endorser` is an array, reproduce `endorsement` to
-    // match spec below, otherwise, leave endorsement as undefined because
-    // we've previously detected there aren't any endorse points in the DAG
-    if(event._endorser !== false) {
-      // generate `endorsement` to match spec below
-      endorsement = event._endorser.map(e => ({mergeEvent: e}));
-    }
-  } else {
-    // endorser must be computed
-    const ancestryMap = event._index.ancestryMap || _buildAncestryMap(event);
-    endorsement = _findEndorsementMergeEvent({
-      ledgerNodeId, x: event, electors, supermajority,
-      recoveryElectors, recoverySupermajority,
-      descendants: {}, ancestryMap});
-  }
-
+  // `endorsement` must be computed
+  const ancestryMap = event._index.ancestryMap || _buildAncestryMap(event);
+  const endorsement = _findEndorsementMergeEvent({
+    ledgerNodeId, x: event, electors, supermajority,
+    descendants: {}, ancestryMap});
   if(endorsement) {
     // `endorsement` will be an array as byzantine nodes may fork, but forks
     // will get detected via endorse point(s) due to overlap of at least
     // one functioning node
-    const allEndorsers = [];
-    for(const {mergeEvent: endorser} of endorsement) {
-      if(endorser[endorsesKey]) {
-        endorser[endorsesKey].push(event);
+    const allEndorsements = [];
+    for(const {mergeEvent: e} of endorsement) {
+      if(e[endorsesKey]) {
+        e[endorsesKey].push(event);
       } else {
-        endorser[endorsesKey] = [event];
+        e[endorsesKey] = [event];
       }
       /*console.log(
-        'created endorse point for', event._generation,
-        'at', endorser._generation);*/
-      allEndorsers.push(endorser);
+        `created ${endorsementKey} endorse point for`, event._generation,
+        'at', e._generation);*/
+      allEndorsements.push(e);
     }
-    event[endorserKey] = allEndorsers;
+    event[sharedEndorsementKey] = event[endorsementKey] = allEndorsements;
   } else {
-    // no endorser in DAG
-    event[endorserKey] = false;
-  }
-
-  // if sharing endorser is enabled, copy to `._endorser` for optimized reuse
-  if(shareEndorser && event._endorser === undefined) {
-    if(event[endorserKey]) {
-      event._endorser = event[endorserKey].slice();
-    } else {
-      event._endorser = false;
-    }
+    // no endorsement of given type in DAG yet for `event`
+    event[sharedEndorsementKey] = event[endorsementKey] = false;
   }
 }
 

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -1482,8 +1482,8 @@ function _computeRecovery({
      tally decision proposals, endorsed recovery proposals, and "met no
      progress threshold"s from most recent ancestors, using `event` when
      processing its own branch (instead of its tree parent). The count for
-     "met no progress threshold" is incremented when an event has a recovery
-     proposal or its `noProgressCounter` is greater than or equal to the
+     "met no progress threshold" is incremented when an event's
+     `noProgressCounter` is greater than or equal to the
      `recoveryGenerationThreshold`.
   3. If event's branch has an existing recovery proposal decide if it should
      be rejected. Reject it if either the "met no progress threshold" is
@@ -1532,8 +1532,8 @@ function _computeRecovery({
      tally decision proposals, endorsed recovery proposals, and "met no
      progress threshold"s from most recent ancestors, using `event` when
      processing its own branch (instead of its tree parent). The count for
-     "met no progress threshold" is incremented when an event has a recovery
-     proposal or its `noProgressCounter` is greater than or equal to the
+     "met no progress threshold" is incremented when an event's
+     `noProgressCounter` is greater than or equal to the
      `recoveryGenerationThreshold`.
   */
   let decisionProposals = 0;
@@ -1562,9 +1562,8 @@ function _computeRecovery({
     if(_hasEndorsedRecoveryProposal(ancestorEvent)) {
       endorsedRecoveryProposals++;
     }
-    if(ancestorEvent._recovery.proposal ||
-      ancestorEvent._recovery.noProgressCounter >=
-        recoveryGenerationThreshold) {
+    if(ancestorEvent._recovery.noProgressCounter >=
+      recoveryGenerationThreshold) {
       meetThreshold++;
     }
   }
@@ -1583,10 +1582,6 @@ function _computeRecovery({
     if(_hasEndorsedRecoveryProposal(event)) {
       endorsedRecoveryProposals--;
     }
-    // FIXME: only decrement if
-    // `noProgressCounter >= recoveryGenerationThreshold` if above check
-    // changes to remove `ancestorEvent._recoveryProposal`
-    meetThreshold--;
     delete recovery.proposal;
   }
 

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -38,7 +38,6 @@ api._findMergeEventProof = _findMergeEventProof;
  *          must be given if `recoveryElectors` is given.
  * @param [mode='first'] an optional mode for selecting which events
  *          to find consensus on:
- *          // FIXME: change default to `first` in code
  *          first: create support sets from the first (aka "tail" or oldest)
  *            event from each participating elector and return the events that
  *            are in the consensus support set as having reached consensus
@@ -67,7 +66,7 @@ api._findMergeEventProof = _findMergeEventProof;
 api.findConsensus = ({
   ledgerNodeId, history, blockHeight, electors,
   recoveryElectors = [], recoveryGenerationThreshold,
-  mode = 'firstWithConsensusProof', logger = noopLogger
+  mode = 'first', logger = noopLogger
 }) => {
   if(recoveryElectors.length > 0 &&
     !(Number.isInteger(recoveryGenerationThreshold) &&
@@ -410,7 +409,6 @@ function _getAncestorHashes({allXs, ledgerNodeId}) {
  *          must be given if `recoveryElectors` is given.
  * @param [mode='first'] an optional mode for selecting which events
  *          to find consensus on:
- *          // FIXME: change default to `first` in code
  *          first: create support sets from the first (aka "tail" or oldest)
  *            event from each participating elector and return the events that
  *            are in the consensus support set as having reached consensus
@@ -440,7 +438,7 @@ function _getAncestorHashes({allXs, ledgerNodeId}) {
  */
 function _findMergeEventProof({
   ledgerNodeId, history, tails, blockHeight, electors, recoveryElectors = [],
-  recoveryGenerationThreshold, mode = 'firstWithConsensusProof',
+  recoveryGenerationThreshold, mode = 'first',
   logger = noopLogger
 }) {
   // FIXME: remove this conditional once confirmed it is enforced elsewhere
@@ -597,7 +595,6 @@ function _findMergeEventProof({
  * @param [recoveryElectors] an optional set of recovery electors.
  * @param [mode='first'] an optional mode for selecting which events
  *          to find consensus on:
- *          // FIXME: change default to `first` in code
  *          first: create support sets from the first (aka "tail" or oldest)
  *            event from each participating elector and return the events that
  *            are in the consensus support set as having reached consensus
@@ -621,7 +618,7 @@ function _findMergeEventProof({
  */
 function _findMergeEventProofCandidates({
   ledgerNodeId, tails, blockHeight, electors, recoveryElectors = [],
-  mode = 'firstWithConsensusProof', logger = noopLogger
+  mode = 'first', logger = noopLogger
 }) {
   const supermajority = api.supermajority(electors.length);
 

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -32,10 +32,21 @@ api._findMergeEventProof = _findMergeEventProof;
  *          including ONLY merge events, it must NOT include local regular
  *          events.
  * @param electors the current electors.
- * @param [recoveryElectors] an optional set of recovery electors.
+ * @param [recoveryElectors=[]] an optional set of recovery electors.
  * @param [recoveryGenerationThreshold] the "no progress" merge event
  *          generation threshold required to enter recovery mode; this
  *          must be given if `recoveryElectors` is given.
+ * @param [mode='first'] an optional mode for selecting which events
+ *          to find consensus on:
+ *          // FIXME: change default to `first` in code
+ *          first: use the first event or the "tail" of each elector.
+ *          firstWithEndorsement: use the first endorsed event of each elector
+ *            to find consensus, but only mark the `first` event (or the "tail")
+ *            of each elector has having consensus.
+ *          firstEndorsed: use the first endorsed event of each elector to
+ *            find consensus and mark all events from the first event to each
+ *            consensus event as having achieved consensus; also known as
+ *            "batch" mode.
  * @param logger the logger to use.
  *
  * @return `null` if no consensus was found or an object `result` if it has,
@@ -47,7 +58,8 @@ api._findMergeEventProof = _findMergeEventProof;
  */
 api.findConsensus = ({
   ledgerNodeId, history, blockHeight, electors,
-  recoveryElectors = [], recoveryGenerationThreshold, logger = noopLogger
+  recoveryElectors = [], recoveryGenerationThreshold,
+  mode = 'firstWithEndorsement', logger = noopLogger
 }) => {
   if(recoveryElectors.length > 0 &&
     !Number.isInteger(recoveryGenerationThreshold)) {
@@ -88,8 +100,7 @@ api.findConsensus = ({
   }
   //logger.verbose('findConsensus proof found, proceeding...');
   const creators = new Set();
-  const allXs = proof.consensus.map(p => p.x);
-  const consensusProofHashes = _.uniq(
+  let consensusProofHashes = _.uniq(
     proof.consensus.reduce((aggregator, current) => {
       creators.add(_getCreator(current.x));
       current.proof.forEach(r => {
@@ -98,6 +109,15 @@ api.findConsensus = ({
       });
       return aggregator;
     }, []));
+  let allXs;
+  if(mode === 'firstEndorsed') {
+    // consider `y` events to have achieved consensus, they are not just
+    // consensus "proof" and clear "proof"
+    allXs = proof.consensus.map(p => p.y);
+    consensusProofHashes = [];
+  } else {
+    allXs = proof.consensus.map(p => p.x);
+  }
   const eventHashes = _getAncestorHashes({ledgerNodeId, allXs});
   // return event and consensus proof hashes and creators
   return {
@@ -369,6 +389,17 @@ function _getAncestorHashes({allXs, ledgerNodeId}) {
  * @param [recoveryGenerationThreshold] the "no progress" merge event
  *          generation threshold required to enter recovery mode; this
  *          must be given if `recoveryElectors` is given.
+ * @param [mode='first'] an optional mode for selecting which events
+ *          to find consensus on:
+ *          // FIXME: change default to `first` in code
+ *          first: use the first event or the "tail" of each elector.
+ *          firstWithEndorsement: use the first endorsed event of each elector
+ *            to find consensus, but only mark the `first` event (or the "tail")
+ *            of each elector has having consensus.
+ *          firstEndorsed: use the first endorsed event of each elector to
+ *            find consensus and mark all events from the first event to each
+ *            consensus event as having achieved consensus; also known as
+ *            "batch" mode.
  * @param logger the logger to use.
  *
  * @return a map with `consensus` and `yCandidates`; the `consensus` key's
@@ -383,7 +414,8 @@ function _getAncestorHashes({allXs, ledgerNodeId}) {
  */
 function _findMergeEventProof({
   ledgerNodeId, history, tails, blockHeight, electors, recoveryElectors = [],
-  recoveryGenerationThreshold, logger = noopLogger
+  recoveryGenerationThreshold, mode = 'firstWithEndorsement',
+  logger = noopLogger
 }) {
   if(electors.length === 1) {
     // if elector count is 1, then no recovery electors permitted
@@ -411,8 +443,9 @@ function _findMergeEventProof({
   //let startTime = Date.now();
   //logger.verbose('Start sync _findMergeEventProofCandidates');
   //console.log('Start sync _findMergeEventProofCandidates');
-  const candidates = _findMergeEventProofCandidates(
-    {ledgerNodeId, tails, blockHeight, electors, recoveryElectors, logger});
+  const candidates = _findMergeEventProofCandidates({
+    ledgerNodeId, tails, blockHeight, electors, recoveryElectors, mode, logger
+  });
   /*console.log('End sync _findMergeEventProofCandidates', {
     duration: Date.now() - startTime
   });*/
@@ -549,6 +582,17 @@ function _findMergeEventProof({
  *          by elector ID.
  * @param electors the current set of electors.
  * @param [recoveryElectors] an optional set of recovery electors.
+ * @param [mode='first'] an optional mode for selecting which events
+ *          to find consensus on:
+ *          // FIXME: change default to `first` in code
+ *          first: use the first event or the "tail" of each elector.
+ *          firstWithEndorsement: use the first endorsed event of each elector
+ *            to find consensus, but only mark the `first` event (or the "tail")
+ *            of each elector has having consensus.
+ *          firstEndorsed: use the first endorsed event of each elector to
+ *            find consensus and mark all events from the first event to each
+ *            consensus event as having achieved consensus; also known as
+ *            "batch" mode.
  * @param logger the logger to use.
  *
  * @return `null` or a map containing `yByElectors` and `xByElectors`; in
@@ -559,7 +603,7 @@ function _findMergeEventProof({
  */
 function _findMergeEventProofCandidates({
   ledgerNodeId, tails, blockHeight, electors, recoveryElectors = [],
-  logger = noopLogger
+  mode = 'firstWithEndorsement', logger = noopLogger
 }) {
   const supermajority = api.supermajority(electors.length);
 
@@ -658,13 +702,18 @@ function _findMergeEventProofCandidates({
   for(const elector in xByElector) {
     for(const x of xByElector[elector]) {
       //console.log('FINDING Y FOR X', x, elector);
-      // pass `x._index.ancestryMap` as the ancestry map to short-circuit
-      // searches as it includes all ancestors of X -- which should not be
-      // searched when finding a Y because they cannot lead to X
-      const results = _findEndorsementMergeEvent({
-        ledgerNodeId, x, electors, supermajority,
-        ancestryMap: x._index.ancestryMap
-      });
+      let results;
+      if(mode === 'first') {
+        results = [{mergeEvent: x, descendants: {}}];
+      } else {
+        // pass `x._index.ancestryMap` as the ancestry map to short-circuit
+        // searches as it includes all ancestors of X -- which should not be
+        // searched when finding a Y because they cannot lead to X
+        results = _findEndorsementMergeEvent({
+          ledgerNodeId, x, electors, supermajority,
+          ancestryMap: x._index.ancestryMap
+        });
+      }
       if(results) {
         const mergeEvents = [];
         for(const result of results) {

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -92,7 +92,7 @@ api.findConsensus = ({
   //startTime = Date.now();
   const proof = _findMergeEventProof({
     ledgerNodeId, history, tails, blockHeight, electors,
-    recoveryElectors, recoveryGenerationThreshold, logger
+    recoveryElectors, recoveryGenerationThreshold, mode, logger
   });
   /*console.log('End sync _findMergeEventProof', {
     duration: Date.now() - startTime

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -39,27 +39,33 @@ api._findMergeEventProof = _findMergeEventProof;
  * @param [mode='first'] an optional mode for selecting which events
  *          to find consensus on:
  *          // FIXME: change default to `first` in code
- *          first: use the first event or the "tail" of each elector.
- *          firstWithEndorsement: use the first endorsed event of each elector
- *            to find consensus, but only mark the `first` event (or the "tail")
- *            of each elector has having consensus.
- *          firstEndorsed: use the first endorsed event of each elector to
- *            find consensus and mark all events from the first event to each
- *            consensus event as having achieved consensus; also known as
- *            "batch" mode.
+ *          first: create support sets from the first (aka "tail" or oldest)
+ *            event from each participating elector and return the events that
+ *            are in the consensus support set as having reached consensus
+ *            (i.e., `eventHashes`) (mode is aka "Ys are Xs").
+ *          firstWithConsensusProof: create support sets from the first
+ *            endorsement event for the first (aka "tail" or oldest) event from
+ *            each participating elector and return the consensus support set
+ *            and all ancestors until the associated tail events as
+ *            `consensusProofHashes` and the tails associated with the
+ *            endorsement events as having reached consensus (i.e.,
+ *            `eventHashes`) (mode is aka "Y is the endorsement of X").
+ *          batch: the same as `firstWithConsensusProof` except all
+ *            `consensusProofHashes` are instead also returned as having
+ *            reached consensus in `eventHashes`.
  * @param logger the logger to use.
  *
  * @return `null` if no consensus was found or an object `result` if it has,
  *          where:
  *            result.eventHashes the hashes of events that have reached
  *              consensus.
- *            result.consensusProofHashes the hashes of events proving
- *              consensus.
+ *            result.consensusProofHashes the hashes of events endorsing
+ *              `result.eventHashes`.
  */
 api.findConsensus = ({
   ledgerNodeId, history, blockHeight, electors,
   recoveryElectors = [], recoveryGenerationThreshold,
-  mode = 'firstWithEndorsement', logger = noopLogger
+  mode = 'firstWithConsensusProof', logger = noopLogger
 }) => {
   if(recoveryElectors.length > 0 &&
     !Number.isInteger(recoveryGenerationThreshold)) {
@@ -364,19 +370,23 @@ function _getAncestorHashes({allXs, ledgerNodeId}) {
 }
 
 /**
- * Find consensus merge event Ys that have ancestors from a supermajority of
- * electors that are descendants of merge event Xs, where merge event Xs include
- * ancestors from a supermajority of electors. This indicates that merge event
- * Xs have both endorsed merge events from a supermajority of electors and
+ * Find consensus merge event Ys.
+ *
+ * In `first` mode, Ys are the first (or "tail" or oldest) events from each of
+ * the electors.
+ *
+ * In `firstWithConsensusProof` and `batch` modes, Ys are merge events from a
+ * supermajority of electors that are descendants of merge event Xs, where
+ * merge event Xs are the first (or "tail" or oldest) events from each of
  * they have been shared with a supermajority of electors because merge event Ys
- * include endorsements of merge event Xs from a supermajority of electors. For
- * each Y and X combo, it means that "merge event Y proves that merge event X
- * has been endorsed by a supermajority of electors".
+ * the electors. This means that merge event Xs have been endorsed by a
+ * supermajority of electors. For each Y and X combo, it means that
+ * "merge event Y (and its ancestors up to X) prove that merge event X has
+ * been endorsed by a supermajority of electors".
  *
  * To have reached consensus, there must be at least a supermajority (a number
- * that constitutes 2/3rds + 1 of the current electors) of merge event Y
- * candidates where the candidates that have reached consensus are the ones
- * that do not have any merge event Y candidates as ancestors.
+ * that constitutes 2/3rds + 1 of the current electors) of a set of merge
+ * event Y candidates.
  *
  * @param ledgerNodeId the ID of the local ledger node.
  * @param history recent history rooted at the ledger node's local branch
@@ -392,20 +402,27 @@ function _getAncestorHashes({allXs, ledgerNodeId}) {
  * @param [mode='first'] an optional mode for selecting which events
  *          to find consensus on:
  *          // FIXME: change default to `first` in code
- *          first: use the first event or the "tail" of each elector.
- *          firstWithEndorsement: use the first endorsed event of each elector
- *            to find consensus, but only mark the `first` event (or the "tail")
- *            of each elector has having consensus.
- *          firstEndorsed: use the first endorsed event of each elector to
- *            find consensus and mark all events from the first event to each
- *            consensus event as having achieved consensus; also known as
- *            "batch" mode.
+ *          first: create support sets from the first (aka "tail" or oldest)
+ *            event from each participating elector and return the events that
+ *            are in the consensus support set as having reached consensus
+ *            (i.e., `eventHashes`) (mode is aka "Ys are Xs").
+ *          firstWithConsensusProof: create support sets from the first
+ *            endorsement event for the first (aka "tail" or oldest) event from
+ *            each participating elector and return the consensus support set
+ *            and all ancestors until the associated tail events as
+ *            `consensusProofHashes` and the tails associated with the
+ *            endorsement events as having reached consensus (i.e.,
+ *            `eventHashes`) (mode is aka "Y is the endorsement of X").
+ *          batch: the same as `firstWithConsensusProof` except all
+ *            `consensusProofHashes` are instead also returned as having
+ *            reached consensus in `eventHashes`.
  * @param logger the logger to use.
  *
  * @return a map with `consensus` and `yCandidates`; the `consensus` key's
- *         value is an array of merge event X and Y pairs where each merge
- *         event Y and its history proves its paired merge event X has been
- *         endorsed by a super majority of electors -- another key, `proof` is
+ *         value is an array of merge event X and Y pairs where either X and Y
+ *         are the same (mode = 'first') or where each merge event Y and its
+ *         history proves its paired merge event X has been endorsed by a super
+ *         majority of electors (other modes) -- another key, `proof` is
  *         also included with each pair that includes `y` and its direct
  *         ancestors until `x`, these, in total, constitute endorsements of `x`.
  *
@@ -414,7 +431,7 @@ function _getAncestorHashes({allXs, ledgerNodeId}) {
  */
 function _findMergeEventProof({
   ledgerNodeId, history, tails, blockHeight, electors, recoveryElectors = [],
-  recoveryGenerationThreshold, mode = 'firstWithEndorsement',
+  recoveryGenerationThreshold, mode = 'firstWithConsensusProof',
   logger = noopLogger
 }) {
   if(electors.length === 1) {
@@ -563,14 +580,7 @@ function _findMergeEventProof({
 }
 
 /**
- * Find the next merge events Y candidates for each elector that has ancestors
- * from a supermajority of electors that are descendants of merge events X,
- * where merge events X are the first events for each elector.
- *
- * A merge event Y provides proof that its corresponding merge event X has been
- * approved by a consensus of electors. In other words, for a given Y and X,
- * "merge event Y proves that merge event X has been endorsed by a
- * supermajority of electors".
+ * Find the next merge events X and Y candidates according to `mode`.
  *
  * Both Y and X must be created by each elector ("branch-native"). Therefore,
  * each elector will produce a single unique Y and X combination (or none at
@@ -585,25 +595,30 @@ function _findMergeEventProof({
  * @param [mode='first'] an optional mode for selecting which events
  *          to find consensus on:
  *          // FIXME: change default to `first` in code
- *          first: use the first event or the "tail" of each elector.
- *          firstWithEndorsement: use the first endorsed event of each elector
- *            to find consensus, but only mark the `first` event (or the "tail")
- *            of each elector has having consensus.
- *          firstEndorsed: use the first endorsed event of each elector to
- *            find consensus and mark all events from the first event to each
- *            consensus event as having achieved consensus; also known as
- *            "batch" mode.
+ *          first: create support sets from the first (aka "tail" or oldest)
+ *            event from each participating elector and return the events that
+ *            are in the consensus support set as having reached consensus
+ *            (i.e., `eventHashes`) (mode is aka "Ys are Xs").
+ *          firstWithConsensusProof: create support sets from the first
+ *            endorsement event for the first (aka "tail" or oldest) event from
+ *            each participating elector and return the consensus support set
+ *            and all ancestors until the associated tail events as
+ *            `consensusProofHashes` and the tails associated with the
+ *            endorsement events as having reached consensus (i.e.,
+ *            `eventHashes`) (mode is aka "Y is the endorsement of X").
+ *          batch: the same as `firstWithConsensusProof` except all
+ *            `consensusProofHashes` are instead also returned as having
+ *            reached consensus in `eventHashes`.
  * @param logger the logger to use.
  *
  * @return `null` or a map containing `yByElectors` and `xByElectors`; in
  *   `xByElectors`, each elector maps to the first event(s) on that elector's
  *   branch. In `yByElectors`, each elector maps to merge event(s) Y on its
- *   branch that prove a merge event X on its branch has been endorsed by a
- *   super majority of electors.
+ *   branch according to `mode`.
  */
 function _findMergeEventProofCandidates({
   ledgerNodeId, tails, blockHeight, electors, recoveryElectors = [],
-  mode = 'firstWithEndorsement', logger = noopLogger
+  mode = 'firstWithConsensusProof', logger = noopLogger
 }) {
   const supermajority = api.supermajority(electors.length);
 
@@ -1221,7 +1236,7 @@ function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
   /* Rules:
 
   Note: `2r+1` is the minimum number of recovery electors that must be
-  functional to enter recovery mode.Every time `2r+1` recovery electors
+  functional to enter recovery mode. Every time `2r+1` recovery electors
   participate in a merge event's ancestry since the last time `2r+1`
   participated, it constitutes a new recovery check.
 

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -442,6 +442,8 @@ function _findMergeEventProof({
   recoveryGenerationThreshold, mode = 'firstWithConsensusProof',
   logger = noopLogger
 }) {
+  // FIXME: remove this conditional once confirmed it is enforced elsewhere
+  // by throwing an error
   if(electors.length === 1) {
     // if elector count is 1, then no recovery electors permitted
     recoveryElectors = [];
@@ -489,8 +491,8 @@ function _findMergeEventProof({
 
   // if recovery mode can't be entered, skip tracking it... we will still
   // ensure that decisions can only be made with the appropriate recovery
-  // elector thresholds, but we know that there are not enough merge event
-  // generations to create sufficient proposals to enter recovery mode
+  // elector thresholds and that no vital computations would be any different
+  // if we *were* tracking recovery information
   if(!canEnterRecoveryMode && recoveryElectors.length > 0) {
     for(const {id: elector} of recoveryElectors) {
       const mergeEvents = xByElector[elector];
@@ -512,10 +514,12 @@ function _findMergeEventProof({
 
   // in recovery mode, enough recovery electors must participate
   let possibleRecoveryDeciders = 0;
-  const recoverySet = new Set(recoveryElectors.map(e => e.id));
-  for(const elector in xByElector) {
-    if(recoverySet.size > 0 && recoverySet.has(elector)) {
-      possibleRecoveryDeciders++;
+  if(recoveryElectors.length > 0) {
+    const recoverySet = new Set(recoveryElectors.map(e => e.id));
+    for(const elector in xByElector) {
+      if(recoverySet.has(elector)) {
+        possibleRecoveryDeciders++;
+      }
     }
   }
 
@@ -524,8 +528,9 @@ function _findMergeEventProof({
   // 2. Voters form a supermajority (2f+1) AND...
   // 2.1. Either not using recovery mode OR...
   // 2.2. There are enough possible recovery deciders to meet the threshold.
-  // TODO: another check to ensure that at least one Y event has at least 2f+1
-  // votes (descending events) ... otherwise clearly the support can't be there
+  // TODO: could add another check to ensure that at least one Y event has at
+  // least 2f+1 descending events ... otherwise clearly the support can't be
+  // there
   const voters = Object.keys(yByElector);
   const supermajority = api.supermajority(electors.length);
   const recoverySupermajority = api.supermajority(recoveryElectors.length);

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -1231,8 +1231,10 @@ function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
 
   1. Check the ancestry of `event` to add any recovery electors or decision
      electors that participated since the event's `treeParent` to sets
-     tracking their participation. A "decision elector" must have be
-     participating in voting and non-byzantine.
+     tracking their participation. A "decision elector" must be participating
+     in voting, non-byzantine, and if it is also a recovery elector, it must
+     not have a recovery proposal in order to be counted as making progress
+     towards a decision.
   2. If < `2r+1` recovery electors have participated since the last recovery
      check, then return because the next recovery check hasn't been reached.
      Otherwise, >= `2r+1` recovery electors have participated, so run a new
@@ -1294,6 +1296,11 @@ function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
     // create a Y could be related to a need to enter recovery mode
     if(recoverySet.has(creator)) {
       recoveryElectorsSeen.add(creator);
+      if(newEvent._recovery.proposal) {
+        // do not count any decision elector that has proposed recovery as
+        // progress towards a decision
+        continue;
+      }
     }
 
     // however, do not count any elector that cannot vote (has not made a Y)
@@ -1542,6 +1549,14 @@ function _tallyBranches({
       // info
       if((event._treeParent && event._treeParent._recovery) ||
         event._recovery) {
+        // if some ancestors haven't computed their recovery info yet, defer
+        const recoveryEvents = Object.values(event._index.mostRecentAncestors)
+          .filter(e => e && e !== event && recoverySet.has(_getCreator(e)));
+        if(recoveryEvents.some(e => !(e._recovery && e._recovery.computed))) {
+          next.push(event);
+          continue;
+        }
+
         if(!event._recovery) {
           // shallow copy tree parent's recovery info
           const {electorsSeen, recoveryElectorsSeen} =
@@ -1557,14 +1572,6 @@ function _tallyBranches({
             _updateRecoveryInfo(
               {electors, recoveryElectors, yByElector, event});
           }
-        }
-
-        // if some ancestors haven't computed their recovery info yet, defer
-        const recoveryEvents = Object.values(event._index.mostRecentAncestors)
-          .filter(e => e && e !== event && recoverySet.has(_getCreator(e)));
-        if(recoveryEvents.some(e => !(e._recovery && e._recovery.computed))) {
-          next.push(event);
-          continue;
         }
       }
 

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -688,7 +688,8 @@ function _findMergeEventProofCandidates({
       if(isRecoveryElector) {
         mergeEvent._recovery = {
           noProgressCounter: 0,
-          electorsSeen: new Set()
+          electorsSeen: new Set(),
+          lastElectorsSeen: 0
         };
       }
     }
@@ -1256,7 +1257,8 @@ function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
      last time the set tracking decision elector participation was reset,
      then reset the `noProgressCounter` to `0` and clear the set tracking
      participating decision electors.
-  5. Clear the set tracking participating recovery electors.
+  5. Update last electors seen and clear the set tracking participating
+     recovery electors.
 
   */
 
@@ -1365,13 +1367,16 @@ function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
        then reset the `noProgressCounter` to `0` and clear the set tracking
        participating decision electors.
     */
+    event._recovery.noProgressCounter = 0;
     event._recovery.lastElectorsSeen = 0;
     electorsSeen.clear();
   }
 
   /*
-  5. Clear the set tracking participating recovery electors.
+  5. Update last electors seen and clear the set tracking participating
+     recovery electors.
   */
+  event._recovery.lastElectorsSeen = electorsSeen.size;
   recoveryElectorsSeen.clear();
 }
 

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -1639,7 +1639,7 @@ function _tallyBranches({
 // optimization -- unit tests MUST cover it to check for correctness
 function _computeRecovery({
   ledgerNodeId, event, blockHeight, electors,
-  recoveryElectors, recoveryGenerationThreshold
+  recoveryElectors, recoveryGenerationThreshold, logger = noopLogger
 }) {
   if(event._recovery.computed) {
     return;
@@ -1678,6 +1678,10 @@ function _computeRecovery({
   const {_recovery: recovery} = event;
   if(event._endorsesRecovery) {
     // endorse point reached
+    // Note: recovery proposals can't be rejected (either a decision is made
+    // or recovery mode is entered once a recovery proposal is created) so
+    // we don't have to be concerned about erroneously marking recovery
+    // proposals as endorsed
     event._endorsesRecovery.forEach(e => e._recoveryEndorsed = true);
   }
 
@@ -1860,8 +1864,6 @@ function _computeSupport({
     const proposal = e._proposal;
     const endorsedProposal = _hasEndorsedProposal(e);
     const isRecoveryElector = recoverySet.has(_getCreator(e));
-    const recoveryElectorEndorsedProposal = endorsedProposal &&
-      isRecoveryElector;
     if(tallyResult) {
       // ensure same instance of set is used for faster comparisons
       e._supporting = tallyResult.set;
@@ -1875,9 +1877,6 @@ function _computeSupport({
       if(endorsedProposal) {
         tallyResult.endorsedProposalCount++;
       }
-      if(recoveryElectorEndorsedProposal) {
-        tallyResult.recoveryElectorEndorsedProposalCount++;
-      }
       if(isRecoveryElector) {
         tallyResult.recoveryElectorCount++;
       }
@@ -1888,8 +1887,6 @@ function _computeSupport({
         endorsedCount: endorsed ? 1 : 0,
         proposalCount: proposal ? 1 : 0,
         endorsedProposalCount: endorsedProposal ? 1 : 0,
-        recoveryElectorEndorsedProposalCount:
-          recoveryElectorEndorsedProposal ? 1 : 0,
         recoveryElectorCount: isRecoveryElector ? 1 : 0
       });
     }
@@ -1957,6 +1954,9 @@ function _computeSupport({
       nextChoice = otherProposals[0];
     } else {
       // TODO: optimize to find largest endorsed proposal faster
+      // Note: if `proposal` will become endorsed at `event`, it is not yet
+      // endorsed here when determining support for `event` ... as we don't
+      // yet know `event`'s support (we're determining that *right now*)
       const union = _findUnionProposalSet(event, proposal);
       nextChoice = _.find(tally, _findSetInTally(union));
     }
@@ -1990,7 +1990,6 @@ function _computeSupport({
           endorsed: 0,
           proposalCount: 0,
           endorsedProposalCount: 0,
-          recoveryElectorEndorsedProposalCount: 0,
           recoveryElectorCount: 0
         };
       }
@@ -2006,16 +2005,12 @@ function _computeSupport({
 
   // check if vote has changed
   if(previousChoice !== nextChoice) {
-    const lastSwitch = event._treeParent && event._treeParent._lastSwitch;
-    if(lastSwitch && !lastSwitch._switchEndorsed &&
-      lastSwitch._switchEndorser) {
-      // delete future endorse point of support as support has changed
-      for(const endorser of lastSwitch._switchEndorser) {
-        endorser._endorsesSwitch = endorser._endorsesSwitch
-          .filter(e => e !== lastSwitch);
-      }
-    }
     // set last time switched
+    // Note: This will cause any `_lastSwitch` on the branch that had a
+    // future endorser to not ever be marked as endorsed because it will not
+    // be brought forward through branch ancestry; i.e., there is no need
+    // to modify `event._treeParent._lastSwitch._endorser` and leaving it
+    // is useful for debugging purposes
     event._lastSwitch = event;
     // increment next choice count
     nextChoice.count++;
@@ -2023,8 +2018,8 @@ function _computeSupport({
       nextChoice.recoveryElectorCount++;
     }
   } else if(event._endorsesSwitch) {
-    // endorse point reached, same support as parent, mark last switch
-    // as endorsed if it has not been removed from endorses list
+    // endorse point reached, if last switch has been brought forward through
+    // branch ancestry since it occurred then mark it as endorsed
     const lastSwitch = event._treeParent._lastSwitch;
     if(!lastSwitch._switchEndorsed &&
       event._endorsesSwitch.includes(lastSwitch)) {
@@ -2065,11 +2060,8 @@ function _computeSupport({
     because it was rejected. */
     if(event._endorsesProposal.includes(proposal)) {
       proposal._proposalEndorsed = true;
-      // ensure counts are updated...
+      // ensure count is updated
       nextChoice.endorsedProposalCount++;
-      if(recoverySet.has(creator)) {
-        nextChoice.recoveryElectorEndorsedProposalCount++;
-      }
     }
   }
 
@@ -2112,7 +2104,7 @@ function _computeSupport({
     event._proposal = proposal;
   }
 
-  // propagate node's last switch
+  // propagate last switch through branch ancestry to enable endorsement
   if(!event._lastSwitch) {
     event._lastSwitch = event._treeParent._lastSwitch;
   } else {
@@ -2208,6 +2200,8 @@ function _computeRecoveryEndorser({
 }) {
   return _computeEndorser({
     ledgerNodeId, event,
+    // recovery endorsement is *only* on recovery electors, so treat them
+    // like regular electors when looking for endorser
     electors: recoveryElectors, supermajority: recoverySupermajority,
     endorserKey: '_recoveryEndorser', endorsesKey: '_endorsesRecovery',
     shareEndorser: false

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -530,8 +530,6 @@ function _findMergeEventProof({
   const supermajority = api.supermajority(electors.length);
   const recoverySupermajority = api.supermajority(recoveryElectors.length);
   const canDecide = (
-    // FIXME: recoveryGenerationThreshold *must* be larger than minMergeEvents
-    // ...throw an error above if this is not true
     totalMergeEvents >= minMergeEvents &&
     voters.length >= supermajority &&
     (recoveryElectors.length === 0 ||
@@ -1624,8 +1622,9 @@ function _computeRecovery({
   2. If >= `r+1` endorsed recovery proposals, enter recovery mode.
   3. Otherwise, if no recovery proposal on `event` and >= `2r+1` recovery
      electors have `noProgressCounter` >= `recoveryGenerationThreshold` (or
-     they already have a recovery proposal), then create a recovery proposal
-     and compute its future endorse point.
+     they already have a recovery proposal) and no decision proposal exists
+     on event's branch, then create a recovery proposal and compute its future
+     endorse point.
   */
 
   /*
@@ -1677,11 +1676,13 @@ function _computeRecovery({
 
   /*
   3. Otherwise, if no recovery proposal on `event` and >= `2r+1` recovery
-     electors have `noProgressCounter` >= `recoveryGenerationThreshold`, then
-     create a recovery proposal and compute its future endorse point.
+     electors have `noProgressCounter` >= `recoveryGenerationThreshold` and
+     no decision proposal exists on event's branch, then create a recovery
+     proposal and compute its future endorse point.
   */
   const recoverySupermajority = api.supermajority(recoveryElectors.length);
-  if(!recovery.proposal && meetThreshold >= recoverySupermajority) {
+  if(!recovery.proposal && meetThreshold >= recoverySupermajority &&
+    !event._proposal) {
     recovery.proposal = event;
     _computeEndorser({
       ledgerNodeId, event, recoveryElectors, recoverySupermajority
@@ -1732,7 +1733,9 @@ function _computeSupport({
   Creating a new proposal:
 
     1. If no existing proposal (or rejected it) and >= 2f+1 nodes support our
-       next choice (endorsement not required), proposal it.
+       next choice (endorsement not required), propose it.
+       CAVEAT: If `recoveryElectors.length > 0` and a recovery proposal has
+       been made on the event's branch, do not create the proposal.
   */
 
   const creator = _getCreator(event);
@@ -1970,8 +1973,10 @@ function _computeSupport({
   // compute if the next choice has a supermajority
   const hasSupermajority = nextChoice.count >= supermajority;
   // If the next choice has a supermajority and has no existing (unrejected)
-  // proposal, so create a new one.
-  if(hasSupermajority && !proposal) {
+  // proposal, so create a new one. CAVEAT: If `recoveryElectors > 0` and
+  // event has a recovery proposal in its ancestry, do not create proposal.
+  if(hasSupermajority && !proposal &&
+    !(event._recovery && event._recovery.proposal)) {
     // no proposal yet, use current event
     proposal = event;
     // compute endorser for proposal

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -65,7 +65,9 @@ api.findConsensus = ({
   //   elector can be cached for quick retrieval in the future without
   //   the need to recompute them (they never change) for a given block...
   //   so the next blockHeight, elector, and X pair (its hash) could be
-  //   stored in the continuity2017 meta for each candidate merge event Y
+  //   stored in the continuity2017 meta for each candidate merge event Y;
+  //   however, this would only apply to certain modes where both X and Y
+  //   are needed vs. modes where Ys are Xs
   //logger.verbose('Start sync _getElectorBranches, branches', {electors});
   //let startTime = Date.now();
   const tails = _getElectorBranches({history, electors});
@@ -219,7 +221,7 @@ function _getElectorBranches({history, electors}) {
   return electorTails;
 }
 
-// FIXME: documentation
+// TODO: documentation
 function _getAncestorHashes({allXs, ledgerNodeId}) {
   // get all ancestor hashes from every consensus X
   // TODO: `hashes` seems like it could use event references here rather
@@ -669,8 +671,6 @@ function _findMergeEventProofCandidates({
       // pass `x._index.ancestryMap` as the ancestry map to short-circuit
       // searches as it includes all ancestors of X -- which should not be
       // searched when finding a Y because they cannot lead to X
-      // TODO: decide if we want Y here to require recovery electors when
-      // using recovery mode
       const results = _findEndorsementMergeEvent({
         ledgerNodeId, x, electors, supermajority,
         ancestryMap: x._index.ancestryMap
@@ -746,7 +746,7 @@ function _findEndorsementMergeEvent({
     return null;
   }
 
-  // TODO: if `recoveryElectors` then build a recoveryElectorSet as well
+  // TODO: RM - if `recoveryElectors` then build a recoveryElectorSet as well
   // and check for `recoverySupermajority` by modifying
   // `_hasSufficientEndorsements()` to also accept these two params
 
@@ -1170,51 +1170,98 @@ function _useMostRecentAncestorEvent({
   index[elector] = younger;
 }
 
-function _updateRecoveryInfo({electors, yByElector, event}) {
-  if(event._recovery.decision) {
-    // no need to compute further, decision already reached, can't move
-    // from a decision to a recovery proposal per rules
+function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
+  // FIXME: the `decision` part of this likely doesn't make sense ... probably
+  // dropping that state var due to `r+1` check being what is required for
+  // a decision ...
+
+  // if either a decision has been seen or a recovery proposal has been created
+  // on the event's branch already, return, there's nothing more to do here,
+  // just waiting for other branches to either decide or propose recovery mode
+  if(event._recovery.decision || event._recovery.proposal) {
     return;
   }
+
+  /* Rules:
+
+  Note: `2r+1` is the minimum number of recovery electors that must be
+  functional to enter recovery mode.Every time `2r+1` recovery electors
+  participate in a merge event's ancestry since the last time `2r+1`
+  participated, it constitutes a new recovery check.
+
+  1. Check the ancestry of `event` to add any recovery electors or decision
+     electors that participated since the event's `treeParent` to sets
+     tracking their participation.
+  2. If < `2r+1` recovery electors have participated since the last recovery
+     check, then return because the next recovery check hasn't been reached.
+     Otherwise, >= `2r+1` recovery electors have participated, so run a new
+     recovery check...
+  3. If zero new decision electors have participated since the last recovery
+     check then increment the `noProgressCounter`.
+  4. Otherwise, if >= `2f+1` decision electors have participated since the
+     last time the set tracking decision elector participation was reset,
+     then reset the `noProgressCounter` to `0` and clear the set tracking
+     participating decision electors.
+  5. Clear the set tracking participating recovery electors.
+
+  */
+
+  /*
+  1. Check the ancestry of `event` to add any recovery electors or decision
+     electors that participated since the event's `treeParent`.
+  */
 
   // find newly seen electors since `event._treeParent`
   let newEvents;
   if(event._treeParent) {
     newEvents = [];
-    const parentAncestors = event._treeParent._index.mostRecentAncestors;
-    for(const elector in parentAncestors) {
+    // go through event's most recent ancestors (mapped by creator) and see if
+    // the event is different from the event's parent's most recent ancestor,
+    // indicating a new event from that creator has been merged after the
+    // event's parent
+    const {mostRecentAncestors} = event._index;
+    const {mostRecentAncestors: parentAncestors} = event._treeParent._index;
+    for(const elector in mostRecentAncestors) {
+      const ancestorEvent = mostRecentAncestors[elector];
       const parentAncestorEvent = parentAncestors[elector];
-      const ancestorEvent = event._index.mostRecentAncestors[elector];
-      if(parentAncestorEvent !== ancestorEvent) {
-        // event is new
+      if(ancestorEvent !== parentAncestorEvent) {
+        // event came after parent
         newEvents.push(ancestorEvent);
       }
     }
   } else {
+    // the event has no parent, so all most recent ancestors are new
     newEvents = Object.values(event._index.mostRecentAncestors);
   }
 
-  // for new events, only add to "new electors seen" if events are from voting
-  // electors (i.e. electors that can make progress) and aren't byzantine
-  const newElectorsSeen = new Set();
+  const {electorsSeen, recoveryElectorsSeen} = event._recovery;
+  const recoverySet = new Set(recoveryElectors.map(e => e.id));
+
+  // go through all new events; updating recovery and decision electors seen
+  // based on all events that are from non-byzantine electors
   for(const newEvent of newEvents) {
     if(!newEvent) {
-      // byzantine node detected, `newEvent` does not advance consensus
+      // byzantine node detected, do not count it
       continue;
     }
-    // need to make sure that `newEvent` comes at or after its creator's Y
+
     const creator = _getCreator(newEvent);
+
+    // if creator is a recovery elector, add it as seen regardless of whether
+    // or not it can vote (has a Y in its history) because its inability to
+    // create a Y could be related to a need to enter recovery mode
+    if(recoverySet.has(creator)) {
+      recoveryElectorsSeen.add(creator);
+    }
+
+    // however, do not count any elector that cannot vote (has not made a Y)
+    // as a decision elector...
+
+    // need to make sure that `newEvent` comes at or after its creator's Y
     const creatorYs = yByElector[creator];
     if(!creatorYs) {
       // `newEvent` does not come from a voting elector
       continue;
-    }
-
-    // if a decision has been seen by an ancestor, accept it; this covers the
-    // case where a recovery node does not have a Y but has seen a decision
-    // from another node -- so it's ok to reach consensus
-    if(newEvent._decision) {
-      event._decision = event._recovery.decision = newEvent._decision;
     }
 
     // if `newEvent` descends from creator's Y then it counts as helping
@@ -1223,7 +1270,7 @@ function _updateRecoveryInfo({electors, yByElector, event}) {
     // common case (non-byzantine creator)
     if(creatorYs.length === 0) {
       if(creatorYs[0]._generation <= newEvent._generation) {
-        newElectorsSeen.add(creator);
+        electorsSeen.add(creator);
       }
       continue;
     }
@@ -1234,54 +1281,44 @@ function _updateRecoveryInfo({electors, yByElector, event}) {
     while(creatorY) {
       if(creatorYs.includes(creatorY)) {
         // `newEvent` occurs after a Y event (so it is a voting event)
-        newElectorsSeen.add(creator);
+        electorsSeen.add(creator);
         break;
       }
       creatorY = creatorY._treeParent;
     }
   }
 
-  // calculate threshold that indicates progress
-  // ... there are always 3f+1 electors, 2f+1 required for consensus
-  // ... >= 2f + 1 means progress towards consensus
-  // ... note there must always be f+1 recovery electors, they are always up
-  // ... (2f+1 - (f+1 recovery_electors)) = f,
-  // Note: So why `>= 2f+1` and not just `2f+1 - (f+1) = f` since the recovery
-  // electors are always up? To mitigate case where an attacker is able to
-  // prevent a recovery elector from communicating with the others ... recovery
-  // mode can still be triggered here and the recovery electors could, once it
-  // is triggered, start using a VPC to communicate, thwarting the attacker
-  const f = api.maximumFailures(electors.length);
-  const threshold = 2 * f + 1;
-
-  // optimize obviously seen enough electors as we saw them all at once
-  const {_recovery: recovery} = event;
-  if(newElectorsSeen.size >= threshold) {
-    recovery.noProgressCounter = 0;
-    recovery.electorsSeen.clear();
+  /*
+  2. If < `2r+1` recovery electors have participated since the last recovery
+     check, then return because the next recovery check hasn't been reached.
+  */
+  const recoverySupermajority = api.supermajority(recoveryElectors.length);
+  if(recoveryElectorsSeen.size < recoverySupermajority) {
     return;
   }
 
-  // update recovery info using any newly seen electors
-  const originalSize = recovery.electorsSeen.size;
-  for(const elector of newElectorsSeen) {
-    const beforeSize = recovery.electorsSeen.size;
-    recovery.electorsSeen.add(elector);
-    // if new elector was seen and threshold crossed...
-    if(recovery.electorsSeen.size > beforeSize &&
-      recovery.electorsSeen.size === threshold) {
-      // progress made, reset counter and return
-      recovery.noProgressCounter = 0;
-      recovery.electorsSeen.clear();
-      return;
-    }
+  /*
+  3. If zero new decision electors have participated since the last recovery
+     check then increment the `noProgressCounter`.
+  */
+  const supermajority = api.supermajority(electors.length);
+  if(event._recovery.lastElectorsSeen === electorsSeen.size) {
+    event._recovery.noProgressCounter++;
+  } else if(electorsSeen.size >= supermajority) {
+    /*
+    4. Otherwise, if >= `2f+1` decision electors have participated since the
+       last time the set tracking decision elector participation was reset,
+       then reset the `noProgressCounter` to `0` and clear the set tracking
+       participating decision electors.
+    */
+    event._recovery.lastElectorsSeen = 0;
+    electorsSeen.clear();
   }
 
-  // if no progress towards consensus with this merge event...
-  if(originalSize === recovery.electorsSeen.size) {
-    // increment no progress counter
-    recovery.noProgressCounter++;
-  }
+  /*
+  5. Clear the set tracking participating recovery electors.
+  */
+  recoveryElectorsSeen.clear();
 }
 
 function _computeMostRecentVotes({event, yElectorSet, yByElector}) {
@@ -1458,15 +1495,18 @@ function _tallyBranches({
         event._recovery) {
         if(!event._recovery) {
           // shallow copy tree parent's recovery info
-          const {electorsSeen} = event._treeParent._recovery;
+          const {electorsSeen, recoveryElectorsSeen} =
+            event._treeParent._recovery;
           event._recovery = {
             ...event._treeParent._recovery,
             electorsSeen: new Set(electorsSeen),
+            recoveryElectorsSeen: new Set(recoveryElectorsSeen),
             computed: false
           };
           if(!event._recovery.skip) {
             // update recovery info based on new most recent ancestors
-            _updateRecoveryInfo({electors, yByElector, event});
+            _updateRecoveryInfo(
+              {electors, recoveryElectors, yByElector, event});
           }
         }
 
@@ -1477,12 +1517,6 @@ function _tallyBranches({
           next.push(event);
           continue;
         }
-
-        // compute recovery info
-        _computeRecovery({
-          ledgerNodeId, event, blockHeight,
-          recoveryElectors, recoveryGenerationThreshold,
-          recoveryDecisionThreshold, logger});
       }
 
       // if event is voting, compute its support
@@ -1502,6 +1536,14 @@ function _tallyBranches({
           // consensus reached
           return result;
         }
+      }
+
+      // if event is from a recovery elector, compute its recovery info
+      if(event._recovery) {
+        _computeRecovery({
+          ledgerNodeId, event, blockHeight,
+          recoveryElectors, recoveryGenerationThreshold,
+          recoveryDecisionThreshold, logger});
       }
 
       // add tree children
@@ -1524,115 +1566,74 @@ function _computeRecovery({
     return;
   }
 
-  // if no recovery proposal has been made *AND* no decision has been made,
-  // check to see if a proposal should be made by testing the no progress
-  // counter against the generation threshold
-  if(!event._recovery.proposal && !event._recovery.decision &&
-    event._recovery.noProgressCounter >= recoveryGenerationThreshold) {
-    // recovery mode proposed! ... this elector cannot reject this proposal
-    // unless another recovery elector creates a decision; however, recovery
-    // mode will not be entered until all recovery electors also create
-    // a recovery proposal (making it impossible for any to reject their own
-    // recovery proposal)
-    event._recovery.proposal = true;
+  /* Rules:
+
+  1. If a recovery proposal endorse point has been reached, mark its event as
+     endorsed.
+  2. If >= `r+1` endorsed recovery proposals, enter recovery mode.
+  3. Otherwise, if no recovery proposal on `event` and >= `2r+1` recovery
+     electors have `noProgressCounter` >= `recoveryGenerationThreshold`, then
+     create a recovery proposal and compute its future endorse point.
+  */
+
+  /*
+  1. If a recovery proposal endorse point has been reached, mark its event as
+     endorsed.
+  */
+  const {_recovery: recovery} = event;
+  if(event._endorsesRecovery) {
+    // endorse point reached
+    event._endorsesRecovery.forEach(e => e._recoveryEndorsed = true);
   }
 
-  if(event._recovery.proposal) {
-    for(const creator in event._index.mostRecentAncestors) {
-      // note: always use a decision from another recovery elector to reject a
-      // recovery proposal (note: don't need to bother checking if creator
-      // is event's creator because event can't both have a proposal and
-      // a decision at the same time)
-      const ancestorEvent = event._index.mostRecentAncestors[creator];
-      if(ancestorEvent && ancestorEvent._recovery &&
-        ancestorEvent._recovery.decision) {
-        delete event._recovery.proposal;
-        break;
-      }
-    }
-  }
-
-  // Note: Here we must ensure that a concurrent acceptance of recovery mode
-  // and a switch from recovery proposal to decision cannot happen. This is
-  // done by checking the DAG to ensure that every recovery elector has seen
-  // the same forks (if any) and has seen the same number of proposals ...
-  // and that the number of proposals is sufficient to enter recovery mode.
-
-  // go through the recovery elector ancestry for this event (including
-  // this event) and, from the perspective of each other recovery elector,
-  // compute how many proposals it has seen and how many recovery elector
-  // it has detected are byzantine (i.e. they have forked) ... then make
-  // sure all of the non-byzantine recovery electors are in agreement
-  let mustMatch;
-  let agreement = true;
-  const ancestry = {
+  /*
+  2. If >= `r+1` endorsed recovery proposals, enter recovery mode.
+  */
+  // tally all endorsed recovery proposals
+  let endorsedRecoveryProposals = 0;
+  let meetThreshold = 0;
+  const rPlusOne = api.maximumFailures(recoveryElectors.length) + 1;
+  const recoverySet = new Set(recoveryElectors.map(e => e.id));
+  // use most recent ancestors but use `event` for own branch
+  const mostRecentAncestors = {
     ...event._index.mostRecentAncestors,
     [_getCreator(event)]: event
   };
-  for(const creator in ancestry) {
-    const ancestorEvent = ancestry[creator];
-    if(!ancestorEvent || !ancestorEvent._recovery) {
-      // skip, no results to compute for a byzantine creator or a non-recovery
-      // elector
-      continue;
-    }
-    const result = {};
-    result.byzantines = new Set();
-    result.proposals = 0;
-    const peerAncestors = {
-      ...ancestorEvent._index.mostRecentAncestors,
-      [creator]: ancestorEvent
-    };
-    for(const c in peerAncestors) {
-      const ancestorEvent = peerAncestors[c];
+  for(const creator in mostRecentAncestors) {
+    if(recoverySet.has(creator)) {
+      const ancestorEvent = mostRecentAncestors[creator];
       if(!ancestorEvent) {
-        result.byzantines.add(c);
-      } else if(ancestorEvent._recovery && ancestorEvent._recovery.proposal) {
-        result.proposals++;
+        // byzantine node detected, skip
+        continue;
       }
-    }
-
-    // make sure all non-byzantine recovery electors are in agreement (note
-    // that any byzantine recovery electors will NOT be in the `results` map
-    // per the above algorithm) ... then, if there's agreement, make sure there
-    // are sufficient proposals to enter recovery mode below
-    if(!mustMatch) {
-      mustMatch = result;
-    } else if(!(
-      mustMatch.proposals === result.proposals &&
-      mustMatch.byzantines.size === result.byzantines.size)) {
-      // results do not match, break out
-      agreement = false;
-      break;
-    } else {
-      // ensure deep set equality
-      for(const e of mustMatch.byzantines) {
-        if(!result.byzantines.has(e)) {
-          agreement = false;
-          break;
+      const {proposal} = ancestorEvent._recovery;
+      if(proposal && proposal._recoveryEndorsed) {
+        endorsedRecoveryProposals++;
+        if(endorsedRecoveryProposals >= rPlusOne) {
+          // enter recovery mode
+          const err = new Error('New electors required.');
+          err.name = 'NewElectorsRequiredError';
+          throw err;
         }
       }
-      // results do not match, break out
-      if(!agreement) {
-        break;
+      if(ancestorEvent._recovery.noProgressCounter >=
+        recoveryGenerationThreshold) {
+        meetThreshold++;
       }
     }
   }
 
-  if(agreement) {
-    // in order to enter recovery mode, 100% of the non-byzantine recovery
-    // electors must have recovery proposals AND the non-byzantine recovery
-    // electors must form a number that is greater than the decision threshold
-    const nonByzantines = recoveryElectors.length - mustMatch.byzantines.size;
-    const threshold = recoveryDecisionThreshold + 1;
-    if(mustMatch.proposals === nonByzantines && nonByzantines >= threshold) {
-      // once all non-byzantine recovery electors have seen that all others
-      // have made proposals, they cannot switch to a decision, so we can
-      // safely enter recovery mode
-      const err = new Error('New electors required.');
-      err.name = 'NewElectorsRequiredError';
-      throw err;
-    }
+  /*
+  3. Otherwise, if no recovery proposal on `event` and >= `2r+1` recovery
+     electors have `noProgressCounter` >= `recoveryGenerationThreshold`, then
+     create a recovery proposal and compute its future endorse point.
+  */
+  const recoverySupermajority = api.supermajority(recoveryElectors.length);
+  if(!recovery.proposal && meetThreshold >= recoverySupermajority) {
+    recovery.proposal = event;
+    _computeRecoveryEndorser({
+      ledgerNodeId, event, recoveryElectors, recoverySupermajority
+    });
   }
 
   // recovery info computed
@@ -1693,6 +1694,7 @@ function _computeSupport({
   const supermajority = api.supermajority(electors.length);
   const r = api.maximumFailures(recoveryElectors.length);
   const recoverySupermajority = api.supermajority(recoveryElectors.length);
+  const recoverySet = new Set(recoveryElectors.map(e => e.id));
 
   // TODO: optimize
   /*logger.verbose('Continuity2017 _computeSupport finding votes seen...',
@@ -1710,6 +1712,8 @@ function _computeSupport({
     const endorsed = _hasEndorsedSwitch(e);
     const proposal = e._proposal;
     const endorsedProposal = _hasEndorsedProposal(e);
+    const recoveryElectorEndorsedProposal = endorsedProposal &&
+      recoverySet.has(_getCreator(e));
     if(tallyResult) {
       // ensure same instance of set is used for faster comparisons
       e._supporting = tallyResult.set;
@@ -1723,13 +1727,18 @@ function _computeSupport({
       if(endorsedProposal) {
         tallyResult.endorsedProposalCount++;
       }
+      if(recoveryElectorEndorsedProposal) {
+        tallyResult.recoveryElectorEndorsedProposalCount++;
+      }
     } else {
       tally.push({
         set: e._supporting,
         count: 1,
         endorsedCount: endorsed ? 1 : 0,
         proposalCount: proposal ? 1 : 0,
-        endorsedProposalCount: endorsedProposal ? 1 : 0
+        endorsedProposalCount: endorsedProposal ? 1 : 0,
+        recoveryElectorEndorsedProposalCount:
+          recoveryElectorEndorsedProposal ? 1 : 0
       });
     }
   });
@@ -1828,7 +1837,8 @@ function _computeSupport({
           count: 0,
           endorsed: 0,
           proposalCount: 0,
-          endorsedProposalCount: 0
+          endorsedProposalCount: 0,
+          recoveryElectorEndorsedProposalCount: 0
         };
       }
     }
@@ -1847,12 +1857,6 @@ function _computeSupport({
     event._lastSwitch = event;
     // increment next choice count
     nextChoice.count++;
-    // TODO: optimize away unnecessary endorser computations if possible
-    // compute endorser for event (if not already computed)
-    _computeEndorser({
-      ledgerNodeId, event, electors, supermajority,
-      recoveryElectors, recoverySupermajority
-    });
   }
 
   /*
@@ -1880,11 +1884,23 @@ function _computeSupport({
 
   if(event._endorses) {
     // endorse point reached
-    if(proposal && !proposal._endorsed &&
-      event._endorses.includes(proposal)) {
-      nextChoice.endorsedProposalCount++;
-    }
     event._endorses.forEach(e => e._endorsed = true);
+  }
+
+  // endorse points for proposals *may* be different from simple endorsement
+  // when recovery electors have been specified because an endorsed proposal
+  // must have been endorsed by not only `2f+1` electors but also `2r+1`
+  // recovery electors
+  if(event._endorsesProposal) {
+    // endorse point reached
+    if(proposal && !proposal._endorsedProposal &&
+      event._endorsesProposal.includes(proposal)) {
+      nextChoice.endorsedProposalCount++;
+      if(recoverySet.has(creator)) {
+        nextChoice.recoveryElectorEndorsedProposalCount++;
+      }
+    }
+    event._endorsesProposal.forEach(e => e._endorsedProposal = true);
   }
 
   /*console.log('SUPPORT at ', event.eventHash, 'IS FOR',
@@ -1892,18 +1908,14 @@ function _computeSupport({
 
   /*
   If at least `f+1` of endorsed proposals support the same set, then consensus
-  has been reached (modulo recovery mode caveat). Otherwise, continue on and
-  hope the next event will decide...
+  has been reached (unless in recovery mode, in which case if `r+1` of those
+  proposals are from recovery electors then consensus has been reached).
+  Otherwise, continue on and hope the next event will decide...
   */
   if(nextChoice.endorsedProposalCount >= (f + 1)) {
-    // TODO: can we optimize such that once `_decision` is set ... skip all
-    // the tallying and just check `_consensusReached` at the top of the
-    // function? ...what else needs to be propagated for this to work?
-    const consensusReached = _consensusReached({
-      event, recoveryElectors, nextChoice
-    });
-    if(consensusReached) {
-      // consensus reached
+    if(recoveryElectors.length === 0 ||
+      (nextChoice.recoveryElectorEndorsedProposalCount >= (r + 1))) {
+      // consensus reached, all done!
       return nextChoice.set;
     }
   }
@@ -1915,13 +1927,11 @@ function _computeSupport({
   if(hasSupermajority && !proposal) {
     // no proposal yet, use current event
     proposal = event;
-    if(!event._endorser) {
-      // compute endorser for event (if not already computed)
-      _computeEndorser({
-        ledgerNodeId, event, electors, supermajority,
-        recoveryElectors, recoverySupermajority
-      });
-    }
+    // compute endorser for proposal
+    _computeProposalEndorser({
+      ledgerNodeId, event, electors, supermajority,
+      recoveryElectors, recoverySupermajority
+    });
   }
 
   // set event's proposal
@@ -1932,6 +1942,9 @@ function _computeSupport({
   // propagate node's last switch
   if(!event._lastSwitch) {
     event._lastSwitch = event._treeParent._lastSwitch;
+  } else {
+    // compute endorser for event (if not already computed)
+    _computeEndorser({ledgerNodeId, event, electors, supermajority});
   }
 
   // support next choice
@@ -1942,8 +1955,8 @@ function _computeSupport({
 
 function _hasEndorsedProposal(event) {
   const proposal = event._proposal;
-  if(proposal && proposal._endorsed) {
-    for(const endorser of proposal._endorser) {
+  if(proposal && proposal._endorsedProposal) {
+    for(const endorser of proposal._proposalEndorser) {
       if(event._generation >= endorser._generation) {
         return true;
       }
@@ -1981,17 +1994,65 @@ function _compareEventHashes(r1, r2) {
   return r1.eventHash === r2.eventHash;
 }
 
-function _computeEndorser({
+function _computeEndorser({ledgerNodeId, event, electors, supermajority}) {
+  return _computeEndorserType({
+    ledgerNodeId, event, electors, supermajority,
+    endorserKey: '_endorser', endorsesKey: '_endorses'
+  });
+}
+
+function _computeProposalEndorser({
   ledgerNodeId, event, electors, supermajority,
   recoveryElectors, recoverySupermajority
 }) {
-  if(event._endorser) {
+  // TODO: optimization - if `event.lastSwitch === event`, then `_endorser`
+  // will not have been set yet and if `_computeEndorserType` were updated to
+  // return *both* the endorse point using only decision electors (`electors`)
+  // *and* the endorse point that *also* includes recovery electors, then
+  // we could avoid having to walk the event's descendants multiple times
+  _computeEndorserType({
+    ledgerNodeId, event, electors, supermajority,
+    recoveryElectors, recoverySupermajority,
+    endorserKey: '_proposalEndorser', endorsesKey: '_endorsesProposal'
+  });
+
+  // optimization: if `recoveryElectors` is zero length and `event` is also the
+  // `lastSwitch`, then reuse the `_proposalEndorser` to create `_endorser`
+  if(recoveryElectors.length === 0 && event._proposalEndorser &&
+    !event._endorser && event._lastSwitch === event) {
+    event._endorser = event._proposalEndorser;
+    for(const endorser of event._endorser) {
+      if(endorser._endorses) {
+        endorser._endorses.push(event);
+      } else {
+        endorser._endorses = [event];
+      }
+    }
+  }
+}
+
+function _computeRecoveryEndorser({
+  ledgerNodeId, event, recoveryElectors, recoverySupermajority
+}) {
+  return _computeEndorserType({
+    ledgerNodeId, event, electors: recoveryElectors,
+    supermajority: recoverySupermajority,
+    endorserKey: '_recoveryEndorser', endorsesKey: '_endorsesRecovery'
+  });
+}
+
+function _computeEndorserType({
+  ledgerNodeId, event, electors, supermajority,
+  recoveryElectors, recoverySupermajority,
+  endorserKey, endorsesKey
+}) {
+  if(event[endorserKey]) {
     // already computed
     return;
   }
 
   // compute endorser
-  const ancestryMap = _buildAncestryMap(event);
+  const ancestryMap = event._index.ancestryMap || _buildAncestryMap(event);
   const endorsement = _findEndorsementMergeEvent({
     ledgerNodeId, x: event, electors, supermajority,
     recoveryElectors, recoverySupermajority,
@@ -2002,17 +2063,17 @@ function _computeEndorser({
     // event will be detected by at least one properly functioning node
     const allEndorsers = [];
     for(const {mergeEvent: endorser} of endorsement) {
-      if(endorser._endorses) {
-        endorser._endorses.push(event);
+      if(endorser[endorsesKey]) {
+        endorser[endorsesKey].push(event);
       } else {
-        endorser._endorses = [event];
+        endorser[endorsesKey] = [event];
       }
       /*console.log(
         'created endorse point for', event._generation,
         'at', endorser._generation);*/
       allEndorsers.push(endorser);
     }
-    event._endorser = allEndorsers;
+    event[endorserKey] = allEndorsers;
   }
 }
 
@@ -2041,59 +2102,6 @@ function _findUnionProposalSet(event, proposal) {
     }
   });
   return union;
-}
-
-function _consensusReached({event, recoveryElectors, nextChoice}) {
-  // can only decide if no recovery electors are specified or if they
-  // are and we've detected decisions on enough recovery electors that
-  // do not have recovery proposals
-  const creator = _getCreator(event);
-  if(recoveryElectors.length === 0) {
-    // no recovery electors so decision is final; consensus reached
-    return true;
-  }
-
-  if(!event._recovery) {
-    // `event` not from a recovery elector, record decision as seen
-    // but not finalized yet
-    event._decision = nextChoice.set;
-  } else {
-    // `event` is from a recovery elector, so mark decision as seen
-    // provided that it does not have a recovery proposal (note: per the
-    // rules, we can't reject our own recovery proposal and any recovery
-    // proposal we have would have been rejected before this code path
-    // if the decision was from another recovery elector... so safe to
-    // mark decision here)
-    if(!event._recovery.proposal) {
-      // decision found, but not finalized yet
-      event._decision = event._recovery.decision = nextChoice.set;
-    }
-  }
-
-  // if `event` ancestry shows enough events from recovery electors have
-  // decisions to meet the decision threshold, then finalize decision
-  // Note: If `event` is from a recovery elector that *just now* saw
-  // a decision we need to make sure we count it because it won't be
-  // in the ancestry otherwise (rather, only its parent will)
-  const ancestry = {
-    ...event._index.mostRecentAncestors,
-    [creator]: event
-  };
-  let decisionCount = 0;
-  const supermajority = api.supermajority(recoveryElectors.length);
-  for(const {id: elector} of recoveryElectors) {
-    const ancestorEvent = ancestry[elector];
-    if(ancestorEvent && ancestorEvent._recovery.decision) {
-      decisionCount++;
-      if(decisionCount >= supermajority) {
-        // decision threshold crossed; consensus reached
-        return true;
-      }
-    }
-  }
-
-  // consensus not yet reached
-  return false;
 }
 
 function _buildAncestryMap(event) {

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -721,7 +721,7 @@ function _findMergeEventProofCandidates({
  */
 function _findEndorsementMergeEvent({
   ledgerNodeId, x, electors, supermajority,
-  recoveryElectors, recoverySupermajority,
+  recoveryElectors = [], recoverySupermajority = 0,
   descendants = {}, ancestryMap = _buildAncestryMap(x)
 }) {
   //console.log('EVENT', x.eventHash);
@@ -736,11 +736,8 @@ function _findEndorsementMergeEvent({
     return null;
   }
 
-  // TODO: RM - if `recoveryElectors` then build a recoveryElectorSet as well
-  // and check for `recoverySupermajority` by modifying
-  // `_hasSufficientEndorsements()` to also accept these two params
-
   const electorSet = new Set(electors.map(e => e.id));
+  const recoverySet = new Set(recoveryElectors.map(e => e.id));
   const results = [];
   let next = x._treeChildren.map(treeDescendant => ({
     treeDescendant,
@@ -761,8 +758,10 @@ function _findEndorsementMergeEvent({
         {ledgerNodeId, x, y: treeDescendant, descendants, ancestryMap});
 
       // see if there are a supermajority of endorsements of `x` now
-      if(_hasSufficientEndorsements(
-        {x, descendants, electorSet, supermajority})) {
+      if(_hasSufficientEndorsements({
+        x, descendants, electorSet, supermajority,
+        recoverySet, recoverySupermajority
+      })) {
         //console.log('supermajority of endorsements found at generation',
         //  treeDescendant._generation);
         //console.log();
@@ -1186,6 +1185,9 @@ function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
      recovery check...
   3. If zero new decision electors have participated since the last recovery
      check then increment the `noProgressCounter`.
+     // FIXME: might need to do more than just look for new participation in
+     // our own history, rather might need to look at each participating
+     // event's latest ancestors vs. what they were during the last recovery
   4. Otherwise, if >= `2f+1` decision electors have participated since the
      last time the set tracking decision elector participation was reset,
      then reset the `noProgressCounter` to `0` and clear the set tracking
@@ -1366,10 +1368,17 @@ function _descendsFrom(younger, older) {
   return parent === older;
 }
 
-function _hasSufficientEndorsements(
-  {x, descendants, electorSet, supermajority}) {
+function _hasSufficientEndorsements({
+  x, descendants, electorSet, supermajority,
+  recoverySet, recoverySupermajority
+}) {
   // always count `x` as self-endorsed
-  const endorsements = new Set([_getCreator(x)]);
+  const xCreator = _getCreator(x);
+  const endorsements = new Set([xCreator]);
+  const recoveryEndorsements = new Set();
+  if(recoverySet.has(xCreator)) {
+    recoveryEndorsements.add(xCreator);
+  }
   let next = [x];
   //console.log('checking for sufficient endorsements...');
   while(next.length > 0) {
@@ -1381,15 +1390,27 @@ function _hasSufficientEndorsements(
         // `event` is in the computed path of descendants
         for(const e of d) {
           const creator = _getCreator(e);
+          let added = false;
           if(electorSet.has(creator)) {
             endorsements.add(creator);
+            added = true;
             //console.log(
             // 'total', endorsements.size, 'supermajority', supermajority);
             //console.log('electors', electorSet);
             //console.log('endorsements', endorsements);
-            if(endorsements.size >= supermajority) {
-              return true;
-            }
+          }
+          if(recoverySet.has(creator)) {
+            recoveryEndorsements.add(creator);
+            added = true;
+            //console.log(
+            //  'total recovery endorsements',
+            //  recoveryEndorsements.size, 'supermajority', supermajority);
+            //console.log('recoveryElectors', recoveryElectorSet);
+            //console.log('recoveryEndorsements', recoveryEndorsements);
+          }
+          if(added && endorsements.size >= supermajority &&
+            recoveryEndorsements.size >= recoverySupermajority) {
+            return true;
           }
         }
         next.push(...d);

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -1216,13 +1216,6 @@ function _useMostRecentAncestorEvent({
 }
 
 function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
-  // if a recovery proposal has been created on the event's branch already,
-  // return, there's nothing more to do here, just waiting for other branches
-  // to either decide or propose recovery mode
-  if(event._recovery.proposal) {
-    return;
-  }
-
   /* Rules:
 
   Note: `2r+1` is the minimum number of recovery electors that must be
@@ -1297,9 +1290,9 @@ function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
     // create a Y could be related to a need to enter recovery mode
     if(recoverySet.has(creator)) {
       recoveryElectorsSeen.add(creator);
+      // do not count any decision elector that has proposed recovery as
+      // progress toward a decision (continue early so it won't get counted)
       if(newEvent._recovery.proposal) {
-        // do not count any decision elector that has proposed recovery as
-        // progress toward a decision
         continue;
       }
     }
@@ -1632,18 +1625,25 @@ function _computeRecovery({
 
   1. If a recovery proposal endorse point has been reached, mark its event as
      endorsed.
-  2. Tally all endorsed recovery proposals and "met no progress threshold"
-     from most recent ancestors, using the event's tree parent (not itself)
-     when processing its branch. A "met no progress threshold" occurs when an
-     event has a recovery proposal, or it has no decision proposal but its
-     `noProgressCounter` is greater than or equal to the
+  2. Iterate over all most recent ancestor events from recovery electors and
+     tally decision proposals, endorsed recovery proposals, and "met no
+     progress threshold" from most recent ancestors, using the event's tree
+     parent (not itself) when processing its branch. The count for "met no
+     progress threshold" is incremented when an event has a recovery proposal
+     or its `noProgressCounter` is greater than or equal to the
      `recoveryGenerationThreshold`.
-  3. If >= `2r+1` endorsed recovery proposals, enter recovery mode.
-  4. Otherwise, if event's branch has a decision proposal and >= r+1 endorsed
+  3. If a recovery proposal exists on event's branch and >= `r+1` decision
+     proposals (endorsed or not, same or different from one another) exist,
+     then reject the recovery proposal and, if it was endorsed by the current
+     event, decrement the tally counter for endorsed recovery proposals.
+  4. If >= `2r+1` endorsed recovery proposals, enter recovery mode.
+  5. Otherwise, if event's branch has a decision proposal and >= r+1 endorsed
      recovery proposals exist, reject the decision proposal.
-  5. If the event's branch has no recovery proposal and no decision proposal
-     and the "met no progress threshold" tally is >= `2r+1`, then create a
-     recovery proposal on the event and compute its future endorse point.
+  6. If the event's branch has no recovery proposal and no decision proposal
+     and the "met no progress threshold" tally is >= `2r+1` and there are
+     < `r+1` decision proposals (endorsed or not, same or different from one
+     another), then create a recovery proposal on the event and compute its
+     future endorse point.
   */
 
   /*
@@ -1657,19 +1657,18 @@ function _computeRecovery({
   }
 
   /*
-  2. Tally all endorsed recovery proposals and "met no progress threshold"
-     from most recent ancestors, using the event's tree parent (not itself)
-     when processing its branch. A "met no progress threshold" occurs when an
-     event has a recovery proposal, or it has no decision proposal but its
-     `noProgressCounter` is greater than or equal to the
+  2. Iterate over all most recent ancestor events from recovery electors and
+     tally decision proposals, endorsed recovery proposals, and "met no
+     progress threshold" from most recent ancestors, using the event's tree
+     parent (not itself) when processing its branch. The count for "met no
+     progress threshold" is incremented when an event has a recovery proposal
+     or its `noProgressCounter` is greater than or equal to the
      `recoveryGenerationThreshold`.
   */
+  let decisionProposals = 0;
   let endorsedRecoveryProposals = 0;
   let meetThreshold = 0;
-  const recoverySupermajority = api.supermajority(recoveryElectors.length);
   const recoverySet = new Set(recoveryElectors.map(e => e.id));
-  // use most recent ancestors (using tree parent for own branch unless it is
-  // the first event)
   const creator = _getCreator(event);
   const {mostRecentAncestors} = event._index;
   for(const recoveryElector in mostRecentAncestors) {
@@ -1682,20 +1681,40 @@ function _computeRecovery({
       // ancestor is not a recovery elector
       continue;
     }
+    if(ancestorEvent._proposal) {
+      decisionProposals++;
+    }
     if(_hasEndorsedRecoveryProposal(ancestorEvent)) {
       endorsedRecoveryProposals++;
     }
-    if(!ancestorEvent._proposal &&
-      (ancestorEvent._recovery.proposal ||
+    if(ancestorEvent._recovery.proposal ||
       ancestorEvent._recovery.noProgressCounter >=
-        recoveryGenerationThreshold)) {
+        recoveryGenerationThreshold) {
       meetThreshold++;
     }
   }
 
   /*
-  3. If >= `2r+1` endorsed recovery proposals, enter recovery mode.
+  3. If a recovery proposal exists on event's branch and >= `r+1` decision
+     proposals (endorsed or not, same or different from one another) exist,
+     then reject the recovery proposal and, if it was endorsed by the current
+     event, decrement the tally counter for endorsed recovery proposals.
   */
+  const rPlusOne = api.maximumFailures(recoveryElectors.length) + 1;
+  const decisionShouldBeMade = decisionProposals >= rPlusOne;
+  if(recovery.proposal && decisionShouldBeMade) {
+    // adjust tally if necessary and reject recovery proposal because a
+    // decision should be made instead
+    if(event._endorses && event._endorses.includes(recovery.proposal)) {
+      endorsedRecoveryProposals--;
+    }
+    delete recovery.proposal;
+  }
+
+  /*
+  4. If >= `2r+1` endorsed recovery proposals, enter recovery mode.
+  */
+  const recoverySupermajority = api.supermajority(recoveryElectors.length);
   if(endorsedRecoveryProposals >= recoverySupermajority) {
     // enter recovery mode
     const err = new Error('New electors required.');
@@ -1704,21 +1723,23 @@ function _computeRecovery({
   }
 
   /*
-  4. Otherwise, if event's branch has a decision proposal and >= r+1 endorsed
+  5. Otherwise, if event's branch has a decision proposal and >= r+1 endorsed
      recovery proposals exist, reject the decision proposal.
   */
-  const r = api.maximumFailures(recoveryElectors.length);
-  if(event._proposal && endorsedRecoveryProposals >= (r + 1)) {
+  if(event._proposal && endorsedRecoveryProposals >= rPlusOne) {
+    // reject decision proposal because recovery mode should be entered instead
     delete event._proposal;
   }
 
   /*
-  5. If the event's branch has no recovery proposal and no decision proposal
-     and the "met no progress threshold" tally is >= `2r+1`, then create a
-     recovery proposal on the event and compute its future endorse point.
+  6. If the event's branch has no recovery proposal and no decision proposal
+     and the "met no progress threshold" tally is >= `2r+1` and there are
+     < `r+1` decision proposals (endorsed or not, same or different from one
+     another), then create a recovery proposal on the event and compute its
+     future endorse point.
   */
   if(!recovery.proposal && !event._proposal &&
-    meetThreshold >= recoverySupermajority) {
+    meetThreshold >= recoverySupermajority && !decisionShouldBeMade) {
     recovery.proposal = event;
     _computeEndorser({
       ledgerNodeId, event, recoveryElectors, recoverySupermajority
@@ -1772,6 +1793,8 @@ function _computeSupport({
        next choice (endorsement not required), propose it.
        CAVEAT: If `recoveryElectors.length > 0` and a recovery proposal has
        been made on the event's branch, do not create the proposal.
+       Note: This proposal will be immediately rejected when recovery rules are
+       applied if there are >= r+1 recovery proposals in the system.
   */
 
   const creator = _getCreator(event);
@@ -1978,21 +2001,25 @@ function _computeSupport({
 
   // Note: While "endorsement" (specifically, the `_endorses` flag) is shared
   // with recovery mode computations, recovery computations always happen
-  // *after* this code is run, which ensures that it is not possible to endorse
-  // a proposal that has been rejected. We do not need to add code to adjust
-  // the tally during rejection.
+  // *after* this above tally code is run, which ensures that it is not
+  // possible to count an endorsed proposal that has been rejected. If the
+  // proposal is rejected, it will not be added to the current event and would
+  // not be tallied in any subsequent call on a new event that has the
+  // current event in its ancestry. We do not need to add code to adjust the
+  // tally for a decision proposal rejection.
   if(event._endorses) {
-    // endorse point reached
+    // endorse point reached...
+    // Note: `proposal` might be marked as endorsed even though we rejected
+    // it because a reference to it could be in `event._endorses`; but the
+    // `notRejectedAndNotEndorsedBefore` flag prevents us from counting it if
+    // it was rejected. The proposal will never be counted again after this if
+    // it was rejected because it will not be attached to the event (and
+    // therefore will not be seen on the branch at any point at or beyond its
+    // endorser).
     const notRejectedAndNotEndorsedBefore = proposal && !proposal._endorsed;
     event._endorses.forEach(e => e._endorsed = true);
     // if proposal existed and was not endorsed before but now is
     // endorsed, ensure counts are updated...
-    // Note: The proposal event might be marked as endorsed even though
-    // we rejected it; but the `notRejectedAndNotEndorsedBefore` flag prevents
-    // us from counting it if it was rejected. The proposal will never be
-    // counted again after this if it was rejected because it will not be
-    // attached to the event (and therefore will not be seen on the branch at
-    // any point at or beyond its endorser).
     if(notRejectedAndNotEndorsedBefore && proposal._endorsed) {
       nextChoice.endorsedProposalCount++;
       if(recoverySet.has(creator)) {
@@ -2023,6 +2050,8 @@ function _computeSupport({
   // If the next choice has a supermajority and has no existing (unrejected)
   // proposal, so create a new one. CAVEAT: If `recoveryElectors > 0` and
   // event has a recovery proposal in its ancestry, do not create proposal.
+  // Note: This proposal will be immediately rejected when recovery rules are
+  // applied if there are >= r+1 recovery proposals in the system.
   if(hasSupermajority && !proposal &&
     !(event._recovery && event._recovery.proposal)) {
     // no proposal yet, use current event

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -1479,24 +1479,28 @@ function _computeRecovery({
      recovery endorsement chain, reset the counter and calculate the next event
      on the chain, otherwise increment it.
   2. Iterate over most recent ancestor events from all electors and
-     tally decision proposals, endorsed recovery proposals, and "met no
-     progress threshold"s from most recent ancestors, using `event` when
-     processing its own branch (instead of its tree parent). The count for
+     tally endorsed decision proposals, endorsed recovery proposals, and
+     "met no progress threshold"s from most recent ancestors, using `event`
+     when processing its own branch (instead of its tree parent). The count for
      "met no progress threshold" is incremented when an event's
      `noProgressCounter` is greater than or equal to the
      `recoveryGenerationThreshold`.
   3. If event's branch has an existing recovery proposal decide if it should
      be rejected. Reject it if either the "met no progress threshold" is
-     < `2r+1` or if the tallied decision proposals >= `f+1`. Adjust the
-     endorsed recovery proposal count if necessary.
+     < `2r+1` or if the tallied endorsed decision proposals >= `f+1`. Note
+     that the decision proposals must be endorsed to create overlap with
+     `r+1` recovery proposals. Adjust the endorsed recovery proposal count if
+     necessary.
   4. If a recovery proposal endorse point has been reached; mark any matching
      recovery proposal as endorsed. Adjust the endorsed recovery proposal
      count if necessary.
   5. If >= `r+1` endorsed recovery proposals, enter recovery mode.
   6. Otherwise, if the event's branch has no recovery proposal, no decision
      proposal, the "met no progress threshold" tally is >= `2r+1`, and there
-     are < `f+1` decision proposals, then create a recovery proposal on the
-     event and compute its future endorse point.
+     are < `f+1` endorsed decision proposals, then create a recovery proposal
+     on the event and compute its future endorse point. Note that the decision
+     proposals need to be endorsed to create an overlap with `r+1` recovery
+     proposals.
   */
 
   /*
@@ -1529,14 +1533,14 @@ function _computeRecovery({
 
   /*
   2. Iterate over most recent ancestor events from all electors and
-     tally decision proposals, endorsed recovery proposals, and "met no
-     progress threshold"s from most recent ancestors, using `event` when
-     processing its own branch (instead of its tree parent). The count for
+     tally endorsed decision proposals, endorsed recovery proposals, and
+     "met no progress threshold"s from most recent ancestors, using `event`
+     when processing its own branch (instead of its tree parent). The count for
      "met no progress threshold" is incremented when an event's
      `noProgressCounter` is greater than or equal to the
      `recoveryGenerationThreshold`.
   */
-  let decisionProposals = 0;
+  let endorsedDecisionProposals = 0;
   let endorsedRecoveryProposals = 0;
   let meetThreshold = 0;
   const recoverySet = new Set(recoveryElectors.map(e => e.id));
@@ -1552,8 +1556,8 @@ function _computeRecovery({
       continue;
     }
     // always count decision proposals, regardless of recovery elector status
-    if(ancestorEvent._proposal) {
-      decisionProposals++;
+    if(_hasEndorsedProposal(ancestorEvent)) {
+      endorsedDecisionProposals++;
     }
     if(!recoverySet.has(elector)) {
       // ancestor is not a recovery elector
@@ -1571,13 +1575,16 @@ function _computeRecovery({
   /*
   3. If event's branch has an existing recovery proposal decide if it should
      be rejected. Reject it if either the "met no progress threshold" is
-     < `2r+1` or if the tallied decision proposals >= `f+1`.
+     < `2r+1` or if the tallied endorsed decision proposals >= `f+1`. Note
+     that the decision proposals must be endorsed to create overlap with
+     `r+1` recovery proposals. Adjust the endorsed recovery proposal count if
+     necessary.
   */
   const f = api.maximumFailures(electors.length);
   const recoverySupermajority = api.supermajority(recoveryElectors.length);
   if(recovery.proposal &&
     ((meetThreshold < recoverySupermajority) ||
-    (decisionProposals >= (f + 1)))) {
+    (endorsedDecisionProposals >= (f + 1)))) {
     // reject recovery proposal, adjusting counts as needed
     if(_hasEndorsedRecoveryProposal(event)) {
       endorsedRecoveryProposals--;
@@ -1611,11 +1618,14 @@ function _computeRecovery({
   /*
   6. Otherwise, if the event's branch has no recovery proposal, no decision
      proposal, the "met no progress threshold" tally is >= `2r+1`, and there
-     are < `f+1` decision proposals, then create a recovery proposal on the
-     event and compute its future endorse point.
+     are < `f+1` endorsed decision proposals, then create a recovery proposal
+     on the event and compute its future endorse point. Note that the decision
+     proposals need to be endorsed to create an overlap with `r+1` recovery
+     proposals.
   */
   if(!recovery.proposal && !event._proposal &&
-    meetThreshold >= recoverySupermajority && (decisionProposals < (f + 1))) {
+    meetThreshold >= recoverySupermajority &&
+    (endorsedDecisionProposals < (f + 1))) {
     recovery.proposal = event;
     _computeRecoveryEndorsement({
       ledgerNodeId, event, electors, recoveryElectors, recoverySupermajority

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -1653,7 +1653,7 @@ function _computeSupport({
     1. If support is not for the proposal, reject.
     2. Otherwise, if >= f+1 support something other than the proposal and
        each of those sets is a larger set and has been endorsed, reject.
-    3. If not rejected, see if >= 2f+1 endorsed proposals for the same thing
+    3. If not rejected, see if >= f+1 endorsed proposals for the same thing
        we support, decide. CAVEAT: If `recoveryElectors.length > 0`, then
        a decision can only be made when `recoveryDecisionThreshold` decision
        events, each created by a recovery elector that does not have a pending
@@ -1901,11 +1901,11 @@ function _computeSupport({
   }
 
   /*
-  If existing proposal intact and a supermajority of endorsed proposals
+  If existing proposal intact and at least `f+1` of endorsed proposals
   support the same set, then consensus has been reached. Otherwise, continue
   on and hope the next event will decide...
   */
-  if(proposal && nextChoice.endorsedProposalCount >= supermajority) {
+  if(proposal && nextChoice.endorsedProposalCount >= (f + 1)) {
     // TODO: can we optimize such that once `_decision` is set ... skip all
     // the tallying and just check `_consensusReached` at the top of the
     // function? ...what else needs to be propagated for this to work?

--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -1227,12 +1227,6 @@ function _useMostRecentAncestorEvent({
 }
 
 function _updateRecoveryInfo({electors, recoveryElectors, yByElector, event}) {
-  // forward existing proposal on the event's branch
-  if(!event._recovery.proposal &&
-    event._treeParent && event._treeParent._recovery.proposal) {
-    event._recovery.proposal = event._treeParent._recovery.proposal;
-  }
-
   // if a recovery proposal has been created on the event's branch already,
   // return, there's nothing more to do here, just waiting for other branches
   // to either decide or propose recovery mode

--- a/lib/election.js
+++ b/lib/election.js
@@ -55,7 +55,6 @@ api._findMergeEventProof = api._consensus._findMergeEventProof;
  *          must be given if `recoveryElectors` is given.
  * @param [mode='first'] an optional mode for selecting which events
  *          to find consensus on:
- *          // FIXME: change default to `first` in code
  *          first: create support sets from the first (aka "tail" or oldest)
  *            event from each participating elector and return the events that
  *            are in the consensus support set as having reached consensus
@@ -89,7 +88,7 @@ api._findMergeEventProof = api._consensus._findMergeEventProof;
 api.findConsensus = callbackify(async ({
   ledgerNode, history, blockHeight, electors,
   recoveryElectors = [], recoveryGenerationThreshold,
-  mode = 'firstWithConsensusProof'
+  mode = 'first'
 }) => {
   logger.verbose('Start sync _runConsensusInPool, electors', {electors});
   const timer = new _cache.Timer();

--- a/lib/election.js
+++ b/lib/election.js
@@ -53,9 +53,23 @@ api._findMergeEventProof = api._consensus._findMergeEventProof;
  * @param [recoveryGenerationThreshold] the "no progress" merge event
  *          generation threshold required to enter recovery mode; this
  *          must be given if `recoveryElectors` is given.
- * @param [recoveryDecisionThreshold] the number of recovery electors
- *          that must see a decision before accepting it as final; this
- *          must be given if `recoveryElectors` is given.
+ * @param [mode='first'] an optional mode for selecting which events
+ *          to find consensus on:
+ *          // FIXME: change default to `first` in code
+ *          first: create support sets from the first (aka "tail" or oldest)
+ *            event from each participating elector and return the events that
+ *            are in the consensus support set as having reached consensus
+ *            (i.e., `eventHashes`) (mode is aka "Ys are Xs").
+ *          firstWithConsensusProof: create support sets from the first
+ *            endorsement event for the first (aka "tail" or oldest) event from
+ *            each participating elector and return the consensus support set
+ *            and all ancestors until the associated tail events as
+ *            `consensusProofHashes` and the tails associated with the
+ *            endorsement events as having reached consensus (i.e.,
+ *            `eventHashes`) (mode is aka "Y is the endorsement of X").
+ *          batch: the same as `firstWithConsensusProof` except all
+ *            `consensusProofHashes` are instead also returned as having
+ *            reached consensus in `eventHashes`.
  *
  * @return a Promise that resolves to `null` if no consensus has been reached
  *    or an object if consensus has been reached, where:
@@ -65,7 +79,8 @@ api._findMergeEventProof = api._consensus._findMergeEventProof;
  */
 api.findConsensus = callbackify(async ({
   ledgerNode, history, blockHeight, electors,
-  recoveryElectors = [], recoveryGenerationThreshold, recoveryDecisionThreshold
+  recoveryElectors = [], recoveryGenerationThreshold,
+  mode = 'firstWithConsensusProof'
 }) => {
   logger.verbose('Start sync _runConsensusInPool, electors', {electors});
   const timer = new _cache.Timer();
@@ -74,7 +89,7 @@ api.findConsensus = callbackify(async ({
   try {
     consensus = await _runConsensusInPool({
       ledgerNode, history, blockHeight, electors,
-      recoveryElectors, recoveryGenerationThreshold, recoveryDecisionThreshold
+      recoveryElectors, recoveryGenerationThreshold, mode
     });
   } finally {
     const duration = await timer.stop();
@@ -241,15 +256,14 @@ api.isBlockElector = (voter, electors) => {
 
 async function _runConsensusInPool({
   ledgerNode, history, blockHeight, electors,
-  recoveryElectors, recoveryGenerationThreshold, recoveryDecisionThreshold
+  recoveryElectors, recoveryGenerationThreshold, mode
 }) {
   const cfg = bedrock.config['ledger-consensus-continuity'].consensus;
   if(!cfg.workerpool.enabled) {
     // run consensus directly
     return api._consensus.findConsensus({
       ledgerNodeId: ledgerNode.id, history, blockHeight, electors,
-      recoveryElectors, recoveryGenerationThreshold, recoveryDecisionThreshold,
-      logger
+      recoveryElectors, recoveryGenerationThreshold, mode, logger
     });
   }
 
@@ -265,7 +279,8 @@ async function _runConsensusInPool({
       localBranchHead: history.localBranchHead
     },
     blockHeight, electors, recoveryElectors,
-    recoveryGenerationThreshold, recoveryDecisionThreshold});
+    recoveryGenerationThreshold, mode
+  });
 }
 
 // FIXME: documentation

--- a/lib/election.js
+++ b/lib/election.js
@@ -85,7 +85,6 @@ api._findMergeEventProof = api._consensus._findMergeEventProof;
  *           electors: all electors that could have participated.
  *           recoveryElectors: all recovery electors that could have
  *             participated.
-
  */
 api.findConsensus = callbackify(async ({
   ledgerNode, history, blockHeight, electors,

--- a/lib/election.js
+++ b/lib/election.js
@@ -71,11 +71,21 @@ api._findMergeEventProof = api._consensus._findMergeEventProof;
  *            `consensusProofHashes` are instead also returned as having
  *            reached consensus in `eventHashes`.
  *
- * @return a Promise that resolves to `null` if no consensus has been reached
- *    or an object if consensus has been reached, where:
- *      `eventHash` the hashes of all events that have reached
- *        consensus in order according to `Continuity2017`.
- *      `consensusProofHash` the hashes of all merge events proving consensus.
+ * @return a Promise that resolves to a result object with the following
+ *         properties:
+ *           consensus: `true` if consensus has been found, `false` if` not.
+ *           eventHash: the hashes of all events that have reached
+ *             consensus in order according to `Continuity2017`.
+ *           consensusProofHash: the hashes of events endorsing `eventHash`,
+ *             if using mode=`firstWithConsensusProof`.
+ *           needsMergeEvent: `true` if consensus is `false` and another merge
+ *             event is needed from the node matching `ledgerNodeId`.
+ *           creators: the electors that participated in events that reached
+ *             consensus.
+ *           electors: all electors that could have participated.
+ *           recoveryElectors: all recovery electors that could have
+ *             participated.
+
  */
 api.findConsensus = callbackify(async ({
   ledgerNode, history, blockHeight, electors,
@@ -85,9 +95,9 @@ api.findConsensus = callbackify(async ({
   logger.verbose('Start sync _runConsensusInPool, electors', {electors});
   const timer = new _cache.Timer();
   timer.start({name: 'findConsensus', ledgerNodeId: ledgerNode.id});
-  let consensus;
+  let result;
   try {
-    consensus = await _runConsensusInPool({
+    result = await _runConsensusInPool({
       ledgerNode, history, blockHeight, electors,
       recoveryElectors, recoveryGenerationThreshold, mode
     });
@@ -97,19 +107,22 @@ api.findConsensus = callbackify(async ({
   }
 
   // no consensus found
-  if(!consensus) {
-    return null;
+  if(!result.consensus) {
+    return {...result, electors, recoveryElectors};
   }
 
   const eventHash = await _getAncestors({
-    blockHeight, hashes: consensus.eventHashes, ledgerNode});
+    blockHeight, hashes: result.eventHashes, ledgerNode});
   const hashSet = new Set(eventHash);
-  const order = consensus.eventHashes.order.filter(h => hashSet.has(h));
+  const order = result.eventHashes.order.filter(h => hashSet.has(h));
   return {
-    consensusProofHash: consensus.consensusProofHashes,
-    creators: consensus.creators,
+    consensus: true,
+    consensusProofHash: result.consensusProofHashes,
+    creators: result.creators,
     eventHash: order,
-    mergeEventHash: consensus.eventHashes.mergeEventHashes,
+    mergeEventHash: result.eventHashes.mergeEventHashes,
+    electors,
+    recoveryElectors
   };
 });
 
@@ -278,7 +291,7 @@ async function _runConsensusInPool({
   });
 }
 
-// FIXME: documentation
+// TODO: documentation
 async function _getAncestors({blockHeight, hashes, ledgerNode}) {
   // must look up `hashes.parentHashes` to filter out only the ones that
   // have not reached consensus yet

--- a/lib/election.js
+++ b/lib/election.js
@@ -199,18 +199,19 @@ api.getBlockElectors = callbackify(async (
     }
 
     // validate that `recoveryElectors` is either empty or a subset of
-    // `electors` with length `f+1`
+    // `electors` and forms a `3r+1` size set
     const {recoveryElectors} = result;
     if(recoveryElectors.length > 0) {
-      if(recoveryElectors.length < (f + 1)) {
+      const r = (recoveryElectors.length - 1) / 3;
+      if(!Number.isInteger(r)) {
         throw new BedrockError(
-          'Recovery electors do not form a set of size ">= f+1"; recovery ' +
-          `electors count is ${recoveryElectors.length} and "f" is ${f}.`,
+          'Recovery electors do not form a set of size "3r+1"; recovery ' +
+          `electors count is ${recoveryElectors.length}, "r" is ${r}, and ' +
+          '"f" is ${f}.`,
           'InvalidStateError');
       }
 
-      // FIXME: is this a requirement?? Because it's problematic.
-      // see note in _computeRecoveryElectors in 100-recovery-mode test
+      // ensure recovery electors are a subset of electors
       const electorIds = new Set(electors.map(e => e.id));
       const recoveryIds = recoveryElectors.map(e => e.id);
       if(!recoveryIds.every(id => electorIds.has(id))) {
@@ -226,12 +227,6 @@ api.getBlockElectors = callbackify(async (
           '"recoveryGenerationThreshold" must be a number when ' +
           'recovery electors are specified.', 'InvalidStateError');
       }
-
-      // forcibly set recovery decision threshold to a majority of the recovery
-      // electors; ties go to the "decision" over recovery mode (e.g. if
-      // using 4 recovery electors, threshold for a decision is 2)
-      const recoveryDecisionThreshold = Math.ceil(recoveryElectors.length / 2);
-      result.recoveryDecisionThreshold = recoveryDecisionThreshold;
     }
   }
 

--- a/test/mocha/066-election_findMergeEventProof.js
+++ b/test/mocha/066-election_findMergeEventProof.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2017-2018 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2017-2019 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 
@@ -126,352 +126,699 @@ describe('Election API _findMergeEventProof', () => {
         }, callback)]
     }, done);
   });
-  it('ledger history alpha', done => {
-    const report = {};
-    async.auto({
-      build: callback => helpers.buildHistory(
-        {consensusApi, historyId: 'alpha', mockData, nodes}, callback),
-      testAll: ['build', (results, callback) => {
-        // NOTE: for ledger history alpha, all nodes should have the same view
-        const build = results.build;
-        // all peers are electors
-        const electors = _.values(peers).map(p => ({id: p}));
-        async.eachOfSeries(nodes, (ledgerNode, i, callback) => async.auto({
-          history: callback => getRecentHistory({
-            creatorId: nodes[i].creatorId,
-            ledgerNode, excludeLocalRegularEvents: true}, callback),
-          proof: ['history', (results, callback) => {
-            const branches = _getElectorBranches({
-              history: results.history,
-              electors
-            });
-            const proof = _findMergeEventProof({
-              ledgerNode,
-              history: results.history,
-              tails: branches,
-              electors
-            });
-            // try {
-            //   report[i] = proofReport({
-            //     proof,
-            //     copyMergeHashes: build.copyMergeHashes,
-            //     copyMergeHashesIndex: build.copyMergeHashesIndex});
-            // } catch(e) {
-            //   report[i] = 'NO PROOF';
-            // }
-            const allXs = proof.consensus.map(p => p.x.eventHash);
-            allXs.should.have.length(4);
-            allXs.should.have.same.members(build.regularEvent.mergeHash);
-            const allYs = proof.consensus.map(p => p.y.eventHash);
-            allYs.should.have.length(4);
-            allYs.should.have.same.members([
-              build.copyMergeHashes.cp5, build.copyMergeHashes.cp6,
-              build.copyMergeHashes.cp7, build.copyMergeHashes.cp8
-            ]);
-            callback();
-          }]
-        }, callback), callback);
-      }]
-    }, err => {
-      // console.log('FINAL REPORT', JSON.stringify(report, null, 2));
-      done(err);
+
+  describe('"first" mode', () => {
+    it('ledger history alpha', done => {
+      const report = {};
+      async.auto({
+        build: callback => helpers.buildHistory(
+          {consensusApi, historyId: 'alpha', mockData, nodes}, callback),
+        testAll: ['build', (results, callback) => {
+          // NOTE: for ledger history alpha, all nodes should have the same view
+          const build = results.build;
+          // all peers are electors
+          const electors = _.values(peers).map(p => ({id: p}));
+          async.eachOfSeries(nodes, (ledgerNode, i, callback) => async.auto({
+            history: callback => getRecentHistory({
+              creatorId: nodes[i].creatorId,
+              ledgerNode, excludeLocalRegularEvents: true}, callback),
+            proof: ['history', (results, callback) => {
+              const branches = _getElectorBranches({
+                history: results.history,
+                electors
+              });
+              const proof = _findMergeEventProof({
+                ledgerNode,
+                history: results.history,
+                tails: branches,
+                electors,
+                mode: 'first'
+              });
+              // try {
+              //   report[i] = proofReport({
+              //     proof,
+              //     copyMergeHashes: build.copyMergeHashes,
+              //     copyMergeHashesIndex: build.copyMergeHashesIndex});
+              // } catch(e) {
+              //   report[i] = 'NO PROOF';
+              // }
+              const allXs = proof.consensus.map(p => p.x.eventHash);
+              allXs.should.have.length(4);
+              allXs.should.have.same.members(build.regularEvent.mergeHash);
+              const allYs = proof.consensus.map(p => p.y.eventHash);
+              allYs.should.have.length(4);
+              allYs.should.have.same.members(build.regularEvent.mergeHash);
+              callback();
+            }]
+          }, callback), callback);
+        }]
+      }, err => {
+        // console.log('FINAL REPORT', JSON.stringify(report, null, 2));
+        done(err);
+      });
     });
-  });
-  it('ledger history beta', done => {
-    const report = {};
-    async.auto({
-      build: callback => helpers.buildHistory(
-        {consensusApi, historyId: 'beta', mockData, nodes}, callback),
-      testAlpha: ['build', (results, callback) => {
-        const build = results.build;
-        // all peers are electors
-        const electors = _.values(peers).map(p => ({id: p}));
-        async.eachOfSeries(nodes, (ledgerNode, i, callback) => async.auto({
-          history: callback => getRecentHistory({
-            creatorId: nodes[i].creatorId,
-            ledgerNode, excludeLocalRegularEvents: true}, callback),
-          branches: ['history', (results, callback) => {
-            const branches = _getElectorBranches({
-              history: results.history,
-              electors
-            });
-            callback(null, branches);
-          }],
-          proof: ['branches', (results, callback) => {
-            const proof = _findMergeEventProof({
-              ledgerNode,
-              history: results.history,
-              tails: results.branches,
-              electors
-            });
-            // try {
-            //   report[i] = proofReport({
-            //     proof,
-            //     copyMergeHashes: build.copyMergeHashes,
-            //     copyMergeHashesIndex: build.copyMergeHashesIndex});
-            // } catch(e) {
-            //   report[i] = 'NO PROOF';
-            // }
-            const allXs = proof.consensus.map(p => p.x.eventHash);
-            allXs.should.have.length(4);
-            allXs.should.have.same.members(build.regularEvent.mergeHash);
-            const allYs = proof.consensus.map(p => p.y.eventHash);
-            allYs.should.have.length(4);
-            allYs.should.have.same.members([
-              build.copyMergeHashes.cp5, build.copyMergeHashes.cp6,
-              build.copyMergeHashes.cp7, build.copyMergeHashes.cp8
-            ]);
-            callback();
-          }]
-        }, callback), callback);
-      }]
-    }, err => {
-      // console.log('FINAL REPORT', JSON.stringify(report, null, 2));
-      done(err);
+    it('ledger history beta', done => {
+      const report = {};
+      async.auto({
+        build: callback => helpers.buildHistory(
+          {consensusApi, historyId: 'beta', mockData, nodes}, callback),
+        testAlpha: ['build', (results, callback) => {
+          const build = results.build;
+          // all peers are electors
+          const electors = _.values(peers).map(p => ({id: p}));
+          async.eachOfSeries(nodes, (ledgerNode, i, callback) => async.auto({
+            history: callback => getRecentHistory({
+              creatorId: nodes[i].creatorId,
+              ledgerNode, excludeLocalRegularEvents: true}, callback),
+            branches: ['history', (results, callback) => {
+              const branches = _getElectorBranches({
+                history: results.history,
+                electors
+              });
+              callback(null, branches);
+            }],
+            proof: ['branches', (results, callback) => {
+              const proof = _findMergeEventProof({
+                ledgerNode,
+                history: results.history,
+                tails: results.branches,
+                electors,
+                mode: 'first'
+              });
+              // try {
+              //   report[i] = proofReport({
+              //     proof,
+              //     copyMergeHashes: build.copyMergeHashes,
+              //     copyMergeHashesIndex: build.copyMergeHashesIndex});
+              // } catch(e) {
+              //   report[i] = 'NO PROOF';
+              // }
+              const allXs = proof.consensus.map(p => p.x.eventHash);
+              allXs.should.have.length(4);
+              allXs.should.have.same.members(build.regularEvent.mergeHash);
+              const allYs = proof.consensus.map(p => p.y.eventHash);
+              allYs.should.have.length(4);
+              allYs.should.have.same.members(build.regularEvent.mergeHash);
+              callback();
+            }]
+          }, callback), callback);
+        }]
+      }, err => {
+        // console.log('FINAL REPORT', JSON.stringify(report, null, 2));
+        done(err);
+      });
+    }); // end test 2
+    it('ledger history gamma', function(done) {
+      this.timeout(120000);
+      const report = {};
+      async.auto({
+        build: callback => helpers.buildHistory(
+          {consensusApi, historyId: 'gamma', mockData, nodes}, callback),
+        testAll: ['build', (results, callback) => {
+          const build = results.build;
+          // all peers are electors
+          const electors = _.values(peers).map(p => ({id: p}));
+          async.eachOfSeries(nodes, (ledgerNode, i, callback) => async.auto({
+            history: callback => getRecentHistory({
+              creatorId: nodes[i].creatorId,
+              ledgerNode, excludeLocalRegularEvents: true}, callback),
+            branches: ['history', (results, callback) => {
+              const branches = _getElectorBranches({
+                history: results.history,
+                electors
+              });
+              callback(null, branches);
+            }],
+            proof: ['branches', (results, callback) => {
+              const proof = _findMergeEventProof({
+                ledgerNode,
+                history: results.history,
+                tails: results.branches,
+                electors,
+                mode: 'first'
+              });
+              // try {
+              //   report[i] = proofReport({
+              //     proof,
+              //     copyMergeHashes: build.copyMergeHashes,
+              //     copyMergeHashesIndex: build.copyMergeHashesIndex});
+              // } catch(e) {
+              //   report[i] = 'NO PROOF';
+              // }
+              const allXs = proof.consensus.map(p => p.x.eventHash);
+              allXs.should.have.length(4);
+              allXs.should.have.same.members(build.regularEvent.mergeHash);
+              const allYs = proof.consensus.map(p => p.y.eventHash);
+              allYs.should.have.length(4);
+              allYs.should.have.same.members(build.regularEvent.mergeHash);
+              callback();
+            }]
+          }, callback), callback);
+        }]
+      }, err => {
+        // console.log('FINAL REPORT', JSON.stringify(report, null, 2));
+        done(err);
+      });
     });
-  }); // end test 2
-  it('ledger history gamma', function(done) {
-    this.timeout(120000);
-    const report = {};
-    async.auto({
-      build: callback => helpers.buildHistory(
-        {consensusApi, historyId: 'gamma', mockData, nodes}, callback),
-      testAll: ['build', (results, callback) => {
-        const build = results.build;
-        // all peers are electors
-        const electors = _.values(peers).map(p => ({id: p}));
-        async.eachOfSeries(nodes, (ledgerNode, i, callback) => async.auto({
-          history: callback => getRecentHistory({
-            creatorId: nodes[i].creatorId,
-            ledgerNode, excludeLocalRegularEvents: true}, callback),
-          branches: ['history', (results, callback) => {
-            const branches = _getElectorBranches({
-              history: results.history,
-              electors
-            });
-            callback(null, branches);
-          }],
-          proof: ['branches', (results, callback) => {
-            const proof = _findMergeEventProof({
-              ledgerNode,
-              history: results.history,
-              tails: results.branches,
-              electors
-            });
-            // try {
-            //   report[i] = proofReport({
-            //     proof,
-            //     copyMergeHashes: build.copyMergeHashes,
-            //     copyMergeHashesIndex: build.copyMergeHashesIndex});
-            // } catch(e) {
-            //   report[i] = 'NO PROOF';
-            // }
-            const allXs = proof.consensus.map(p => p.x.eventHash);
-            allXs.should.have.length(4);
-            allXs.should.have.same.members(build.regularEvent.mergeHash);
-            const allYs = proof.consensus.map(p => p.y.eventHash);
-            allYs.should.have.length(4);
-            allYs.should.have.same.members([
-              build.copyMergeHashes.cp5, build.copyMergeHashes.cp6,
-              build.copyMergeHashes.cp7, build.copyMergeHashes.cp8
-            ]);
-            callback();
-          }]
-        }, callback), callback);
-      }]
-    }, err => {
-      // console.log('FINAL REPORT', JSON.stringify(report, null, 2));
-      done(err);
-    });
-  });
-  // involves 4 elector nodes and one non-elector
-  it('ledger history delta produces same as alpha result', function(done) {
-    this.timeout(120000);
-    const report = {};
-    // add node epsilon for this test and remove it afterwards
-    async.auto({
-      nodeEpsilon: callback => async.auto({
-        add: callback => brLedgerNode.add(
-          null, {genesisBlock}, (err, result) => {
-            if(err) {
-              return callback(err);
-            }
-            nodes.epsilon = result;
-            nodes.epsilon.eventWriter = new EventWriter(
-              {immediate: true, ledgerNode: nodes.epsilon});
-            callback();
-          }),
-        creator: ['add', (results, callback) =>
-          consensusApi._voters.get(
-            {ledgerNodeId: nodes.epsilon.id}, (err, result) => {
+    // involves 4 elector nodes and one non-elector
+    it('ledger history delta produces same as alpha result', function(done) {
+      this.timeout(120000);
+      const report = {};
+      // add node epsilon for this test and remove it afterwards
+      async.auto({
+        nodeEpsilon: callback => async.auto({
+          add: callback => brLedgerNode.add(
+            null, {genesisBlock}, (err, result) => {
               if(err) {
                 return callback(err);
               }
-              peers.epsilon = result.id;
-              nodes.epsilon.creatorId = result.id;
-              helpers.peersReverse[result.id] = 'epsilon';
+              nodes.epsilon = result;
+              nodes.epsilon.eventWriter = new EventWriter(
+                {immediate: true, ledgerNode: nodes.epsilon});
               callback();
-            })]
-      }, callback),
-      build: ['nodeEpsilon', (results, callback) => helpers.buildHistory(
-        {consensusApi, historyId: 'delta', mockData, nodes}, callback)],
-      testAll: ['build', (results, callback) => {
-        // NOTE: for ledger history alpha, all nodes should have the same view
-        const build = results.build;
-        // all peers are electors
-        const electors = _.values(peers).map(p => ({id: p}));
-        async.eachOfSeries(nodes, (ledgerNode, i, callback) => async.auto({
-          history: callback => getRecentHistory({
-            creatorId: nodes[i].creatorId,
-            ledgerNode, excludeLocalRegularEvents: true}, callback),
-          proof: ['history', (results, callback) => {
-            const branches = _getElectorBranches({
-              history: results.history,
-              electors
-            });
-            const proof = _findMergeEventProof({
-              ledgerNode,
-              history: results.history,
-              tails: branches,
-              electors
-            });
-            // try {
-            //   report[i] = proofReport({
-            //     proof,
-            //     copyMergeHashes: build.copyMergeHashes,
-            //     copyMergeHashesIndex: build.copyMergeHashesIndex});
-            // } catch(e) {
-            //   report[i] = 'NO PROOF';
-            // }
-            const allXs = proof.consensus.map(p => p.x.eventHash);
-            allXs.should.have.length(4);
-            const mergeHashes = [
-              build.regularEvent.alpha.mergeHash,
-              build.regularEvent.beta.mergeHash,
-              build.regularEvent.gamma.mergeHash,
-              build.regularEvent.delta.mergeHash
-              // exclude epsilon (non-elector)
-            ];
-            allXs.should.have.same.members(mergeHashes);
-            const allYs = proof.consensus.map(p => p.y.eventHash);
-            allYs.should.have.length(4);
-            allYs.should.have.same.members([
-              build.copyMergeHashes.cp5, build.copyMergeHashes.cp6,
-              build.copyMergeHashes.cp7, build.copyMergeHashes.cp8
-            ]);
-            callback();
-          }]
-        }, callback), callback);
-      }],
-      cleanup: ['testAll', (results, callback) => {
-        delete nodes.epsilon;
-        callback();
-      }]
-    }, err => {
-      // console.log('FINAL REPORT', JSON.stringify(report, null, 2));
-      done(err);
+            }),
+          creator: ['add', (results, callback) =>
+            consensusApi._voters.get(
+              {ledgerNodeId: nodes.epsilon.id}, (err, result) => {
+                if(err) {
+                  return callback(err);
+                }
+                peers.epsilon = result.id;
+                nodes.epsilon.creatorId = result.id;
+                helpers.peersReverse[result.id] = 'epsilon';
+                callback();
+              })]
+        }, callback),
+        build: ['nodeEpsilon', (results, callback) => helpers.buildHistory(
+          {consensusApi, historyId: 'delta', mockData, nodes}, callback)],
+        testAll: ['build', (results, callback) => {
+          // NOTE: for ledger history alpha, all nodes should have the same view
+          const build = results.build;
+          // all peers are electors
+          const electors = _.values(peers).map(p => ({id: p}));
+          async.eachOfSeries(nodes, (ledgerNode, i, callback) => async.auto({
+            history: callback => getRecentHistory({
+              creatorId: nodes[i].creatorId,
+              ledgerNode, excludeLocalRegularEvents: true}, callback),
+            proof: ['history', (results, callback) => {
+              const branches = _getElectorBranches({
+                history: results.history,
+                electors
+              });
+              const proof = _findMergeEventProof({
+                ledgerNode,
+                history: results.history,
+                tails: branches,
+                electors,
+                mode: 'first'
+              });
+              // try {
+              //   report[i] = proofReport({
+              //     proof,
+              //     copyMergeHashes: build.copyMergeHashes,
+              //     copyMergeHashesIndex: build.copyMergeHashesIndex});
+              // } catch(e) {
+              //   report[i] = 'NO PROOF';
+              // }
+              const allXs = proof.consensus.map(p => p.x.eventHash);
+              allXs.should.have.length(4);
+              const mergeHashes = [
+                build.regularEvent.alpha.mergeHash,
+                build.regularEvent.beta.mergeHash,
+                build.regularEvent.gamma.mergeHash,
+                build.regularEvent.delta.mergeHash
+                // exclude epsilon (non-elector)
+              ];
+              allXs.should.have.same.members(mergeHashes);
+              const allYs = proof.consensus.map(p => p.y.eventHash);
+              allYs.should.have.length(4);
+              allYs.should.have.same.members(mergeHashes);
+              callback();
+            }]
+          }, callback), callback);
+        }],
+        cleanup: ['testAll', (results, callback) => {
+          delete nodes.epsilon;
+          callback();
+        }]
+      }, err => {
+        // console.log('FINAL REPORT', JSON.stringify(report, null, 2));
+        done(err);
+      });
+    });
+    // FIXME: enable test
+    it('ledger history epsilon', done => {
+      const report = {};
+      async.auto({
+        build: callback => helpers.buildHistory(
+          {consensusApi, historyId: 'epsilon', mockData, nodes}, callback),
+        testAll: ['build', (results, callback) => {
+          // NOTE: for ledger history alpha, all nodes should have the same view
+          const build = results.build;
+          // all peers are electors
+          const electors = _.values(peers).map(p => ({id: p}));
+          async.eachOfSeries(nodes, (ledgerNode, i, callback) => async.auto({
+            history: callback => getRecentHistory({
+              creatorId: nodes[i].creatorId,
+              ledgerNode, excludeLocalRegularEvents: true}, callback),
+            proof: ['history', (results, callback) => {
+              const branches = _getElectorBranches({
+                history: results.history,
+                electors
+              });
+              const proof = _findMergeEventProof({
+                ledgerNode,
+                history: results.history,
+                tails: branches,
+                electors,
+                mode: 'first'
+              });
+              // try {
+              //   report[i] = proofReport({
+              //     proof,
+              //     copyMergeHashes: build.copyMergeHashes,
+              //     copyMergeHashesIndex: build.copyMergeHashesIndex});
+              // } catch(e) {
+              //   report[i] = 'NO PROOF';
+              // }
+              const allXs = proof.consensus.map(p => p.x.eventHash);
+              allXs.should.have.length(4);
+              allXs.should.have.same.members(build.regularEvent.mergeHash);
+              const allYs = proof.consensus.map(p => p.y.eventHash);
+              allYs.should.have.length(4);
+              allYs.should.have.same.members(build.regularEvent.mergeHash);
+              callback();
+            }]
+          }, callback), callback);
+        }]
+      }, err => {
+        // console.log('REPORT', JSON.stringify(report, null, 2));
+        done(err);
+      });
+    });
+    // add regular event on alpha before running findMergeEventProof on alpha
+    it('add regular local event before getting proof', done => {
+      const ledgerNode = nodes.alpha;
+      const eventTemplate = mockData.events.alpha;
+      const opTemplate = mockData.operations.alpha;
+      async.auto({
+        build: callback => helpers.buildHistory(
+          {consensusApi, historyId: 'alpha', mockData, nodes}, callback),
+        event: ['build', (results, callback) => helpers.addEvent(
+          {ledgerNode, eventTemplate, opTemplate}, callback)],
+        testAll: ['event', (results, callback) => {
+          // NOTE: for ledger history alpha, all nodes should have the same view
+          const build = results.build;
+          // all peers are electors
+          const electors = _.values(peers).map(p => ({id: p}));
+          async.auto({
+            history: callback => getRecentHistory({
+              creatorId: nodes.alpha.creatorId,
+              ledgerNode, excludeLocalRegularEvents: true}, callback),
+            proof: ['history', (results, callback) => {
+              const branches = _getElectorBranches({
+                history: results.history,
+                electors
+              });
+              const proof = _findMergeEventProof({
+                ledgerNode,
+                history: results.history,
+                tails: branches,
+                electors,
+                mode: 'first'
+              });
+              // proofReport({
+              //   proof,
+              //   copyMergeHashes: build.copyMergeHashes,
+              //   copyMergeHashesIndex: build.copyMergeHashesIndex});
+              const allXs = proof.consensus.map(p => p.x.eventHash);
+              allXs.should.have.length(4);
+              allXs.should.have.same.members(build.regularEvent.mergeHash);
+              const allYs = proof.consensus.map(p => p.y.eventHash);
+              allYs.should.have.length(4);
+              allYs.should.have.same.members(build.regularEvent.mergeHash);
+              callback();
+            }]
+          }, callback);
+        }]
+      }, done);
     });
   });
-  // FIXME: enable test
-  it('ledger history epsilon', done => {
-    const report = {};
-    async.auto({
-      build: callback => helpers.buildHistory(
-        {consensusApi, historyId: 'epsilon', mockData, nodes}, callback),
-      testAll: ['build', (results, callback) => {
-        // NOTE: for ledger history alpha, all nodes should have the same view
-        const build = results.build;
-        // all peers are electors
-        const electors = _.values(peers).map(p => ({id: p}));
-        async.eachOfSeries(nodes, (ledgerNode, i, callback) => async.auto({
-          history: callback => getRecentHistory({
-            creatorId: nodes[i].creatorId,
-            ledgerNode, excludeLocalRegularEvents: true}, callback),
-          proof: ['history', (results, callback) => {
-            const branches = _getElectorBranches({
-              history: results.history,
-              electors
-            });
-            const proof = _findMergeEventProof({
-              ledgerNode,
-              history: results.history,
-              tails: branches,
-              electors
-            });
-            // try {
-            //   report[i] = proofReport({
-            //     proof,
-            //     copyMergeHashes: build.copyMergeHashes,
-            //     copyMergeHashesIndex: build.copyMergeHashesIndex});
-            // } catch(e) {
-            //   report[i] = 'NO PROOF';
-            // }
-            const allXs = proof.consensus.map(p => p.x.eventHash);
-            allXs.should.have.length(4);
-            allXs.should.have.same.members(build.regularEvent.mergeHash);
-            const allYs = proof.consensus.map(p => p.y.eventHash);
-            allYs.should.have.length(4);
-            allYs.should.have.same.members([
-              build.copyMergeHashes.cp5, build.copyMergeHashes.cp6,
-              build.copyMergeHashes.cp7, build.copyMergeHashes.cp8
-            ]);
-            callback();
-          }]
-        }, callback), callback);
-      }]
-    }, err => {
-      // console.log('REPORT', JSON.stringify(report, null, 2));
-      done(err);
+
+  describe('"firstWithConsensusProof" mode', () => {
+    it('ledger history alpha', done => {
+      const report = {};
+      async.auto({
+        build: callback => helpers.buildHistory(
+          {consensusApi, historyId: 'alpha', mockData, nodes}, callback),
+        testAll: ['build', (results, callback) => {
+          // NOTE: for ledger history alpha, all nodes should have the same view
+          const build = results.build;
+          // all peers are electors
+          const electors = _.values(peers).map(p => ({id: p}));
+          async.eachOfSeries(nodes, (ledgerNode, i, callback) => async.auto({
+            history: callback => getRecentHistory({
+              creatorId: nodes[i].creatorId,
+              ledgerNode, excludeLocalRegularEvents: true}, callback),
+            proof: ['history', (results, callback) => {
+              const branches = _getElectorBranches({
+                history: results.history,
+                electors
+              });
+              const proof = _findMergeEventProof({
+                ledgerNode,
+                history: results.history,
+                tails: branches,
+                electors,
+                mode: 'firstWithConsensusProof'
+              });
+              // try {
+              //   report[i] = proofReport({
+              //     proof,
+              //     copyMergeHashes: build.copyMergeHashes,
+              //     copyMergeHashesIndex: build.copyMergeHashesIndex});
+              // } catch(e) {
+              //   report[i] = 'NO PROOF';
+              // }
+              const allXs = proof.consensus.map(p => p.x.eventHash);
+              allXs.should.have.length(4);
+              allXs.should.have.same.members(build.regularEvent.mergeHash);
+              const allYs = proof.consensus.map(p => p.y.eventHash);
+              allYs.should.have.length(4);
+              allYs.should.have.same.members([
+                build.copyMergeHashes.cp5, build.copyMergeHashes.cp6,
+                build.copyMergeHashes.cp7, build.copyMergeHashes.cp8
+              ]);
+              callback();
+            }]
+          }, callback), callback);
+        }]
+      }, err => {
+        // console.log('FINAL REPORT', JSON.stringify(report, null, 2));
+        done(err);
+      });
     });
-  });
-  // add regular event on alpha before running findMergeEventProof on alpha
-  it('add regular local event before getting proof', done => {
-    const ledgerNode = nodes.alpha;
-    const eventTemplate = mockData.events.alpha;
-    const opTemplate = mockData.operations.alpha;
-    async.auto({
-      build: callback => helpers.buildHistory(
-        {consensusApi, historyId: 'alpha', mockData, nodes}, callback),
-      event: ['build', (results, callback) => helpers.addEvent(
-        {ledgerNode, eventTemplate, opTemplate}, callback)],
-      testAll: ['event', (results, callback) => {
-        // NOTE: for ledger history alpha, all nodes should have the same view
-        const build = results.build;
-        // all peers are electors
-        const electors = _.values(peers).map(p => ({id: p}));
-        async.auto({
-          history: callback => getRecentHistory({
-            creatorId: nodes.alpha.creatorId,
-            ledgerNode, excludeLocalRegularEvents: true}, callback),
-          proof: ['history', (results, callback) => {
-            const branches = _getElectorBranches({
-              history: results.history,
-              electors
-            });
-            const proof = _findMergeEventProof({
-              ledgerNode,
-              history: results.history,
-              tails: branches,
-              electors
-            });
-            // proofReport({
-            //   proof,
-            //   copyMergeHashes: build.copyMergeHashes,
-            //   copyMergeHashesIndex: build.copyMergeHashesIndex});
-            const allXs = proof.consensus.map(p => p.x.eventHash);
-            allXs.should.have.length(4);
-            allXs.should.have.same.members(build.regularEvent.mergeHash);
-            const allYs = proof.consensus.map(p => p.y.eventHash);
-            allYs.should.have.length(4);
-            allYs.should.have.same.members([
-              build.copyMergeHashes.cp5, build.copyMergeHashes.cp6,
-              build.copyMergeHashes.cp7, build.copyMergeHashes.cp8
-            ]);
-            callback();
-          }]
-        }, callback);
-      }]
-    }, done);
+    it('ledger history beta', done => {
+      const report = {};
+      async.auto({
+        build: callback => helpers.buildHistory(
+          {consensusApi, historyId: 'beta', mockData, nodes}, callback),
+        testAlpha: ['build', (results, callback) => {
+          const build = results.build;
+          // all peers are electors
+          const electors = _.values(peers).map(p => ({id: p}));
+          async.eachOfSeries(nodes, (ledgerNode, i, callback) => async.auto({
+            history: callback => getRecentHistory({
+              creatorId: nodes[i].creatorId,
+              ledgerNode, excludeLocalRegularEvents: true}, callback),
+            branches: ['history', (results, callback) => {
+              const branches = _getElectorBranches({
+                history: results.history,
+                electors
+              });
+              callback(null, branches);
+            }],
+            proof: ['branches', (results, callback) => {
+              const proof = _findMergeEventProof({
+                ledgerNode,
+                history: results.history,
+                tails: results.branches,
+                electors,
+                mode: 'firstWithConsensusProof'
+              });
+              // try {
+              //   report[i] = proofReport({
+              //     proof,
+              //     copyMergeHashes: build.copyMergeHashes,
+              //     copyMergeHashesIndex: build.copyMergeHashesIndex});
+              // } catch(e) {
+              //   report[i] = 'NO PROOF';
+              // }
+              const allXs = proof.consensus.map(p => p.x.eventHash);
+              allXs.should.have.length(4);
+              allXs.should.have.same.members(build.regularEvent.mergeHash);
+              const allYs = proof.consensus.map(p => p.y.eventHash);
+              allYs.should.have.length(4);
+              allYs.should.have.same.members([
+                build.copyMergeHashes.cp5, build.copyMergeHashes.cp6,
+                build.copyMergeHashes.cp7, build.copyMergeHashes.cp8
+              ]);
+              callback();
+            }]
+          }, callback), callback);
+        }]
+      }, err => {
+        // console.log('FINAL REPORT', JSON.stringify(report, null, 2));
+        done(err);
+      });
+    }); // end test 2
+    it('ledger history gamma', function(done) {
+      this.timeout(120000);
+      const report = {};
+      async.auto({
+        build: callback => helpers.buildHistory(
+          {consensusApi, historyId: 'gamma', mockData, nodes}, callback),
+        testAll: ['build', (results, callback) => {
+          const build = results.build;
+          // all peers are electors
+          const electors = _.values(peers).map(p => ({id: p}));
+          async.eachOfSeries(nodes, (ledgerNode, i, callback) => async.auto({
+            history: callback => getRecentHistory({
+              creatorId: nodes[i].creatorId,
+              ledgerNode, excludeLocalRegularEvents: true}, callback),
+            branches: ['history', (results, callback) => {
+              const branches = _getElectorBranches({
+                history: results.history,
+                electors
+              });
+              callback(null, branches);
+            }],
+            proof: ['branches', (results, callback) => {
+              const proof = _findMergeEventProof({
+                ledgerNode,
+                history: results.history,
+                tails: results.branches,
+                electors,
+                mode: 'firstWithConsensusProof'
+              });
+              // try {
+              //   report[i] = proofReport({
+              //     proof,
+              //     copyMergeHashes: build.copyMergeHashes,
+              //     copyMergeHashesIndex: build.copyMergeHashesIndex});
+              // } catch(e) {
+              //   report[i] = 'NO PROOF';
+              // }
+              const allXs = proof.consensus.map(p => p.x.eventHash);
+              allXs.should.have.length(4);
+              allXs.should.have.same.members(build.regularEvent.mergeHash);
+              const allYs = proof.consensus.map(p => p.y.eventHash);
+              allYs.should.have.length(4);
+              allYs.should.have.same.members([
+                build.copyMergeHashes.cp5, build.copyMergeHashes.cp6,
+                build.copyMergeHashes.cp7, build.copyMergeHashes.cp8
+              ]);
+              callback();
+            }]
+          }, callback), callback);
+        }]
+      }, err => {
+        // console.log('FINAL REPORT', JSON.stringify(report, null, 2));
+        done(err);
+      });
+    });
+    // involves 4 elector nodes and one non-elector
+    it('ledger history delta produces same as alpha result', function(done) {
+      this.timeout(120000);
+      const report = {};
+      // add node epsilon for this test and remove it afterwards
+      async.auto({
+        nodeEpsilon: callback => async.auto({
+          add: callback => brLedgerNode.add(
+            null, {genesisBlock}, (err, result) => {
+              if(err) {
+                return callback(err);
+              }
+              nodes.epsilon = result;
+              nodes.epsilon.eventWriter = new EventWriter(
+                {immediate: true, ledgerNode: nodes.epsilon});
+              callback();
+            }),
+          creator: ['add', (results, callback) =>
+            consensusApi._voters.get(
+              {ledgerNodeId: nodes.epsilon.id}, (err, result) => {
+                if(err) {
+                  return callback(err);
+                }
+                peers.epsilon = result.id;
+                nodes.epsilon.creatorId = result.id;
+                helpers.peersReverse[result.id] = 'epsilon';
+                callback();
+              })]
+        }, callback),
+        build: ['nodeEpsilon', (results, callback) => helpers.buildHistory(
+          {consensusApi, historyId: 'delta', mockData, nodes}, callback)],
+        testAll: ['build', (results, callback) => {
+          // NOTE: for ledger history alpha, all nodes should have the same view
+          const build = results.build;
+          // all peers are electors
+          const electors = _.values(peers).map(p => ({id: p}));
+          async.eachOfSeries(nodes, (ledgerNode, i, callback) => async.auto({
+            history: callback => getRecentHistory({
+              creatorId: nodes[i].creatorId,
+              ledgerNode, excludeLocalRegularEvents: true}, callback),
+            proof: ['history', (results, callback) => {
+              const branches = _getElectorBranches({
+                history: results.history,
+                electors
+              });
+              const proof = _findMergeEventProof({
+                ledgerNode,
+                history: results.history,
+                tails: branches,
+                electors,
+                mode: 'firstWithConsensusProof'
+              });
+              // try {
+              //   report[i] = proofReport({
+              //     proof,
+              //     copyMergeHashes: build.copyMergeHashes,
+              //     copyMergeHashesIndex: build.copyMergeHashesIndex});
+              // } catch(e) {
+              //   report[i] = 'NO PROOF';
+              // }
+              const allXs = proof.consensus.map(p => p.x.eventHash);
+              allXs.should.have.length(4);
+              const mergeHashes = [
+                build.regularEvent.alpha.mergeHash,
+                build.regularEvent.beta.mergeHash,
+                build.regularEvent.gamma.mergeHash,
+                build.regularEvent.delta.mergeHash
+                // exclude epsilon (non-elector)
+              ];
+              allXs.should.have.same.members(mergeHashes);
+              const allYs = proof.consensus.map(p => p.y.eventHash);
+              allYs.should.have.length(4);
+              allYs.should.have.same.members([
+                build.copyMergeHashes.cp5, build.copyMergeHashes.cp6,
+                build.copyMergeHashes.cp7, build.copyMergeHashes.cp8
+              ]);
+              callback();
+            }]
+          }, callback), callback);
+        }],
+        cleanup: ['testAll', (results, callback) => {
+          delete nodes.epsilon;
+          callback();
+        }]
+      }, err => {
+        // console.log('FINAL REPORT', JSON.stringify(report, null, 2));
+        done(err);
+      });
+    });
+    // FIXME: enable test
+    it('ledger history epsilon', done => {
+      const report = {};
+      async.auto({
+        build: callback => helpers.buildHistory(
+          {consensusApi, historyId: 'epsilon', mockData, nodes}, callback),
+        testAll: ['build', (results, callback) => {
+          // NOTE: for ledger history alpha, all nodes should have the same view
+          const build = results.build;
+          // all peers are electors
+          const electors = _.values(peers).map(p => ({id: p}));
+          async.eachOfSeries(nodes, (ledgerNode, i, callback) => async.auto({
+            history: callback => getRecentHistory({
+              creatorId: nodes[i].creatorId,
+              ledgerNode, excludeLocalRegularEvents: true}, callback),
+            proof: ['history', (results, callback) => {
+              const branches = _getElectorBranches({
+                history: results.history,
+                electors
+              });
+              const proof = _findMergeEventProof({
+                ledgerNode,
+                history: results.history,
+                tails: branches,
+                electors,
+                mode: 'firstWithConsensusProof'
+              });
+              // try {
+              //   report[i] = proofReport({
+              //     proof,
+              //     copyMergeHashes: build.copyMergeHashes,
+              //     copyMergeHashesIndex: build.copyMergeHashesIndex});
+              // } catch(e) {
+              //   report[i] = 'NO PROOF';
+              // }
+              const allXs = proof.consensus.map(p => p.x.eventHash);
+              allXs.should.have.length(4);
+              allXs.should.have.same.members(build.regularEvent.mergeHash);
+              const allYs = proof.consensus.map(p => p.y.eventHash);
+              allYs.should.have.length(4);
+              allYs.should.have.same.members([
+                build.copyMergeHashes.cp5, build.copyMergeHashes.cp6,
+                build.copyMergeHashes.cp7, build.copyMergeHashes.cp8
+              ]);
+              callback();
+            }]
+          }, callback), callback);
+        }]
+      }, err => {
+        // console.log('REPORT', JSON.stringify(report, null, 2));
+        done(err);
+      });
+    });
+    // add regular event on alpha before running findMergeEventProof on alpha
+    it('add regular local event before getting proof', done => {
+      const ledgerNode = nodes.alpha;
+      const eventTemplate = mockData.events.alpha;
+      const opTemplate = mockData.operations.alpha;
+      async.auto({
+        build: callback => helpers.buildHistory(
+          {consensusApi, historyId: 'alpha', mockData, nodes}, callback),
+        event: ['build', (results, callback) => helpers.addEvent(
+          {ledgerNode, eventTemplate, opTemplate}, callback)],
+        testAll: ['event', (results, callback) => {
+          // NOTE: for ledger history alpha, all nodes should have the same view
+          const build = results.build;
+          // all peers are electors
+          const electors = _.values(peers).map(p => ({id: p}));
+          async.auto({
+            history: callback => getRecentHistory({
+              creatorId: nodes.alpha.creatorId,
+              ledgerNode, excludeLocalRegularEvents: true}, callback),
+            proof: ['history', (results, callback) => {
+              const branches = _getElectorBranches({
+                history: results.history,
+                electors
+              });
+              const proof = _findMergeEventProof({
+                ledgerNode,
+                history: results.history,
+                tails: branches,
+                electors,
+                mode: 'firstWithConsensusProof'
+              });
+              // proofReport({
+              //   proof,
+              //   copyMergeHashes: build.copyMergeHashes,
+              //   copyMergeHashesIndex: build.copyMergeHashesIndex});
+              const allXs = proof.consensus.map(p => p.x.eventHash);
+              allXs.should.have.length(4);
+              allXs.should.have.same.members(build.regularEvent.mergeHash);
+              const allYs = proof.consensus.map(p => p.y.eventHash);
+              allYs.should.have.length(4);
+              allYs.should.have.same.members([
+                build.copyMergeHashes.cp5, build.copyMergeHashes.cp6,
+                build.copyMergeHashes.cp7, build.copyMergeHashes.cp8
+              ]);
+              callback();
+            }]
+          }, callback);
+        }]
+      }, done);
+    });
   });
 });
 

--- a/test/mocha/067-election-get-elector-branches.js
+++ b/test/mocha/067-election-get-elector-branches.js
@@ -120,7 +120,6 @@ describe.skip('Election API _getElectorBranches', () => {
     });
     const getRecentHistory = consensusApi._events.getRecentHistory;
     const _getElectorBranches = consensusApi._election._getElectorBranches;
-    const _findMergeEventProof = consensusApi._election._findMergeEventProof;
     const eventTemplate = mockData.events.alpha;
     async.auto({
       // add a regular event and merge on every node

--- a/test/mocha/069-election-find-consensus.js
+++ b/test/mocha/069-election-find-consensus.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2017-2018 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2017-2019 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 
@@ -124,19 +124,21 @@ describe('Election API findConsensus', () => {
       history: ['event1', (results, callback) => getRecentHistory(
         {creatorId, ledgerNode}, callback)],
       consensus: ['history', (results, callback) => {
-        findConsensus(
-          {electors, ledgerNode, history: results.history}, (err, result) => {
-            assertNoError(err);
-            result.consensusProofHash.should.have.length(1);
-            result.consensusProofHash[0].should.equal(
-              results.event1.mergeHash);
-            result.eventHash.should.have.length(2);
-            result.eventHash.should.have.same.members([
-              Object.keys(results.event1.regular)[0],
-              results.event1.merge.meta.eventHash
-            ]);
-            callback();
-          });
+        findConsensus({
+          electors, ledgerNode, history: results.history,
+          mode: 'firstWithConsensusProof'
+        }, (err, result) => {
+          assertNoError(err);
+          result.consensusProofHash.should.have.length(1);
+          result.consensusProofHash[0].should.equal(
+            results.event1.mergeHash);
+          result.eventHash.should.have.length(2);
+          result.eventHash.should.have.same.members([
+            Object.keys(results.event1.regular)[0],
+            results.event1.merge.meta.eventHash
+          ]);
+          callback();
+        });
       }]
     }, done);
   });
@@ -156,13 +158,15 @@ describe('Election API findConsensus', () => {
       history: ['event1', (results, callback) => getRecentHistory(
         {creatorId, ledgerNode}, callback)],
       consensus: ['history', (results, callback) => {
-        findConsensus(
-          {electors, ledgerNode, history: results.history}, (err, result) => {
-            assertNoError(err);
-            should.exist(result);
-            result.consensus.should.equal(false);
-            callback();
-          });
+        findConsensus({
+          electors, ledgerNode, history: results.history,
+          mode: 'firstWithConsensusProof'
+        }, (err, result) => {
+          assertNoError(err);
+          should.exist(result);
+          result.consensus.should.equal(false);
+          callback();
+        });
       }]
     }, done);
   });
@@ -183,40 +187,41 @@ describe('Election API findConsensus', () => {
             getRecentHistory({creatorId, ledgerNode}, callback);
           },
           consensus: ['history', (results, callback) => {
-            findConsensus(
-              {electors, ledgerNode, history: results.history},
-              (err, result) => {
-                assertNoError(err);
-                should.exist(result);
-                should.exist(result.eventHash);
-                result.eventHash.should.be.an('array');
-                result.eventHash.should.have.length(8);
-                result.eventHash.should.have.same.members([
-                  ...regularEvent.regularHash,
-                  ...regularEvent.mergeHash
-                ]);
-                should.exist(result.consensusProofHash);
-                result.consensusProofHash.should.be.an('array');
-                result.consensusProofHash.should.have.length(10);
-                result.consensusProofHash.should.have.same.members([
-                  copyMergeHashes.cpa,
-                  copyMergeHashes.cpb,
-                  copyMergeHashes.cp1,
-                  copyMergeHashes.cp2,
-                  copyMergeHashes.cp3,
-                  copyMergeHashes.cp4,
-                  copyMergeHashes.cp5,
-                  copyMergeHashes.cp6,
-                  copyMergeHashes.cp7,
-                  copyMergeHashes.cp8
-                ]);
-                // proofReport({
-                //   copyMergeHashes,
-                //   copyMergeHashesIndex,
-                //   consensusProofHash: result.consensusProofHash,
-                // });
-                callback();
-              });
+            findConsensus({
+              electors, ledgerNode, history: results.history,
+              mode: 'firstWithConsensusProof'
+            }, (err, result) => {
+              assertNoError(err);
+              should.exist(result);
+              should.exist(result.eventHash);
+              result.eventHash.should.be.an('array');
+              result.eventHash.should.have.length(8);
+              result.eventHash.should.have.same.members([
+                ...regularEvent.regularHash,
+                ...regularEvent.mergeHash
+              ]);
+              should.exist(result.consensusProofHash);
+              result.consensusProofHash.should.be.an('array');
+              result.consensusProofHash.should.have.length(10);
+              result.consensusProofHash.should.have.same.members([
+                copyMergeHashes.cpa,
+                copyMergeHashes.cpb,
+                copyMergeHashes.cp1,
+                copyMergeHashes.cp2,
+                copyMergeHashes.cp3,
+                copyMergeHashes.cp4,
+                copyMergeHashes.cp5,
+                copyMergeHashes.cp6,
+                copyMergeHashes.cp7,
+                copyMergeHashes.cp8
+              ]);
+              // proofReport({
+              //   copyMergeHashes,
+              //   copyMergeHashesIndex,
+              //   consensusProofHash: result.consensusProofHash,
+              // });
+              callback();
+            });
           }]
         }, callback), callback);
       }]
@@ -239,35 +244,36 @@ describe('Election API findConsensus', () => {
             getRecentHistory({creatorId, ledgerNode}, callback);
           },
           consensus: ['history', (results, callback) => {
-            findConsensus(
-              {electors, ledgerNode, history: results.history},
-              (err, result) => {
-                assertNoError(err);
-                result.eventHash.should.have.length(8);
-                result.eventHash.should.have.same.members([
-                  ...regularEvent.regularHash,
-                  ...regularEvent.mergeHash
-                ]);
-                result.consensusProofHash.should.have.length(10);
-                result.consensusProofHash.should.have.same.members([
-                  copyMergeHashes.cpa,
-                  copyMergeHashes.cpb,
-                  copyMergeHashes.cp1,
-                  copyMergeHashes.cp2,
-                  copyMergeHashes.cp3,
-                  copyMergeHashes.cp4,
-                  copyMergeHashes.cp5,
-                  copyMergeHashes.cp6,
-                  copyMergeHashes.cp7,
-                  copyMergeHashes.cp8
-                ]);
-                // proofReport({
-                //   copyMergeHashes,
-                //   copyMergeHashesIndex,
-                //   consensusProofHash: result.consensusProofHash,
-                // });
-                callback();
-              });
+            findConsensus({
+              electors, ledgerNode, history: results.history,
+              mode: 'firstWithConsensusProof'
+            }, (err, result) => {
+              assertNoError(err);
+              result.eventHash.should.have.length(8);
+              result.eventHash.should.have.same.members([
+                ...regularEvent.regularHash,
+                ...regularEvent.mergeHash
+              ]);
+              result.consensusProofHash.should.have.length(10);
+              result.consensusProofHash.should.have.same.members([
+                copyMergeHashes.cpa,
+                copyMergeHashes.cpb,
+                copyMergeHashes.cp1,
+                copyMergeHashes.cp2,
+                copyMergeHashes.cp3,
+                copyMergeHashes.cp4,
+                copyMergeHashes.cp5,
+                copyMergeHashes.cp6,
+                copyMergeHashes.cp7,
+                copyMergeHashes.cp8
+              ]);
+              // proofReport({
+              //   copyMergeHashes,
+              //   copyMergeHashesIndex,
+              //   consensusProofHash: result.consensusProofHash,
+              // });
+              callback();
+            });
           }]
         }, callback), callback);
       }]
@@ -290,35 +296,36 @@ describe('Election API findConsensus', () => {
             getRecentHistory({creatorId, ledgerNode}, callback);
           },
           consensus: ['history', (results, callback) => {
-            findConsensus(
-              {electors, ledgerNode, history: results.history},
-              (err, result) => {
-                assertNoError(err);
-                result.eventHash.should.have.length(8);
-                result.eventHash.should.have.same.members([
-                  ...regularEvent.regularHash,
-                  ...regularEvent.mergeHash
-                ]);
-                result.consensusProofHash.should.have.length(10);
-                result.consensusProofHash.should.have.same.members([
-                  copyMergeHashes.cpa,
-                  copyMergeHashes.cpb,
-                  copyMergeHashes.cp1,
-                  copyMergeHashes.cp2,
-                  copyMergeHashes.cp3,
-                  copyMergeHashes.cp4,
-                  copyMergeHashes.cp5,
-                  copyMergeHashes.cp6,
-                  copyMergeHashes.cp7,
-                  copyMergeHashes.cp8
-                ]);
-                // proofReport({
-                //   copyMergeHashes,
-                //   copyMergeHashesIndex,
-                //   consensusProofHash: result.consensusProofHash,
-                // });
-                callback();
-              });
+            findConsensus({
+              electors, ledgerNode, history: results.history,
+              mode: 'firstWithConsensusProof'
+            }, (err, result) => {
+              assertNoError(err);
+              result.eventHash.should.have.length(8);
+              result.eventHash.should.have.same.members([
+                ...regularEvent.regularHash,
+                ...regularEvent.mergeHash
+              ]);
+              result.consensusProofHash.should.have.length(10);
+              result.consensusProofHash.should.have.same.members([
+                copyMergeHashes.cpa,
+                copyMergeHashes.cpb,
+                copyMergeHashes.cp1,
+                copyMergeHashes.cp2,
+                copyMergeHashes.cp3,
+                copyMergeHashes.cp4,
+                copyMergeHashes.cp5,
+                copyMergeHashes.cp6,
+                copyMergeHashes.cp7,
+                copyMergeHashes.cp8
+              ]);
+              // proofReport({
+              //   copyMergeHashes,
+              //   copyMergeHashesIndex,
+              //   consensusProofHash: result.consensusProofHash,
+              // });
+              callback();
+            });
           }]
         }, callback), callback);
       }]
@@ -366,45 +373,46 @@ describe('Election API findConsensus', () => {
             getRecentHistory({creatorId, ledgerNode}, callback);
           },
           consensus: ['history', (results, callback) => {
-            findConsensus(
-              {electors, ledgerNode, history: results.history},
-              (err, result) => {
-                assertNoError(err);
-                should.exist(result);
-                should.exist(result.eventHash);
-                result.eventHash.should.be.an('array');
-                result.eventHash.should.have.length(8);
-                result.eventHash.should.have.same.members([
-                  regularEvent.alpha.regularHashes[0],
-                  regularEvent.beta.regularHashes[0],
-                  regularEvent.gamma.regularHashes[0],
-                  regularEvent.delta.regularHashes[0],
-                  regularEvent.alpha.mergeHash,
-                  regularEvent.beta.mergeHash,
-                  regularEvent.gamma.mergeHash,
-                  regularEvent.delta.mergeHash
-                  // exclude epsilon (non-elector)
-                ]);
-                result.consensusProofHash.should.have.length(10);
-                result.consensusProofHash.should.have.same.members([
-                  copyMergeHashes.cpa,
-                  copyMergeHashes.cpb,
-                  copyMergeHashes.cp1,
-                  copyMergeHashes.cp2,
-                  copyMergeHashes.cp3,
-                  copyMergeHashes.cp4,
-                  copyMergeHashes.cp5,
-                  copyMergeHashes.cp6,
-                  copyMergeHashes.cp7,
-                  copyMergeHashes.cp8
-                ]);
-                // proofReport({
-                //   copyMergeHashes,
-                //   copyMergeHashesIndex,
-                //   consensusProofHash: result.consensusProofHash,
-                // });
-                callback();
-              });
+            findConsensus({
+              electors, ledgerNode, history: results.history,
+              mode: 'firstWithConsensusProof'
+            }, (err, result) => {
+              assertNoError(err);
+              should.exist(result);
+              should.exist(result.eventHash);
+              result.eventHash.should.be.an('array');
+              result.eventHash.should.have.length(8);
+              result.eventHash.should.have.same.members([
+                regularEvent.alpha.regularHashes[0],
+                regularEvent.beta.regularHashes[0],
+                regularEvent.gamma.regularHashes[0],
+                regularEvent.delta.regularHashes[0],
+                regularEvent.alpha.mergeHash,
+                regularEvent.beta.mergeHash,
+                regularEvent.gamma.mergeHash,
+                regularEvent.delta.mergeHash
+                // exclude epsilon (non-elector)
+              ]);
+              result.consensusProofHash.should.have.length(10);
+              result.consensusProofHash.should.have.same.members([
+                copyMergeHashes.cpa,
+                copyMergeHashes.cpb,
+                copyMergeHashes.cp1,
+                copyMergeHashes.cp2,
+                copyMergeHashes.cp3,
+                copyMergeHashes.cp4,
+                copyMergeHashes.cp5,
+                copyMergeHashes.cp6,
+                copyMergeHashes.cp7,
+                copyMergeHashes.cp8
+              ]);
+              // proofReport({
+              //   copyMergeHashes,
+              //   copyMergeHashesIndex,
+              //   consensusProofHash: result.consensusProofHash,
+              // });
+              callback();
+            });
           }]
         }, callback), callback);
       }],
@@ -431,36 +439,38 @@ describe('Election API findConsensus', () => {
       event: ['history', (results, callback) => helpers.addEvent(
         {ledgerNode, eventTemplate, opTemplate}, callback)],
       consensus: ['event', (results, callback) => {
-        findConsensus(
-          {electors, ledgerNode, history: results.history}, (err, result) => {
-            const {copyMergeHashes, copyMergeHashesIndex, regularEvent} =
-              results.build;
-            assertNoError(err);
-            result.eventHash.should.have.length(8);
-            result.eventHash.should.have.same.members([
-              ...regularEvent.regularHash,
-              ...regularEvent.mergeHash
-            ]);
-            result.consensusProofHash.should.have.length(10);
-            result.consensusProofHash.should.have.same.members([
-              copyMergeHashes.cpa,
-              copyMergeHashes.cpb,
-              copyMergeHashes.cp1,
-              copyMergeHashes.cp2,
-              copyMergeHashes.cp3,
-              copyMergeHashes.cp4,
-              copyMergeHashes.cp5,
-              copyMergeHashes.cp6,
-              copyMergeHashes.cp7,
-              copyMergeHashes.cp8
-            ]);
-            // proofReport({
-            //   copyMergeHashes,
-            //   copyMergeHashesIndex,
-            //   consensusProofHash: result.consensusProofHash,
-            // });
-            callback();
-          });
+        findConsensus({
+          electors, ledgerNode, history: results.history,
+          mode: 'firstWithConsensusProof'
+        }, (err, result) => {
+          const {copyMergeHashes, copyMergeHashesIndex, regularEvent} =
+            results.build;
+          assertNoError(err);
+          result.eventHash.should.have.length(8);
+          result.eventHash.should.have.same.members([
+            ...regularEvent.regularHash,
+            ...regularEvent.mergeHash
+          ]);
+          result.consensusProofHash.should.have.length(10);
+          result.consensusProofHash.should.have.same.members([
+            copyMergeHashes.cpa,
+            copyMergeHashes.cpb,
+            copyMergeHashes.cp1,
+            copyMergeHashes.cp2,
+            copyMergeHashes.cp3,
+            copyMergeHashes.cp4,
+            copyMergeHashes.cp5,
+            copyMergeHashes.cp6,
+            copyMergeHashes.cp7,
+            copyMergeHashes.cp8
+          ]);
+          // proofReport({
+          //   copyMergeHashes,
+          //   copyMergeHashesIndex,
+          //   consensusProofHash: result.consensusProofHash,
+          // });
+          callback();
+        });
       }]
     }, done);
   });

--- a/test/mocha/069-election-find-consensus.js
+++ b/test/mocha/069-election-find-consensus.js
@@ -159,7 +159,8 @@ describe('Election API findConsensus', () => {
         findConsensus(
           {electors, ledgerNode, history: results.history}, (err, result) => {
             assertNoError(err);
-            should.not.exist(result);
+            should.exist(result);
+            result.consensus.should.equal(false);
             callback();
           });
       }]

--- a/test/mocha/093-xblock-multinode-recovery.js
+++ b/test/mocha/093-xblock-multinode-recovery.js
@@ -29,6 +29,20 @@ describe('X Block Test using elector selector with recovery', () => {
     helpers.prepareDatabase(mockData, done);
   });
 
+  // FIXME: update bedrock-ledger...es-most-recent-participants-with-recovery
+  // to fix recovery elector count
+  before(() => {
+    const electorSelectionApi = brLedgerNode.use(
+      'MostRecentParticipantsWithRecovery');
+    electorSelectionApi.api._computeRecoveryElectors = ({electors, f}) => {
+      if(f <= 1) {
+        return [];
+      }
+      const r = f - 1;
+      return electors.slice(0, 3 * r + 1);
+    };
+  });
+
   const nodeCount = 6;
   describe(`Consensus with ${nodeCount} Nodes`, () => {
 

--- a/test/mocha/093-xblock-multinode-recovery.js
+++ b/test/mocha/093-xblock-multinode-recovery.js
@@ -43,7 +43,7 @@ describe('X Block Test using elector selector with recovery', () => {
     };
   });
 
-  const nodeCount = 6;
+  const nodeCount = 8;
   describe(`Consensus with ${nodeCount} Nodes`, () => {
 
     // get consensus plugin and create genesis ledger node

--- a/test/mocha/100-basic-recovery-mode.js
+++ b/test/mocha/100-basic-recovery-mode.js
@@ -68,7 +68,7 @@ describe('Recovery mode simulation', () => {
         return recoveryElectors.length < total ? [] : recoveryElectors;
       };
     // the return value here gets multiplied by 10
-    electorSelectionApi.api._computeRecoveryMinimumMergeEvents = () => 2;
+    electorSelectionApi.api._computeRecoveryMinimumMergeEvents = () => 0.5;
   });
 
   const nodeCount = 7;

--- a/test/mocha/100-basic-recovery-mode.js
+++ b/test/mocha/100-basic-recovery-mode.js
@@ -55,15 +55,17 @@ describe('Recovery mode simulation', () => {
 
     electorSelectionApi.api._computeRecoveryElectors =
       ({electors, f}) => {
+        if(electors.length === 1 || f === 1) {
+          return [];
+        }
         let recoveryElectors = [];
         for(const n of ['alpha', 'beta', 'gamma', 'delta']) {
           recoveryElectors.push({id: peers[n]});
         }
-        if(electors.length === 1) {
-          return [];
-        }
-        recoveryElectors = recoveryElectors.slice(0, f + 1);
-        return recoveryElectors.length < f + 1 ? [] : recoveryElectors;
+        const r = f - 1;
+        const total = 3 * r + 1;
+        recoveryElectors = recoveryElectors.slice(0, total);
+        return recoveryElectors.length < total ? [] : recoveryElectors;
       };
     // the return value here gets multiplied by 10
     electorSelectionApi.api._computeRecoveryMinimumMergeEvents = () => 2;

--- a/test/mocha/100-basic-recovery-mode.js
+++ b/test/mocha/100-basic-recovery-mode.js
@@ -34,9 +34,14 @@ describe('Recovery mode simulation', () => {
     const electorSelectionApi = brLedgerNode.use(
       'MostRecentParticipantsWithRecovery');
 
-    // always return alpha as the sole elector
+    // use all REs as the decision electors when in recovery mode
     electorSelectionApi.api._computeElectorsForRecoveryMode = () => {
-      return [{id: peers.alpha}];
+      return [
+        {id: peers.alpha},
+        {id: peers.beta},
+        {id: peers.gamma},
+        {id: peers.delta}
+      ];
     };
 
     let savedElectors;

--- a/test/mocha/101-recovery-mode.js
+++ b/test/mocha/101-recovery-mode.js
@@ -420,16 +420,19 @@ describe('Recovery mode simulation', () => {
 
         await _testRecords(result.recordIds);
 
-        // test participants in last block
-        const ledgerNode = nodes.alpha;
-        const {getParticipants} = ledgerNode.consensus._blocks;
-        const p = await getParticipants(
-          {blockHeight: stageFiveBlockHeight, ledgerNode});
+        // FIXME: check for electors via another new property in the
+        // data model (not consensusProofHash) once one has been adopted
 
-        // proof on the last block created should involve all 7 nodes
-        p.consensusProofPeers.should.have.length(7);
-        p.consensusProofPeers.should.have.same.members(
-          _.values(peers));
+      //   // test participants in last block
+      //   const ledgerNode = nodes.alpha;
+      //   const {getParticipants} = ledgerNode.consensus._blocks;
+      //   const p = await getParticipants(
+      //     {blockHeight: stageFiveBlockHeight, ledgerNode});
+      //
+      //   // proof on the last block created should involve all 7 nodes
+      //   p.consensusProofPeers.should.have.length(7);
+      //   p.consensusProofPeers.should.have.same.members(
+      //     _.values(peers));
       });
     }); // end regular blocks seven nodes
   });

--- a/test/mocha/101-recovery-mode.js
+++ b/test/mocha/101-recovery-mode.js
@@ -349,7 +349,7 @@ describe.skip('Recovery mode simulation', () => {
     }); // end recovery blocks three nodes
 
     let stageFourBlockHeight;
-    describe('Enable formerly disable nodes', () => {
+    describe('Enable formerly disabled nodes', () => {
       it('let disabled nodes catch up', async function() {
         this.timeout(TEST_TIMEOUT);
 

--- a/test/mocha/101-recovery-mode.js
+++ b/test/mocha/101-recovery-mode.js
@@ -31,7 +31,7 @@ const disabledNodes = {};
 const peers = {};
 const heads = {};
 
-describe('Recovery mode simulation', () => {
+describe.skip('Recovery mode simulation', () => {
   before(function(done) {
     this.timeout(TEST_TIMEOUT);
     helpers.prepareDatabase(mockData, done);

--- a/test/mocha/101-recovery-mode.js
+++ b/test/mocha/101-recovery-mode.js
@@ -75,15 +75,18 @@ describe('Recovery mode simulation', () => {
           recoveryElectors.push({id: peers[n]});
         }
 
-        // let r = recoveryElectorsByBlockHeight.get(blockHeight);
-        // if(r) {
-        //   return r;
+        // let res = recoveryElectorsByBlockHeight.get(blockHeight);
+        // if(res) {
+        //   return res;
         // }
 
-        if(electors.length === 1) {
+        if(electors.length === 1 || f === 1) {
           // recoveryElectorsByBlockHeight.set(blockHeight, []);
           return [];
         }
+
+        const r = f - 1;
+        const total = 3 * r + 1;
 
         // NOTE: computing recovery electors based on `electors` does not work
         // because the elector selection algorithm may have chosen multiple
@@ -95,13 +98,13 @@ describe('Recovery mode simulation', () => {
         //   .slice(0, f + 1);
 
         // recoveryElectors = recoveryElectors
-        //   .sort((a, b) => a.id.localeCompare(b.id)).slice(0, f + 1);
+        //   .sort((a, b) => a.id.localeCompare(b.id)).slice(0, total);
 
-        recoveryElectors = recoveryElectors.slice(0, f + 1);
+        recoveryElectors = recoveryElectors.slice(0, total);
 
-        const r = recoveryElectors.length < f + 1 ? [] : recoveryElectors;
-        // recoveryElectorsByBlockHeight.set(blockHeight, r);
-        return r;
+        const res = recoveryElectors.length < total ? [] : recoveryElectors;
+        // recoveryElectorsByBlockHeight.set(blockHeight, res);
+        return res;
       };
     // the return value here gets multiplied by 10
     electorSelectionApi.api._computeRecoveryMinimumMergeEvents = () => 2;

--- a/test/mocha/101-recovery-mode.js
+++ b/test/mocha/101-recovery-mode.js
@@ -31,7 +31,7 @@ const disabledNodes = {};
 const peers = {};
 const heads = {};
 
-describe.skip('Recovery mode simulation', () => {
+describe('Recovery mode simulation', () => {
   before(function(done) {
     this.timeout(TEST_TIMEOUT);
     helpers.prepareDatabase(mockData, done);

--- a/test/mocha/101-recovery-mode.js
+++ b/test/mocha/101-recovery-mode.js
@@ -107,7 +107,7 @@ describe('Recovery mode simulation', () => {
         return res;
       };
     // the return value here gets multiplied by 10
-    electorSelectionApi.api._computeRecoveryMinimumMergeEvents = () => 2;
+    electorSelectionApi.api._computeRecoveryMinimumMergeEvents = () => 0.5;
   });
 
   const nodeCount = 7;

--- a/test/mocha/101-recovery-mode.js
+++ b/test/mocha/101-recovery-mode.js
@@ -421,7 +421,7 @@ describe('Recovery mode simulation', () => {
         await _testRecords(result.recordIds);
 
         // FIXME: check for electors via another new property in the
-        // data model (not consensusProofHash) once one has been adopted
+        // data model (not consensusProofHash) once `mode = 'first'` has been adopted
 
       //   // test participants in last block
       //   const ledgerNode = nodes.alpha;

--- a/test/mocha/101-recovery-mode.js
+++ b/test/mocha/101-recovery-mode.js
@@ -56,9 +56,14 @@ describe('Recovery mode simulation', () => {
       return electors;
     };
 
-    // always return alpha as the sole elector
+    // use all REs as the decision electors when in recovery mode
     electorSelectionApi.api._computeElectorsForRecoveryMode = () => {
-      return [{id: peers.alpha}];
+      return [
+        {id: peers.alpha},
+        {id: peers.beta},
+        {id: peers.gamma},
+        {id: peers.delta}
+      ];
     };
 
     // since the recoveryElectors in this test are based on `nodes` which

--- a/test/mocha/300-cache-recovery.js
+++ b/test/mocha/300-cache-recovery.js
@@ -1,0 +1,373 @@
+/*!
+ * Copyright (c) 2017-2018 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const _ = require('lodash');
+const brLedgerNode = require('bedrock-ledger-node');
+const async = require('async');
+const cache = require('bedrock-redis');
+const {callbackify} = require('util');
+const helpers = require('./helpers');
+const mockData = require('./mock.data');
+
+const TEST_TIMEOUT = 300000;
+
+// NOTE: the tests in this file are designed to run in series
+// DO NOT use `it.only`
+
+const opTemplate = mockData.operations.alpha;
+
+// NOTE: alpha is assigned manually
+// NOTE: all these may not be used
+const nodeLabels = [
+  'beta', 'gamma', 'delta', 'epsilon', 'zeta', 'eta', 'theta', 'iota'
+];
+const nodes = {};
+const peers = {};
+const heads = {};
+
+describe.only('Cache Recovery', () => {
+  before(function(done) {
+    this.timeout(TEST_TIMEOUT);
+    helpers.prepareDatabase(mockData, done);
+  });
+
+  const nodeCount = 6;
+  describe(`Consensus with ${nodeCount} Nodes`, () => {
+
+    // get consensus plugin and create genesis ledger node
+    let consensusApi;
+    const mockIdentity = mockData.identities.regularUser;
+    const ledgerConfiguration = mockData.ledgerConfiguration;
+    before(function(done) {
+      this.timeout(TEST_TIMEOUT);
+      async.auto({
+        clean: callback => cache.client.flushall(callback),
+        consensusPlugin: ['clean', (results, callback) => helpers.use(
+          'Continuity2017', callback)],
+        ledgerNode: ['clean', (results, callback) => {
+          brLedgerNode.add(null, {ledgerConfiguration}, (err, ledgerNode) => {
+            if(err) {
+              return callback(err);
+            }
+            nodes.alpha = ledgerNode;
+            callback(null, ledgerNode);
+          });
+        }]
+      }, (err, results) => {
+        assertNoError(err);
+        consensusApi = results.consensusPlugin.api;
+        done();
+      });
+    });
+
+    // get genesis record (block + meta)
+    let genesisRecord;
+    before(function(done) {
+      this.timeout(TEST_TIMEOUT);
+      nodes.alpha.blocks.getGenesis((err, result) => {
+        assertNoError(err);
+        genesisRecord = result.genesisBlock;
+        done();
+      });
+    });
+
+    // add N - 1 more private nodes
+    before(function(done) {
+      this.timeout(TEST_TIMEOUT);
+      async.times(nodeCount - 1, (i, callback) => {
+        brLedgerNode.add(null, {
+          genesisBlock: genesisRecord.block,
+          owner: mockIdentity.identity.id
+        }, (err, ledgerNode) => {
+          assertNoError(err);
+          nodes[nodeLabels[i]] = ledgerNode;
+          callback();
+        });
+      }, err => {
+        assertNoError(err);
+        done();
+      });
+    });
+
+    // populate peers and init heads
+    before(function(done) {
+      this.timeout(TEST_TIMEOUT);
+      async.eachOf(nodes, (ledgerNode, i, callback) =>
+        consensusApi._voters.get(
+          {ledgerNodeId: ledgerNode.id}, (err, result) => {
+            assertNoError(err);
+            peers[i] = result.id;
+            ledgerNode._peerId = result.id;
+            heads[i] = [];
+            callback();
+          }),
+      err => {
+        assertNoError(err);
+        done();
+      });
+    });
+
+    describe('Check Genesis Block', () => {
+      it('should have the proper information', done => {
+        const blockHashes = [];
+        async.auto({
+          getLatest: callback => async.each(nodes, (ledgerNode, callback) =>
+            ledgerNode.storage.blocks.getLatest((err, result) => {
+              assertNoError(err);
+              const eventBlock = result.eventBlock;
+              should.exist(eventBlock.block);
+              eventBlock.block.blockHeight.should.equal(0);
+              eventBlock.block.event.should.be.an('array');
+              eventBlock.block.event.should.have.length(2);
+              const event = eventBlock.block.event[0];
+              // TODO: signature is dynamic... needs a better check
+              delete event.signature;
+              delete event.proof;
+              event.ledgerConfiguration.should.deep.equal(ledgerConfiguration);
+              should.exist(eventBlock.meta);
+              should.exist(eventBlock.block.consensusProof);
+              const consensusProof = eventBlock.block.consensusProof;
+              consensusProof.should.be.an('array');
+              consensusProof.should.have.length(1);
+              // FIXME: make assertions about the contents of consensusProof
+              // console.log('8888888', JSON.stringify(eventBlock, null, 2));
+              blockHashes.push(eventBlock.meta.blockHash);
+              callback();
+            }), callback),
+          testHash: ['getLatest', (results, callback) => {
+            blockHashes.every(h => h === blockHashes[0]).should.be.true;
+            callback();
+          }]
+        }, done);
+      });
+    });
+
+    /*
+     * 1. add new unique operations/records on nodes alpha, beta, gamma, delta
+     * 2. run worker on *all* nodes
+     * 3. repeat 1 and 2 until target block height is reached on all nodes
+     * 4. ensure that blockHash for the target block height is identical on all
+     * 5. settle the network, see notes on _settleNetwork
+     * 6. ensure that the final blockHeight and blockHash is identical on all
+     * 7. attempt to retrieve all records added in 1 from the `records` API
+     */
+
+    const targetBlockHeight = 10;
+
+    describe(`${targetBlockHeight} Blocks`, () => {
+      it('makes many more blocks', function(done) {
+        this.timeout(0);
+        async.auto({
+          nBlocks: callback => _nBlocks(
+            {consensusApi, targetBlockHeight}, (err, result) => {
+              if(err) {
+                return callback(err);
+              }
+              console.log(
+                'targetBlockHashMap',
+                JSON.stringify(result, null, 2));
+              _.values(result.targetBlockHashMap)
+                .every(h => h === result.targetBlockHashMap.alpha)
+                .should.be.true;
+              callback(null, result);
+            }),
+          // inspect outstandingMerge key
+          inspectCache: ['nBlocks', callbackify(async () => {
+            for(const nodeLabel in nodes) {
+              const ledgerNode = nodes[nodeLabel];
+              const ledgerNodeId = ledgerNode.id;
+              const {consensus: {_cache: {cacheKey: _cacheKey}}} = ledgerNode;
+              const outstandingMergeKey = _cacheKey.outstandingMerge(
+                ledgerNodeId);
+              const keys = await cache.client.smembers(outstandingMergeKey);
+              const eventHashes = [];
+              for(const key of keys) {
+                eventHashes.push(key.substr(key.lastIndexOf('|') + 1));
+              }
+              // get events from mongodb
+              const result = await ledgerNode.storage.events.collection.find({
+                'meta.continuity2017.type': 'm',
+                'meta.consensus': false
+              }).project({
+                _id: 0,
+                'meta.eventHash': 1,
+              }).toArray();
+              const mongoEventHashes = result.map(r => r.meta.eventHash);
+              eventHashes.should.have.same.members(mongoEventHashes);
+            }
+          })],
+          // inspect childess hash key
+          inspectCache2: ['inspectCache', callbackify(async () => {
+            for(const nodeLabel in nodes) {
+              const ledgerNode = nodes[nodeLabel];
+              const ledgerNodeId = ledgerNode.id;
+              const {id: creatorId} = await ledgerNode.consensus._voters.get(
+                {ledgerNodeId});
+              const {eventHash: localHeadHash} = await ledgerNode.consensus.
+                _events.getHead({creatorId, ledgerNode, useCache: false});
+              const {consensus: {_cache: {cacheKey: _cacheKey}}} = ledgerNode;
+              const childlessKey = _cacheKey.childless(ledgerNodeId);
+              const keys = await cache.client.smembers(childlessKey);
+              const childlessHashesCache = [];
+              for(const key of keys) {
+                childlessHashesCache.push(key.substr(key.lastIndexOf('|') + 1));
+              }
+              const result = await ledgerNode.storage.events.collection.find({
+                'meta.consensus': false
+              }).project({
+                _id: 0,
+                'meta.eventHash': 1,
+                'event.parentHash': 1,
+              }).toArray();
+              const eventsMap = new Map();
+              for(const e of result) {
+                eventsMap.set(e.meta.eventHash, {
+                  parentHash: e.event.parentHash,
+                  _children: 0,
+                });
+              }
+
+              for(const [, event] of eventsMap) {
+                for(const p of event.parentHash) {
+                  const parent = eventsMap.get(p);
+                  if(parent) {
+                    parent._children++;
+                  }
+                }
+              }
+              const childless = [];
+              for(const [eventHash, event] of eventsMap) {
+                if(event._children === 0 && eventHash !== localHeadHash) {
+                  childless.push(eventHash);
+                }
+              }
+              childlessHashesCache.should.have.same.members(childless);
+            }
+          })],
+          settle: ['inspectCache2', (results, callback) =>
+            helpers.settleNetwork(
+              {consensusApi, nodes: _.values(nodes)}, callback)],
+          blockSummary: ['settle', (results, callback) =>
+            _latestBlockSummary((err, result) => {
+              if(err) {
+                return callback(err);
+              }
+              const summaries = {};
+              Object.keys(result).forEach(k => {
+                summaries[k] = {
+                  blockCollection: nodes[k].storage.blocks.collection.s.name,
+                  blockHeight: result[k].eventBlock.block.blockHeight,
+                  blockHash: result[k].eventBlock.meta.blockHash,
+                  previousBlockHash: result[k].eventBlock.block
+                    .previousBlockHash,
+                };
+              });
+              console.log('Finishing block summaries:', JSON.stringify(
+                summaries, null, 2));
+              _.values(summaries).forEach(b => {
+                b.blockHeight.should.equal(summaries.alpha.blockHeight);
+                b.blockHash.should.equal(summaries.alpha.blockHash);
+              });
+              callback();
+            })],
+          state: ['blockSummary', (results, callback) => {
+            const allRecordIds = [].concat(..._.values(
+              results.nBlocks.recordIds));
+            console.log(`Total operation count: ${allRecordIds.length}`);
+            async.eachSeries(allRecordIds, (recordId, callback) => {
+              nodes.alpha.records.get({recordId}, err => {
+                // just need to ensure that there is no NotFoundError
+                assertNoError(err);
+                callback();
+              });
+            }, callback);
+          }]
+        }, err => {
+          assertNoError(err);
+          done();
+        });
+      });
+    }); // end one block
+  });
+});
+
+function _addOperations({count}, callback) {
+  async.auto({
+    alpha: callback => helpers.addOperation(
+      {count, ledgerNode: nodes.alpha, opTemplate}, callback),
+    beta: callback => helpers.addOperation(
+      {count, ledgerNode: nodes.beta, opTemplate}, callback),
+    gamma: callback => helpers.addOperation(
+      {count, ledgerNode: nodes.gamma, opTemplate}, callback),
+    delta: callback => helpers.addOperation(
+      {count, ledgerNode: nodes.delta, opTemplate}, callback),
+  }, callback);
+}
+
+function _latestBlockSummary(callback) {
+  const blocks = {};
+  async.eachOf(nodes, (ledgerNode, nodeName, callback) => {
+    ledgerNode.storage.blocks.getLatestSummary((err, result) => {
+      blocks[nodeName] = result;
+      callback();
+    });
+  }, err => callback(err, blocks));
+}
+
+function _nBlocks({consensusApi, targetBlockHeight}, callback) {
+  const recordIds = {alpha: [], beta: [], gamma: [], delta: []};
+  const targetBlockHashMap = {};
+  async.until(() => {
+    return Object.keys(targetBlockHashMap).length ===
+      Object.keys(nodes).length;
+  }, callback => {
+    const count = 1;
+    async.auto({
+      operations: callback => _addOperations({count}, callback),
+      workCycle: ['operations', (results, callback) => {
+        // record the IDs for the records that were just added
+        for(const n of ['alpha', 'beta', 'gamma', 'delta']) {
+          for(const opHash of Object.keys(results.operations[n])) {
+            recordIds[n].push(results.operations[n][opHash].record.id);
+          }
+        }
+        // in this test `nodes` is an object that needs to be converted to
+        // an array for the helper
+        helpers.runWorkerCycle(
+          {consensusApi, nodes: _.values(nodes), series: false}, callback);
+      }],
+      report: ['workCycle', (results, callback) => async.forEachOfSeries(
+        nodes, (ledgerNode, i, callback) => {
+          ledgerNode.storage.blocks.getLatestSummary((err, result) => {
+            if(err) {
+              return callback(err);
+            }
+            const {block} = result.eventBlock;
+            if(block.blockHeight >= targetBlockHeight) {
+              return ledgerNode.storage.blocks.getByHeight(
+                targetBlockHeight, (err, result) => {
+                  if(err) {
+                    return callback(err);
+                  }
+                  targetBlockHashMap[i] = result.meta.blockHash;
+                  callback();
+                });
+            }
+            callback();
+          });
+        }, callback)]
+    }, err => {
+      if(err) {
+        return callback(err);
+      }
+      callback();
+    });
+  }, err => {
+    if(err) {
+      return callback(err);
+    }
+    callback(null, {recordIds, targetBlockHashMap});
+  });
+}

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -28,3 +28,6 @@ config['ledger-consensus-continuity'].writer.debounce = 50;
 config.mocha.options.bail = true;
 
 config['https-agent'].rejectUnauthorized = false;
+
+// put jobs stuff in another redis database so db 0 can be flushed
+config.jobs.queueOptions.db = 1;


### PR DESCRIPTION
Code on 3e01ae7 has 4K+ loopbench passes using zero debounce settings (from master) as well as 1.5K passes using old debounce settings.

We want to do more live node testing on Test Cloud before committing to master.

This will be a breaking change because we see different blocks being created vs old algorithm in replay-history tests.