### PR TITLE
Simulator fast compare

### DIFF
--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -1311,7 +1311,7 @@ function _compareSupportSet(set1, set2) {
 }
 
 function _compareEventHashes(a, b) {
-  return a.eventHash.localeCompare(b.eventHash);
+  return (a.eventHash < b.eventHash ? -1 : (a.eventHash > b.eventHash ? 1 : 0));
 }
 
 function _computeProposalEndorsement({


### PR DESCRIPTION
I don't think there is any reason this should be using `localCompare` as it does not use any unusual characters.  The profile shows an 10X performance improvement.  Total time before was 3099ms (11% of total), after 318ms (1.16% of total).

**However**, this is likely a breaking change because as this replit shows, the sorted results are not the same.  The two algorithms treat uppercase/lowercase characters differently.  https://repl.it/@mattcollier/GrumpyCompassionateConstant#index.js

See discussion: https://stackoverflow.com/questions/14677060/400x-sorting-speedup-by-switching-a-localecompareb-to-ab-1ab10

## Before
![Screenshot from 2020-11-14 20-25-36](https://user-images.githubusercontent.com/902041/99160679-b0ae0f80-26b7-11eb-8e34-655c04c7b056.png)

## After
![Screenshot from 2020-11-14 20-24-49](https://user-images.githubusercontent.com/902041/99160686-c8859380-26b7-11eb-87ff-512a8be7988e.png)
