### PR TITLE
Single pipeline gossip tweaks.

### DIFF
--- a/lib/cache/gossip.js
+++ b/lib/cache/gossip.js
@@ -17,8 +17,12 @@ const _cacheKey = require('./cache-key');
  */
 exports.addNotification = async ({ledgerNodeId, peerId}) => {
   const key = _cacheKey.gossipNotification(ledgerNodeId);
-  // a set is used here because it only allows unique values
-  return cache.client.sadd(key, peerId);
+  // a set is used here because it enforces unique values
+  // FIXME: limit size of this set
+  return cache.client.multi()
+    .sadd(key, peerId)
+    .publish(`continuity2017|needsMerge|${ledgerNodeId}`, 'notification')
+    .exec();
 };
 
 /**

--- a/lib/events.js
+++ b/lib/events.js
@@ -682,39 +682,40 @@ api.difference = async ({eventHashes, ledgerNode}) => {
   return ledgerNode.storage.events.difference(notFound);
 };
 
-api.getMergeStatus = async ({
-  ledgerNode, creatorId, priorityPeers = [], checkOperations = false
-}) => {
+api.getMergeStatus = async ({ledgerNode, creatorId, priorityPeers = []}) => {
   const ledgerNodeId = ledgerNode.id;
   const status = await _cache.events.getMergeStatus({ledgerNodeId});
   const {peerChildlessHashes} = status;
 
   // if there are no peer events to merge and there are `priorityPeers`
   // but `creatorId` is not one of them, do not merge
+  let mergeable = true;
   if(peerChildlessHashes.length === 0 &&
     (priorityPeers.length > 0 && !priorityPeers.includes(creatorId))) {
-    return {mergeable: false, ...status};
+    mergeable = false;
   }
 
-  // if no outstanding regular events to merge, nothing to merge
+  // report outstanding regular events
   const {hasOutstandingRegularEvents} = ledgerNode.storage.events
     .plugins['continuity-storage'];
-  if(!await hasOutstandingRegularEvents()) {
-    if(!checkOperations) {
-      // not checking for outstanding operations, so not mergeable
-      return {mergeable: false, ...status};
-    }
+  status.hasOutstandingRegularEvents = await hasOutstandingRegularEvents();
 
-    // check if any outstanding operations could be merged...
-    // TODO: optimize checking for outstanding operations
-    const queue = new _cache.OperationQueue({ledgerNodeId});
-    if(!await queue.hasNextChunk()) {
-      // no outstanding operations, so nothing to merge
-      return {mergeable: false, ...status};
-    }
+  // report outstanding local operations
+  // TODO: optimize checking for outstanding operations
+  const queue = new _cache.OperationQueue({ledgerNodeId});
+  status.hasOutstandingLocalOperations = await queue.hasNextChunk();
+
+  // report any outstanding operations (already in regular events or not)
+  status.hasOutstandingOperations = status.hasOutstandingRegularEvents ||
+    status.hasOutstandingLocalOperations;
+
+  // if no outstanding regular events and no outstanding local operations,
+  // then there is nothing to merge
+  if(!status.hasOutstandingOperations) {
+    mergeable = false;
   }
 
-  return {mergeable: true, ...status};
+  return {mergeable, ...status};
 };
 
 async function _genesisProofCreate({ledgerNode, eventHash}) {

--- a/lib/worker/GossipPeer.js
+++ b/lib/worker/GossipPeer.js
@@ -1,5 +1,5 @@
 /*!
- * Copyright (c) 2017-2018 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2017-2019 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 
@@ -39,6 +39,17 @@ module.exports = class GossipPeer {
     };
   }
 
+  async clearBackoff() {
+    this._backoff = 0;
+    // TODO: do we want to record this?
+  }
+
+  async isRecommended() {
+    const {backoff, lastContactDate} = await this.getStatus();
+    const nextContact = lastContactDate + backoff;
+    return nextContact <= Date.now();
+  }
+
   async fail(err) {
     logger.error('Gossip peer failure.', {error: err});
     const {creatorId, ledgerNodeId} = this;
@@ -56,9 +67,9 @@ module.exports = class GossipPeer {
     });
   }
 
-  async success() {
+  async success({backoff = 0}) {
     const {creatorId, ledgerNodeId} = this;
-    this._backoff = 0;
+    this._backoff = backoff;
     this._lastContactDate = Date.now();
     this._lastContactResult = 'success';
     // record success

--- a/lib/worker/GossipPeerSelector.js
+++ b/lib/worker/GossipPeerSelector.js
@@ -5,11 +5,7 @@
 
 const _ = require('lodash');
 const _cache = require('../cache');
-const bedrock = require('bedrock');
-const {config} = bedrock;
 const GossipPeer = require('./GossipPeer');
-
-const {coolDownPeriod} = config['ledger-consensus-continuity'].gossip;
 
 module.exports = class GossipPeerSelector {
   constructor({creatorId, ledgerNode}) {
@@ -30,18 +26,24 @@ module.exports = class GossipPeerSelector {
       {ledgerNodeId});
     if(notification && !candidates.includes(notification)) {
       candidates.unshift(notification);
+      // TODO: we need to be able to distinguish good peers from bad ones
+      // ...so we can ignore `backoff` for good peers that have more to
+      // ...say and not ignore it for bad peers... also we may still timeout
+      // ...and never contact this peer meaning no one will get their
+      // ...operations if they are not a priority peer; they should resend
+      // ...notifications if no one has pulled from them
+      const peer = this.getGossipPeer({creatorId: notification});
+      peer.clearBackoff();
     }
 
-    return this._filterPeers({candidates, priorityPeers, coolDownPeriod});
+    return candidates.map(creatorId => this.getGossipPeer({creatorId}));
   }
 
   async getNotifyPeers({priorityPeers}) {
     // get priority peers to notify, removing self from list
     const {creatorId} = this;
     const candidates = _.shuffle(priorityPeers.filter(p => p !== creatorId));
-
-    // Note: `coolDownPeriod` does not apply to notifications
-    return this._filterPeers({candidates, priorityPeers, coolDownPeriod: 0});
+    return candidates.map(creatorId => this.getGossipPeer({creatorId}));
   }
 
   getGossipPeer({creatorId}) {
@@ -52,24 +54,5 @@ module.exports = class GossipPeerSelector {
       candidateMap.set(creatorId, gossipPeer);
     }
     return gossipPeer;
-  }
-
-  async _filterPeers({candidates, priorityPeers, coolDownPeriod = 0}) {
-    // filter set of peers to notify by earliest next contact
-    const filtered = [];
-    const now = Date.now();
-    for(const creatorId of candidates) {
-      const gossipPeer = this.getGossipPeer({creatorId});
-      const {backoff, lastContactDate} = await gossipPeer.getStatus();
-      let earliestNextContact = lastContactDate + backoff;
-      if(!priorityPeers.includes(creatorId)) {
-        // TODO: need to be smarter about cool down period
-        earliestNextContact += coolDownPeriod;
-      }
-      if(earliestNextContact < now) {
-        filtered.push(gossipPeer);
-      }
-    }
-    return filtered;
   }
 };

--- a/lib/worker/gossip.js
+++ b/lib/worker/gossip.js
@@ -7,23 +7,36 @@ const _cache = require('../cache');
 const _client = require('../client');
 const _events = require('../events');
 const _gossip = require('../gossip');
+const bedrock = require('bedrock');
+const {config} = bedrock;
 const logger = require('../logger');
 
+const {coolDownPeriod} = config['ledger-consensus-continuity'].gossip;
+
 exports.runGossipCycle = async ({
-  ledgerNode, priorityPeers, creatorId, peerSelector, mergePermits, halt
+  ledgerNode, priorityPeers, creatorId, peerSelector, mergePermits,
+  needsGossip, halt
 }) => {
-  // use up to all but 1 merge permit, leaving it to create a local merge event
-  const startingPermits = mergePermits - 1;
+  // attempt to use all merge permits given
+  const startingPermits = mergePermits;
   let remainingPermits = startingPermits;
   let mergePermitsConsumed = 0;
 
   // get a set of peers to communicate with during this cycle
   const peers = await peerSelector.getPeers({priorityPeers});
+  const priorityPeerSet = new Set(priorityPeers);
   while(peers.length > 0 && remainingPermits > 0 && !halt()) {
     const peer = peers.shift();
 
+    // if we don't need gossip or the peer isn't a priority peer, then don't
+    // contact the peer if not recommended
+    // if(!(needsGossip && priorityPeerSet.has(needsGossip)) &&
+    //   !await peer.isRecommended()) {
+    //   continue;
+    // }
+
     // use up to 50% of remaining merge permits on a non-priority peer
-    const mergePermits = priorityPeers.includes(peer.creatorId) ?
+    const mergePermits = priorityPeerSet.has(peer.creatorId) ?
       remainingPermits : Math.ceil(remainingPermits / 2);
 
     // gossip with `peer`
@@ -104,9 +117,12 @@ async function _gw({ledgerNode, mergePermits, creatorId, peer}) {
   if(err && err.name !== 'TimeoutError') {
     await peer.fail(err);
   } else {
-    // TODO: do not fail peers exceeding maxRetries, but in the future
-    // back-off peers that repeatedly fail max retries
-    await peer.success();
+    let backoff = 0;
+    if(result && result.done) {
+      // no more gossip from the peer, add `coolDownPeriod` to backoff
+      backoff = coolDownPeriod;
+    }
+    await peer.success({backoff});
   }
 
   return {mergePermitsConsumed};

--- a/lib/worker/index.js
+++ b/lib/worker/index.js
@@ -81,7 +81,7 @@ async function _sync(session) {
   } catch(e) {
     subscriber.quit();
     logger.verbose(
-      'Work session failed, could not subscribe to new operation messages.',
+      'Work session failed, could not subscribe to new pub/sub messages.',
       {session: session.id});
     return;
   }
@@ -93,6 +93,7 @@ async function _sync(session) {
     const creatorId = (await _voters.get({ledgerNodeId})).id;
     const peerSelector = new GossipPeerSelector({creatorId, ledgerNode});
     const eventWriter = new EventWriter({ledgerNode});
+    let needsGossip = true;
 
     // run consensus/gossip/merge pipeline until work session expires
     while(!halt()) {
@@ -109,7 +110,7 @@ async function _sync(session) {
       // a local merge event
       let {mergePermitsConsumed} = await runGossipCycle({
         ledgerNode, priorityPeers, creatorId, peerSelector,
-        mergePermits: mergePermits - 1, halt
+        mergePermits: mergePermits - 1, needsGossip, halt
       });
 
       // work session expired
@@ -121,8 +122,9 @@ async function _sync(session) {
       await eventWriter.write();
 
       // 4. merge if possible
-      const {merged} = await merge(
+      const {merged, hasOutstandingOperations} = await merge(
         {ledgerNode, creatorId, priorityPeers, halt});
+      needsGossip = hasOutstandingOperations;
 
       // determine if peers need to be notified
       let notify;
@@ -146,9 +148,10 @@ async function _sync(session) {
         }
       }
 
-      // if no merge permits were consumed, delay for cool down period or
-      // until a local operation notification comes in
-      if(!halt() && mergePermitsConsumed === 0) {
+      // if no merge permits were consumed and no gossip is needed, delay for
+      // cool down period or until a peer notification or a local operation
+      // notification comes in
+      if(!halt() && mergePermitsConsumed === 0 && !needsGossip) {
         await new Promise(resolve => {
           resume = resolve;
           setTimeout(() => resolve(), coolDownPeriod);

--- a/lib/worker/merge.js
+++ b/lib/worker/merge.js
@@ -20,14 +20,15 @@ exports.merge = async ({ledgerNode, creatorId, priorityPeers, halt}) => {
 
     // get merge status
     const mergeStatus = await _events.getMergeStatus(
-      {ledgerNode, creatorId, priorityPeers, checkOperations: true});
+      {ledgerNode, creatorId, priorityPeers});
     const {
-      mergeable, peerChildlessHashes, localChildlessHashes
+      mergeable, peerChildlessHashes, localChildlessHashes,
+      hasOutstandingOperations
     } = mergeStatus;
 
     // can't merge yet; we'll run again when later to try again
     if(!mergeable) {
-      return {merged: false};
+      return {merged: false, hasOutstandingOperations};
     }
 
     // up to 50% of parent spots are for peer merge events, one spot is
@@ -51,13 +52,13 @@ exports.merge = async ({ledgerNode, creatorId, priorityPeers, halt}) => {
     // priority peer, then don't merge
     if(regularEvents === 0 &&
       (priorityPeers.length > 0 && !priorityPeers.includes(creatorId))) {
-      return {merged: false};
+      return {merged: false, hasOutstandingOperations};
     }
 
     // do the merge
     if(!halt()) {
       const record = await _events.merge({creatorId, ledgerNode, mergeStatus});
-      return {merged: !!record, record};
+      return {merged: !!record, record, hasOutstandingOperations};
     }
   } catch(e) {
     logger.error(`Error during merge: ${ledgerNode.id}`, {error: e});


### PR DESCRIPTION
- Always report outstanding operations of any sort.
- Use outstanding operations to set `needsGossip` flag.
- Check recommended peer contact within gossip cycle instead
  of when peers are selected to account for time passage
  during gossip with other peers.
- Fix off by one bug with merge permits.