### PR TITLE
Optimize iteration in _tallyBranches.

### DIFF
--- a/lib/consensus.js
+++ b/lib/consensus.js
@@ -974,10 +974,24 @@ function _tallyBranches({
           _computeMostRecentVotes({event, yElectorSet, yByElector});
         }
         // if some voting ancestors haven't computed support yet, defer
-        const votingEvents = Object.values(event._votes);
-        if(votingEvents.some(
-          e => e && e !== event && e._supporting === undefined)) {
-          next.push(event);
+        let pushed = false;
+        for(const v in event._votes) {
+          const e = event._votes[v];
+          // FIXME: remove this conditional, e is undefined in exactly one
+          // place in the test
+          // suite which is some of the findConsensus figures. Specifically
+          // seems to be in relation to a node `b` there.
+          if(!e) {
+            console.log('VVVVVVVVVVVVVv', v);
+            console.log(event._votes);
+          }
+          if(e && e !== event && e._supporting === undefined) {
+            next.push(event);
+            pushed = true;
+            break;
+          }
+        }
+        if(pushed) {
           continue;
         }
       }


### PR DESCRIPTION
This code is in the hot path.  When there are 31 electors (for instance) the `votingEvents` array allocated on L977 is 31 items long and it is the hope that we hit the `some` short circuit sooner rather than later.  This 32 position array is created and destroyed many times.  The new algorithm skips the provisioning of this array, but is still functionally the same.  The full test suite passes with this change.

That said, we never actually fall into the conditional on the new line 988 except in synthetic ledger histories in the test suite. So I would like to discuss the necessity for some of this code existing in the first place. 