### PR TITLE
Include merge generation in recent history.

### DIFF
--- a/lib/cache/events.js
+++ b/lib/cache/events.js
@@ -102,7 +102,7 @@ exports.addLocalMergeEvent = async ({event, meta, ledgerNodeId}) => {
   // is all that is needed for consensus to be computed
   const eventSummary = JSON.stringify({
     event: {parentHash, treeHash, type},
-    meta: {eventHash, continuity2017: {creator: creatorId}}
+    meta: {eventHash, continuity2017: {creator: creatorId, generation}}
   });
   try {
     const message = `merge|${JSON.stringify([creatorId])}`;
@@ -493,13 +493,13 @@ exports.getRecentHistory = async ({ledgerNodeId}) => {
     const parsed = JSON.parse(eventSummaryJson);
     const {eventHash} = parsed.meta;
     const {parentHash, treeHash, type} = parsed.event;
-    const {creator} = parsed.meta.continuity2017;
+    const {creator, generation} = parsed.meta.continuity2017;
     const doc = {
       _children: [],
       _parents: [],
       eventHash,
       event: {parentHash, treeHash, type},
-      meta: {continuity2017: {creator}}
+      meta: {continuity2017: {creator, generation}}
     };
     events.push(doc);
     eventMap[eventHash] = doc;


### PR DESCRIPTION
With this, the events and eventMap returned by getRecentHistory includes the `generation` for the merge event which can be used to restrict the depth of history.