### PR TITLE
Cache recovery

### DIFF
--- a/lib/agents/event-writer-agent.js
+++ b/lib/agents/event-writer-agent.js
@@ -128,7 +128,9 @@ module.exports = class EventWriter extends ContinuityAgent {
     multi.srem(this.cacheKey.eventQueueSet, Array.from(eventHashes));
     // update heads
     const creators = Object.keys(creatorHeads);
-    // contains cache keys for all new heads
+    // contains the current cache keys for all new heads
+    const currentKeysForNewHeads = new Set();
+    // contains new cache keys for all new heads
     const newHeadKeys = new Set();
     if(creators.length !== 0) {
       const {dupHashes} = storeEvents;
@@ -149,7 +151,12 @@ module.exports = class EventWriter extends ContinuityAgent {
         if(dupSet.has(eventHash)) {
           continue;
         }
-        newHeadKeys.add(_cacheKey.event({eventHash, ledgerNodeId}));
+        const currentKeyForNewHead = _cacheKey.event({eventHash, ledgerNodeId});
+        const newHeadKey = _cacheKey.outstandingMergeEvent(
+          {eventHash, ledgerNodeId});
+        multi.rename(currentKeyForNewHead, newHeadKey);
+        currentKeysForNewHeads.add(currentKeyForNewHead);
+        newHeadKeys.add(newHeadKey);
         const headGenerationKey = _cacheKey.headGeneration(
           {eventHash, ledgerNodeId});
         // these keys are mainly useful during gossip about recent events
@@ -165,8 +172,9 @@ module.exports = class EventWriter extends ContinuityAgent {
     }
     // remove head keys so they will not be removed from the cache
     if(newHeadKeys.size !== 0) {
-      _.pull(rangeData, ...newHeadKeys);
-      multi.sadd(this.cacheKey.outstandingMerge, Array.from(newHeadKeys));
+      // head keys have already been renamed, don't attempt to delete again
+      _.pull(rangeData, ...currentKeysForNewHeads);
+      multi.sadd(this.cacheKey.outstandingMerge, [...newHeadKeys]);
     }
     // TODO: maybe just mark these to expired because they could be used
     // for gossip

--- a/lib/cache/blocks.js
+++ b/lib/cache/blocks.js
@@ -41,7 +41,7 @@ exports.commitBlock = async ({eventHashes, ledgerNodeId}) => {
   const blockHeightKey = _cacheKey.blockHeight(ledgerNodeId);
   const outstandingMergeKey = _cacheKey.outstandingMerge(ledgerNodeId);
   const eventKeys = eventHashes.map(
-    eventHash => _cacheKey.event({eventHash, ledgerNodeId}));
+    eventHash => _cacheKey.outstandingMergeEvent({eventHash, ledgerNodeId}));
   return cache.client.multi()
     .srem(outstandingMergeKey, eventKeys)
     .del(eventKeys)

--- a/lib/cache/cache-key.js
+++ b/lib/cache/cache-key.js
@@ -69,6 +69,8 @@ api.ledgerNode = creatorId => `ln|${_ci(creatorId)}`;
 
 // contains a list of all non-consensus merge events, local and peer
 api.outstandingMerge = ledgerNodeId => `om|${_lni(ledgerNodeId)}`;
+api.outstandingMergeEvent = ({eventHash, ledgerNodeId}) =>
+  `ome|${_lni(ledgerNodeId)}|${eventHash}`;
 
 api.opCountLocal = ({ledgerNodeId, second}) =>
   `ocl|${_lni(ledgerNodeId)}|${second}`;

--- a/lib/cache/events.js
+++ b/lib/cache/events.js
@@ -85,7 +85,8 @@ exports.addLocalMergeEvent = async ({event, meta, ledgerNodeId}) => {
   const {creator: creatorId, generation} = meta.continuity2017;
   const {eventHash} = meta;
   const headKey = _cacheKey.head({creatorId, ledgerNodeId});
-  const eventKey = _cacheKey.event({eventHash, ledgerNodeId});
+  const outstandingMergeEventKey = _cacheKey.outstandingMergeEvent(
+    {eventHash, ledgerNodeId});
   const eventGossipKey = _cacheKey.eventGossip({eventHash, ledgerNodeId});
   const outstandingMergeKey = _cacheKey.outstandingMerge(ledgerNodeId);
   const {parentHash, treeHash, type} = event;
@@ -107,11 +108,11 @@ exports.addLocalMergeEvent = async ({event, meta, ledgerNodeId}) => {
     const result = await cache.client.multi()
       .srem(childlessKey, parentHashes)
       // this key is removed when the event reaches consensus
-      .set(eventKey, eventSummary)
+      .set(outstandingMergeEventKey, eventSummary)
       // expire key which is used for gossip
       .hmset(eventGossipKey, 'event', fullEvent, 'meta', metaString)
       .expire(eventGossipKey, 600)
-      .sadd(outstandingMergeKey, eventKey)
+      .sadd(outstandingMergeKey, outstandingMergeEventKey)
       .hmset(headKey, 'h', eventHash, 'g', generation)
       .publish(`continuity2017|event|${ledgerNodeId}`, 'merge')
       .exec();

--- a/lib/cache/index.js
+++ b/lib/cache/index.js
@@ -19,4 +19,5 @@ api.consensus = require('./consensus');
 api.events = require('./events');
 api.gossip = require('./gossip');
 api.operations = require('./operations');
+api.prime = require('./prime');
 api.voters = require('./voters');

--- a/lib/cache/prime.js
+++ b/lib/cache/prime.js
@@ -1,0 +1,126 @@
+/*!
+ * Copyright (c) 2017-2019 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const _blocks = require('./blocks');
+const _cacheKey = require('./cache-key');
+const cache = require('bedrock-redis');
+const logger = require('../logger');
+
+exports.primeAll = async ({ledgerNode}) => {
+  logger.debug('Priming the cache...', {ledgerNodeId: ledgerNode.id});
+  await exports.primeBlockHeight({ledgerNode});
+  logger.debug(
+    'Successfully primed block height.', {ledgerNodeId: ledgerNode.id});
+  await exports.primeOutstandingMergeEvents({ledgerNode});
+  logger.debug(
+    'Successfully primed outstanding merge events.',
+    {ledgerNodeId: ledgerNode.id});
+  await exports.primeChildlessEvents({ledgerNode});
+  logger.debug(
+    'Successfully primed childless events.', {ledgerNodeId: ledgerNode.id});
+  logger.debug('Successfully primed the cache.', {ledgerNodeId: ledgerNode.id});
+};
+
+exports.primeBlockHeight = async ({ledgerNode}) => {
+  const ledgerNodeId = ledgerNode.id;
+  const {eventBlock: {block: {blockHeight}}} = await ledgerNode.storage
+    .blocks.getLatestSummary();
+  await _blocks.setBlockHeight({blockHeight, ledgerNodeId});
+};
+
+exports.primeChildlessEvents = async ({ledgerNode}) => {
+  const ledgerNodeId = ledgerNode.id;
+  const childlessKey = _cacheKey.childless(ledgerNodeId);
+  const childless = await exports.getChildlessEvents({ledgerNode});
+  const txn = cache.client.multi();
+  txn.del(childlessKey);
+  if(childless.length > 0) {
+    txn.sadd(childlessKey, childless);
+  }
+  await txn.exec();
+};
+
+exports.primeOutstandingMergeEvents = async ({ledgerNode}) => {
+  const ledgerNodeId = ledgerNode.id;
+  const outstandingMergeKey = _cacheKey.outstandingMerge(ledgerNodeId);
+  // get events from mongodb
+  const mergeEvents = await exports.getOutstandingMergeEvents({ledgerNode});
+  await exports.removeOutstandingMergeEventKeys({ledgerNodeId});
+  const txn = cache.client.multi();
+  txn.del(outstandingMergeKey);
+  // add all outstanding merge events to the cache
+  if(mergeEvents.length > 0) {
+    const keys = mergeEvents.map(({meta: {eventHash}}) =>
+      _cacheKey.outstandingMergeEvent({eventHash, ledgerNodeId}));
+    txn.sadd(outstandingMergeKey, keys);
+    for(const [index, event] of mergeEvents.entries()) {
+      txn.set(keys[index], JSON.stringify(event));
+    }
+  }
+  await txn.exec();
+};
+
+exports.getChildlessEvents = async ({ledgerNode}) => {
+  const ledgerNodeId = ledgerNode.id;
+  const {id: creatorId} = await ledgerNode.consensus._voters.get(
+    {ledgerNodeId});
+  const {eventHash: localHeadHash} = await ledgerNode.consensus.
+    _events.getHead({creatorId, ledgerNode, useCache: false});
+  const result = await ledgerNode.storage.events.collection.find({
+    'meta.consensus': false
+  }).project({
+    _id: 0,
+    'meta.eventHash': 1,
+    'event.parentHash': 1,
+  }).toArray();
+  const eventsMap = new Map();
+  for(const e of result) {
+    eventsMap.set(e.meta.eventHash, {
+      parentHash: e.event.parentHash,
+      _children: 0,
+    });
+  }
+  // compute the number of children for each event
+  for(const [, event] of eventsMap) {
+    for(const p of event.parentHash) {
+      const parent = eventsMap.get(p);
+      if(parent) {
+        parent._children++;
+      }
+    }
+  }
+  const childless = [];
+  for(const [eventHash, event] of eventsMap) {
+    if(event._children === 0 && eventHash !== localHeadHash) {
+      childless.push(eventHash);
+    }
+  }
+  return childless;
+};
+
+exports.getOutstandingMergeEvents = async ({ledgerNode}) =>
+  ledgerNode.storage.events.collection.find({
+    'meta.continuity2017.type': 'm',
+    'meta.consensus': false
+  }).project({
+    _id: 0,
+    'event.parentHash': 1,
+    'event.treeHash': 1,
+    // FIXME: determine if event.type is actually used, if not eliminate it
+    'event.type': 1,
+    'meta.eventHash': 1,
+    'meta.continuity2017.creator': 1,
+  }).toArray();
+
+exports.removeOutstandingMergeEventKeys = async ({ledgerNodeId}) => {
+  // this is a sample eventHash used to produce a sample key
+  const eventHash = 'zQmRkvkWf3ToMhkzFbWmyfpyFDEUEjbBLWJUj7JwT14D7ex';
+  const sampleKey = _cacheKey.outstandingMergeEvent({eventHash, ledgerNodeId});
+  const keyPrefix = sampleKey.substr(0, sampleKey.lastIndexOf('|') + 1);
+  const eventKeysInCache = await cache.client.keys(`${keyPrefix}*`);
+  if(eventKeysInCache.length > 0) {
+    await cache.client.del(eventKeysInCache);
+  }
+};

--- a/test/mocha/300-cache-recovery.js
+++ b/test/mocha/300-cache-recovery.js
@@ -1,0 +1,373 @@
+/*!
+ * Copyright (c) 2017-2018 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const _ = require('lodash');
+const brLedgerNode = require('bedrock-ledger-node');
+const async = require('async');
+const cache = require('bedrock-redis');
+const {callbackify} = require('util');
+const helpers = require('./helpers');
+const mockData = require('./mock.data');
+
+const TEST_TIMEOUT = 300000;
+
+// NOTE: the tests in this file are designed to run in series
+// DO NOT use `it.only`
+
+const opTemplate = mockData.operations.alpha;
+
+// NOTE: alpha is assigned manually
+// NOTE: all these may not be used
+const nodeLabels = [
+  'beta', 'gamma', 'delta', 'epsilon', 'zeta', 'eta', 'theta', 'iota'
+];
+const nodes = {};
+const peers = {};
+const heads = {};
+
+describe.only('Cache Recovery', () => {
+  before(function(done) {
+    this.timeout(TEST_TIMEOUT);
+    helpers.prepareDatabase(mockData, done);
+  });
+
+  const nodeCount = 6;
+  describe(`Consensus with ${nodeCount} Nodes`, () => {
+
+    // get consensus plugin and create genesis ledger node
+    let consensusApi;
+    const mockIdentity = mockData.identities.regularUser;
+    const ledgerConfiguration = mockData.ledgerConfiguration;
+    before(function(done) {
+      this.timeout(TEST_TIMEOUT);
+      async.auto({
+        clean: callback => cache.client.flushall(callback),
+        consensusPlugin: ['clean', (results, callback) => helpers.use(
+          'Continuity2017', callback)],
+        ledgerNode: ['clean', (results, callback) => {
+          brLedgerNode.add(null, {ledgerConfiguration}, (err, ledgerNode) => {
+            if(err) {
+              return callback(err);
+            }
+            nodes.alpha = ledgerNode;
+            callback(null, ledgerNode);
+          });
+        }]
+      }, (err, results) => {
+        assertNoError(err);
+        consensusApi = results.consensusPlugin.api;
+        done();
+      });
+    });
+
+    // get genesis record (block + meta)
+    let genesisRecord;
+    before(function(done) {
+      this.timeout(TEST_TIMEOUT);
+      nodes.alpha.blocks.getGenesis((err, result) => {
+        assertNoError(err);
+        genesisRecord = result.genesisBlock;
+        done();
+      });
+    });
+
+    // add N - 1 more private nodes
+    before(function(done) {
+      this.timeout(TEST_TIMEOUT);
+      async.times(nodeCount - 1, (i, callback) => {
+        brLedgerNode.add(null, {
+          genesisBlock: genesisRecord.block,
+          owner: mockIdentity.identity.id
+        }, (err, ledgerNode) => {
+          assertNoError(err);
+          nodes[nodeLabels[i]] = ledgerNode;
+          callback();
+        });
+      }, err => {
+        assertNoError(err);
+        done();
+      });
+    });
+
+    // populate peers and init heads
+    before(function(done) {
+      this.timeout(TEST_TIMEOUT);
+      async.eachOf(nodes, (ledgerNode, i, callback) =>
+        consensusApi._voters.get(
+          {ledgerNodeId: ledgerNode.id}, (err, result) => {
+            assertNoError(err);
+            peers[i] = result.id;
+            ledgerNode._peerId = result.id;
+            heads[i] = [];
+            callback();
+          }),
+      err => {
+        assertNoError(err);
+        done();
+      });
+    });
+
+    describe('Check Genesis Block', () => {
+      it('should have the proper information', done => {
+        const blockHashes = [];
+        async.auto({
+          getLatest: callback => async.each(nodes, (ledgerNode, callback) =>
+            ledgerNode.storage.blocks.getLatest((err, result) => {
+              assertNoError(err);
+              const eventBlock = result.eventBlock;
+              should.exist(eventBlock.block);
+              eventBlock.block.blockHeight.should.equal(0);
+              eventBlock.block.event.should.be.an('array');
+              eventBlock.block.event.should.have.length(2);
+              const event = eventBlock.block.event[0];
+              // TODO: signature is dynamic... needs a better check
+              delete event.signature;
+              delete event.proof;
+              event.ledgerConfiguration.should.deep.equal(ledgerConfiguration);
+              should.exist(eventBlock.meta);
+              should.exist(eventBlock.block.consensusProof);
+              const consensusProof = eventBlock.block.consensusProof;
+              consensusProof.should.be.an('array');
+              consensusProof.should.have.length(1);
+              // FIXME: make assertions about the contents of consensusProof
+              // console.log('8888888', JSON.stringify(eventBlock, null, 2));
+              blockHashes.push(eventBlock.meta.blockHash);
+              callback();
+            }), callback),
+          testHash: ['getLatest', (results, callback) => {
+            blockHashes.every(h => h === blockHashes[0]).should.be.true;
+            callback();
+          }]
+        }, done);
+      });
+    });
+
+    /*
+     * 1. add new unique operations/records on nodes alpha, beta, gamma, delta
+     * 2. run worker on *all* nodes
+     * 3. repeat 1 and 2 until target block height is reached on all nodes
+     * 4. ensure that blockHash for the target block height is identical on all
+     * 5. settle the network, see notes on _settleNetwork
+     * 6. ensure that the final blockHeight and blockHash is identical on all
+     * 7. attempt to retrieve all records added in 1 from the `records` API
+     */
+
+    const targetBlockHeight = 10;
+
+    describe(`${targetBlockHeight} Blocks`, () => {
+      it('makes many more blocks', function(done) {
+        this.timeout(0);
+        async.auto({
+          nBlocks: callback => _nBlocks(
+            {consensusApi, targetBlockHeight}, (err, result) => {
+              if(err) {
+                return callback(err);
+              }
+              console.log(
+                'targetBlockHashMap',
+                JSON.stringify(result, null, 2));
+              _.values(result.targetBlockHashMap)
+                .every(h => h === result.targetBlockHashMap.alpha)
+                .should.be.true;
+              callback(null, result);
+            }),
+          // inspect outstandingMerge key
+          inspectCache: ['nBlocks', callbackify(async () => {
+            for(const nodeLabel in nodes) {
+              const ledgerNode = nodes[nodeLabel];
+              const ledgerNodeId = ledgerNode.id;
+              const {consensus: {_cache: {cacheKey: _cacheKey}}} = ledgerNode;
+              const outstandingMergeKey = _cacheKey.outstandingMerge(
+                ledgerNodeId);
+              const keys = await cache.client.smembers(outstandingMergeKey);
+              const eventHashes = [];
+              for(const key of keys) {
+                eventHashes.push(key.substr(key.lastIndexOf('|') + 1));
+              }
+              // get events from mongodb
+              const result = await ledgerNode.storage.events.collection.find({
+                'meta.continuity2017.type': 'm',
+                'meta.consensus': false
+              }).project({
+                _id: 0,
+                'meta.eventHash': 1,
+              }).toArray();
+              const mongoEventHashes = result.map(r => r.meta.eventHash);
+              eventHashes.should.have.same.members(mongoEventHashes);
+            }
+          })],
+          // inspect childess hash key
+          inspectCache2: ['inspectCache', callbackify(async () => {
+            for(const nodeLabel in nodes) {
+              const ledgerNode = nodes[nodeLabel];
+              const ledgerNodeId = ledgerNode.id;
+              const {id: creatorId} = await ledgerNode.consensus._voters.get(
+                {ledgerNodeId});
+              const {eventHash: localHeadHash} = await ledgerNode.consensus.
+                _events.getHead({creatorId, ledgerNode, useCache: false});
+              const {consensus: {_cache: {cacheKey: _cacheKey}}} = ledgerNode;
+              const childlessKey = _cacheKey.childless(ledgerNodeId);
+              const keys = await cache.client.smembers(childlessKey);
+              const childlessHashesCache = [];
+              for(const key of keys) {
+                childlessHashesCache.push(key.substr(key.lastIndexOf('|') + 1));
+              }
+              const result = await ledgerNode.storage.events.collection.find({
+                'meta.consensus': false
+              }).project({
+                _id: 0,
+                'meta.eventHash': 1,
+                'event.parentHash': 1,
+              }).toArray();
+              const eventsMap = new Map();
+              for(const e of result) {
+                eventsMap.set(e.meta.eventHash, {
+                  parentHash: e.event.parentHash,
+                  _children: 0,
+                });
+              }
+
+              for(const [, event] of eventsMap) {
+                for(const p of event.parentHash) {
+                  const parent = eventsMap.get(p);
+                  if(parent) {
+                    parent._children++;
+                  }
+                }
+              }
+              const childless = [];
+              for(const [eventHash, event] of eventsMap) {
+                if(event._children === 0 && eventHash !== localHeadHash) {
+                  childless.push(eventHash);
+                }
+              }
+              childlessHashesCache.should.have.same.members(childless);
+            }
+          })],
+          settle: ['inspectCache2', (results, callback) =>
+            helpers.settleNetwork(
+              {consensusApi, nodes: _.values(nodes)}, callback)],
+          blockSummary: ['settle', (results, callback) =>
+            _latestBlockSummary((err, result) => {
+              if(err) {
+                return callback(err);
+              }
+              const summaries = {};
+              Object.keys(result).forEach(k => {
+                summaries[k] = {
+                  blockCollection: nodes[k].storage.blocks.collection.s.name,
+                  blockHeight: result[k].eventBlock.block.blockHeight,
+                  blockHash: result[k].eventBlock.meta.blockHash,
+                  previousBlockHash: result[k].eventBlock.block
+                    .previousBlockHash,
+                };
+              });
+              console.log('Finishing block summaries:', JSON.stringify(
+                summaries, null, 2));
+              _.values(summaries).forEach(b => {
+                b.blockHeight.should.equal(summaries.alpha.blockHeight);
+                b.blockHash.should.equal(summaries.alpha.blockHash);
+              });
+              callback();
+            })],
+          state: ['blockSummary', (results, callback) => {
+            const allRecordIds = [].concat(..._.values(
+              results.nBlocks.recordIds));
+            console.log(`Total operation count: ${allRecordIds.length}`);
+            async.eachSeries(allRecordIds, (recordId, callback) => {
+              nodes.alpha.records.get({recordId}, err => {
+                // just need to ensure that there is no NotFoundError
+                assertNoError(err);
+                callback();
+              });
+            }, callback);
+          }]
+        }, err => {
+          assertNoError(err);
+          done();
+        });
+      });
+    }); // end one block
+  });
+});
+
+function _addOperations({count}, callback) {
+  async.auto({
+    alpha: callback => helpers.addOperation(
+      {count, ledgerNode: nodes.alpha, opTemplate}, callback),
+    beta: callback => helpers.addOperation(
+      {count, ledgerNode: nodes.beta, opTemplate}, callback),
+    gamma: callback => helpers.addOperation(
+      {count, ledgerNode: nodes.gamma, opTemplate}, callback),
+    delta: callback => helpers.addOperation(
+      {count, ledgerNode: nodes.delta, opTemplate}, callback),
+  }, callback);
+}
+
+function _latestBlockSummary(callback) {
+  const blocks = {};
+  async.eachOf(nodes, (ledgerNode, nodeName, callback) => {
+    ledgerNode.storage.blocks.getLatestSummary((err, result) => {
+      blocks[nodeName] = result;
+      callback();
+    });
+  }, err => callback(err, blocks));
+}
+
+function _nBlocks({consensusApi, targetBlockHeight}, callback) {
+  const recordIds = {alpha: [], beta: [], gamma: [], delta: []};
+  const targetBlockHashMap = {};
+  async.until(() => {
+    return Object.keys(targetBlockHashMap).length ===
+      Object.keys(nodes).length;
+  }, callback => {
+    const count = 1;
+    async.auto({
+      operations: callback => _addOperations({count}, callback),
+      workCycle: ['operations', (results, callback) => {
+        // record the IDs for the records that were just added
+        for(const n of ['alpha', 'beta', 'gamma', 'delta']) {
+          for(const opHash of Object.keys(results.operations[n])) {
+            recordIds[n].push(results.operations[n][opHash].record.id);
+          }
+        }
+        // in this test `nodes` is an object that needs to be converted to
+        // an array for the helper
+        helpers.runWorkerCycle(
+          {consensusApi, nodes: _.values(nodes), series: false}, callback);
+      }],
+      report: ['workCycle', (results, callback) => async.forEachOfSeries(
+        nodes, (ledgerNode, i, callback) => {
+          ledgerNode.storage.blocks.getLatestSummary((err, result) => {
+            if(err) {
+              return callback(err);
+            }
+            const {block} = result.eventBlock;
+            if(block.blockHeight >= targetBlockHeight) {
+              return ledgerNode.storage.blocks.getByHeight(
+                targetBlockHeight, (err, result) => {
+                  if(err) {
+                    return callback(err);
+                  }
+                  targetBlockHashMap[i] = result.meta.blockHash;
+                  callback();
+                });
+            }
+            callback();
+          });
+        }, callback)]
+    }, err => {
+      if(err) {
+        return callback(err);
+      }
+      callback();
+    });
+  }, err => {
+    if(err) {
+      return callback(err);
+    }
+    callback(null, {recordIds, targetBlockHashMap});
+  });
+}

--- a/test/test.config.js
+++ b/test/test.config.js
@@ -28,3 +28,6 @@ config['ledger-consensus-continuity'].writer.debounce = 50;
 config.mocha.options.bail = true;
 
 config['https-agent'].rejectUnauthorized = false;
+
+// put jobs stuff in another redis database so db 0 can be flushed
+config.jobs.queueOptions.db = 1;


### PR DESCRIPTION
The new test here flushes the entire redis cache in the middle of our standard Xblock test (with the consensus workers stopped), primes the cache from mongo, and resumes operations and completes successfully with no inconsistencies.

https://github.com/digitalbazaar/bedrock-ledger-consensus-continuity/compare/update-cache-documentation...cache-recovery#diff-c18b592e5026a31cbe11ff10a4acf2d4R187-R195

Now that we have these `prime` APIs, we have to determine how they should be used.