### PR TITLE
Use proper cache key in repairCache test setup.

### DIFF
--- a/test/mocha/075-events-api.js
+++ b/test/mocha/075-events-api.js
@@ -141,14 +141,15 @@ describe('events API', () => {
         rebuildCache: ['merge', (results, callback) => {
           const {mergeHash: eventHash, regularHashes} = results.merge;
 
-          const eventKey = _cacheKey.event({eventHash, ledgerNodeId});
+          const outstandingMergeEventKey = _cacheKey.outstandingMergeEvent(
+            {eventHash, ledgerNodeId});
           const headKey = _cacheKey.head({creatorId, ledgerNodeId});
           const outstandingMergeKey = _cacheKey.outstandingMerge(ledgerNodeId);
           const parentHashes = [...regularHashes];
           cache.client.multi()
             .sadd(childlessKey, parentHashes)
-            .del(eventKey, headKey)
-            .srem(outstandingMergeKey, eventKey)
+            .del(outstandingMergeEventKey, headKey)
+            .srem(outstandingMergeKey, outstandingMergeEventKey)
             .exec(callback);
         }],
         repair: ['rebuildCache', (results, callback) => {
@@ -189,14 +190,15 @@ describe('events API', () => {
         rebuildCache: ['merge', (results, callback) => {
           const {mergeHash: eventHash, regularHashes} = results.merge;
 
-          const eventKey = _cacheKey.event({eventHash, ledgerNodeId});
+          const outstandingMergeEventKey = _cacheKey.outstandingMergeEvent(
+            {eventHash, ledgerNodeId});
           const headKey = _cacheKey.head({creatorId, ledgerNodeId});
           const outstandingMergeKey = _cacheKey.outstandingMerge(ledgerNodeId);
           const parentHashes = [...regularHashes];
           cache.client.multi()
             .sadd(childlessKey, parentHashes)
-            .del(eventKey, headKey)
-            .srem(outstandingMergeKey, eventKey)
+            .del(outstandingMergeEventKey, headKey)
+            .srem(outstandingMergeKey, outstandingMergeEventKey)
             .exec(callback);
         }],
         repair: ['rebuildCache', (results, callback) => {

--- a/test/mocha/080-blocks-api.js
+++ b/test/mocha/080-blocks-api.js
@@ -145,12 +145,12 @@ describe('blocks API', () => {
           const ledgerNodeId = nodes.alpha.id;
           const blockHeightKey = _cacheKey.blockHeight(ledgerNodeId);
           const outstandingMergeKey = _cacheKey.outstandingMerge(ledgerNodeId);
-          const eventKeys = hashes.map(eventHash => _cacheKey.event(
-            {eventHash, ledgerNodeId}));
+          const outstandingMergeEventKeys = hashes.map(eventHash =>
+            _cacheKey.outstandingMergeEvent({eventHash, ledgerNodeId}));
           const multi = cache.client.multi();
-          multi.sadd(outstandingMergeKey, eventKeys);
+          multi.sadd(outstandingMergeKey, outstandingMergeEventKeys);
           multi.set(blockHeightKey, 0);
-          eventKeys.forEach(k => multi.set(
+          outstandingMergeEventKeys.forEach(k => multi.set(
             k, JSON.stringify({test: 'string'})));
           multi.exec(callback);
         },
@@ -206,12 +206,12 @@ describe('blocks API', () => {
           const ledgerNodeId = nodes.alpha.id;
           const blockHeightKey = _cacheKey.blockHeight(ledgerNodeId);
           const outstandingMergeKey = _cacheKey.outstandingMerge(ledgerNodeId);
-          const eventKeys = hashes.map(eventHash => _cacheKey.event(
-            {eventHash, ledgerNodeId}));
+          const outstandingMergeEventKeys = hashes.map(eventHash =>
+            _cacheKey.outstandingMergeEvent({eventHash, ledgerNodeId}));
           const multi = cache.client.multi();
-          multi.sadd(outstandingMergeKey, eventKeys);
+          multi.sadd(outstandingMergeKey, outstandingMergeEventKeys);
           multi.set(blockHeightKey, 499);
-          eventKeys.forEach(k => multi.set(
+          outstandingMergeEventKeys.forEach(k => multi.set(
             k, JSON.stringify({test: 'string'})));
           multi.exec(callback);
         }],


### PR DESCRIPTION
The test setups for existing repair functions needed to be updated to use the new `_cacheKey.outstandingMergeEvent` API.