### PR TITLE
Implement history.getRecentHistory API.

### DIFF
--- a/lib/history.js
+++ b/lib/history.js
@@ -1,0 +1,148 @@
+/*!
+ * Copyright (c) 2017-2019 Digital Bazaar, Inc. All rights reserved.
+ */
+'use strict';
+
+const _cacheKey = require('./cache/cache-key');
+const _events = require('./events');
+const _voters = require('./voters');
+const cache = require('bedrock-redis');
+const {util: {BedrockError}} = require('bedrock');
+
+/**
+ * Get non-consensus ledger history.
+ *
+ * @param {Object} options - The options to use.
+ * @param {Array<string>} options.creatorIds - The creator IDs of interest.
+ * @param {Object} options.ledgerNode - The node that is tracking the history.
+ * @param {Number} options.maxDepth - The maximum number of generations
+ *   to include in the history for each creator.
+ *
+ * @returns {Promise} that resolves once the operation completes.
+ */
+// FIXME: defaulting maxDepth until callers are updated
+exports.getRecentHistory = async ({creatorIds, ledgerNode, maxDepth = 100}) => {
+
+  // get ids for all the creators known to the node
+  // FIXME: this is problematic... we can't possibly return ALL creators
+  // ever known to the node when the network (and its history) gets quite
+  // large.
+  // localCreators is an array of strings which are peerIds (URLs)
+  const localCreators = await _voters.getPeerIds({ledgerNode});
+
+  // FIXME defaulting this until the caller passes it in
+  creatorIds = creatorIds || localCreators;
+
+  const consensusHeads = await _getConsensusHeads({ledgerNode, localCreators});
+
+  const {aggregateHistory, getHead} = ledgerNode.storage.events
+    .plugins['continuity-storage'];
+
+  const creatorHeads = {};
+  await Promise.all(localCreators.map(async creatorId => {
+    creatorHeads[creatorId] = await _events.getHead({creatorId, ledgerNode});
+  }));
+
+  const {creatorRestriction, startParentHash} = await _computeAggregateParams({
+    consensusHeads, creatorHeads, creatorIds, getHead, maxDepth
+  });
+
+  const events = [];
+  const eventMap = {};
+  if(startParentHash.length === 0) {
+    return {events, eventMap};
+  }
+  const eventHistory = await aggregateHistory({
+    creatorRestriction,
+    eventTypeFilter: 'ContinuityMergeEvent',
+    startParentHash
+  });
+  if(eventHistory.length === 0) {
+    return {events, eventMap};
+  }
+  const ledgerNodeId = ledgerNode.id;
+  const outstandingMergeEventKeys = eventHistory.map(({meta: {eventHash}}) =>
+    _cacheKey.outstandingMergeEvent({eventHash, ledgerNodeId}));
+  const result = await cache.client.mget(outstandingMergeEventKeys);
+  // sanity check to ensure all merge events could be retrieved... if
+  // `null` is in the array then at least one is missing
+  if(result.includes(null)) {
+    // FIXME: this is a signal that the cache recovery would need to be run.
+    throw new BedrockError(
+      'One or more events are missing from the cache.',
+      'InvalidStateError', {
+        httpStatusCode: 400,
+        public: true,
+      });
+  }
+
+  for(const eventSummaryJson of result) {
+    const parsed = JSON.parse(eventSummaryJson);
+    const {eventHash} = parsed.meta;
+    const {parentHash, treeHash, type} = parsed.event;
+    const {creator} = parsed.meta.continuity2017;
+    const doc = {
+      _children: [],
+      _parents: [],
+      eventHash,
+      event: {parentHash, treeHash, type},
+      meta: {continuity2017: {creator}}
+    };
+    events.push(doc);
+    eventMap[eventHash] = doc;
+  }
+
+  return {events, eventMap};
+};
+
+async function _computeAggregateParams({
+  consensusHeads, creatorHeads, creatorIds, getHead, maxDepth
+}) {
+  const startParentHash = [];
+  // creator restriction defines the base of the branches which are the
+  // most recent consensus merge events for each branch
+  const creatorRestriction = [];
+  for(const creatorId of creatorIds) {
+    const consensusHead = consensusHeads.get(creatorId);
+    // there may not be a consensusHead for the creator if it's a new node
+    // or when the ledger is starting up etc.
+    const consensusGeneration = consensusHead ? consensusHead.generation : 0;
+    creatorRestriction.push(
+      {creator: creatorId, generation: consensusGeneration});
+
+    const maxGeneration = consensusGeneration + maxDepth;
+    const {
+      generation: currentGeneration,
+      eventHash: currentGenerationEventHash
+    } = creatorHeads[creatorId];
+    if(currentGeneration <= maxGeneration) {
+      // the current head is within range, use it
+      startParentHash.push(currentGenerationEventHash);
+    } else {
+      const [{meta: {eventHash}}] = await getHead(
+        {creatorId, generation: maxGeneration});
+      startParentHash.push(eventHash);
+    }
+  }
+  return {creatorRestriction, startParentHash};
+}
+
+async function _getConsensusHeads({ledgerNode, localCreators}) {
+  // get the latest merge event for peer that has consensus
+  const result = new Map();
+  const query = {
+    'meta.continuity2017.type': 'm',
+    'meta.continuity2017.creator': {$in: localCreators},
+    'meta.consensus': true,
+  };
+  (await ledgerNode.storage.events.collection.aggregate([
+    {$match: query},
+    {$sort: {'meta.continuity2017.generation': -1}},
+    {$group: {
+      _id: '$meta.continuity2017.creator',
+      generation: {$first: '$meta.continuity2017.generation'},
+    }},
+  ]).toArray()).forEach(r => result.set(r._id, {generation: r.generation}));
+
+  return result;
+}

--- a/lib/history.js
+++ b/lib/history.js
@@ -43,9 +43,10 @@ exports.getRecentHistory = async ({creatorIds, ledgerNode, maxDepth = 100}) => {
     creatorHeads[creatorId] = await _events.getHead({creatorId, ledgerNode});
   }));
 
-  const {creatorRestriction, startParentHash} = await _computeAggregateParams({
-    consensusHeads, creatorHeads, creatorIds, getHead, maxDepth
-  });
+  const {creatorRestriction, hasMore, startParentHash} =
+    await _computeAggregateParams({
+      consensusHeads, creatorHeads, creatorIds, getHead, maxDepth
+    });
 
   const events = [];
   const eventMap = {};
@@ -92,12 +93,13 @@ exports.getRecentHistory = async ({creatorIds, ledgerNode, maxDepth = 100}) => {
     eventMap[eventHash] = doc;
   }
 
-  return {events, eventMap};
+  return {events, eventMap, hasMore};
 };
 
 async function _computeAggregateParams({
   consensusHeads, creatorHeads, creatorIds, getHead, maxDepth
 }) {
+  let hasMore = false;
   const startParentHash = [];
   // creator restriction defines the base of the branches which are the
   // most recent consensus merge events for each branch
@@ -119,12 +121,13 @@ async function _computeAggregateParams({
       // the current head is within range, use it
       startParentHash.push(currentGenerationEventHash);
     } else {
+      hasMore = true;
       const [{meta: {eventHash}}] = await getHead(
         {creatorId, generation: maxGeneration});
       startParentHash.push(eventHash);
     }
   }
-  return {creatorRestriction, startParentHash};
+  return {creatorRestriction, hasMore, startParentHash};
 }
 
 async function _getConsensusHeads({ledgerNode, localCreators}) {

--- a/lib/worker/consensus.js
+++ b/lib/worker/consensus.js
@@ -6,8 +6,7 @@
 const _blocks = require('../blocks');
 const _cache = require('../cache');
 const _election = require('../election');
-const _events = require('../events');
-const _voters = require('../voters');
+const _history = require('../history');
 const bedrock = require('bedrock');
 const logger = require('../logger');
 const {BedrockError} = bedrock.util;
@@ -83,13 +82,7 @@ exports.extendBlockchain = async ({ledgerNode, halt}) => {
  * @returns {Promise}
  */
 async function _findConsensus({ledgerNode, state}) {
-  const ledgerNodeId = ledgerNode.id;
-  const creator = await _voters.get({ledgerNodeId});
-  const history = await _events.getRecentHistory({
-    creatorId: creator.id,
-    excludeLocalRegularEvents: true,
-    ledgerNode,
-  });
+  const history = await _history.getRecentHistory({ledgerNode});
 
   // Note: DO NOT LOG RESULTS OF FINDCONSENSUS
   logger.verbose('Starting extendBlockchain.findConsensus.');

--- a/lib/worker/consensus.js
+++ b/lib/worker/consensus.js
@@ -82,6 +82,9 @@ exports.extendBlockchain = async ({ledgerNode, halt}) => {
  * @returns {Promise}
  */
 async function _findConsensus({ledgerNode, state}) {
+  // TODO: pass in `maxDepth` to indicate how many generations are desired
+  // TODO: `history.hasMore` indicates if there is more history available
+  // beyond the specified `maxDepth` value.
   const history = await _history.getRecentHistory({ledgerNode});
 
   // Note: DO NOT LOG RESULTS OF FINDCONSENSUS


### PR DESCRIPTION
@dlongley here's the API you requested.  It's my suggestion that the gossip and event writer agent be allowed to operate basically as it is now, but with better guidance on peer selection.

Flushing the event writer immediately before a merge or computing a merge would be great.

As for the merge and consensus agents, maybe those can be pipelined together or what have you.

All tests are passing with this except for one assertion as noted in a fixme.

I structured this so it could easily be cherry picked onto another branch.