### PR TITLE
Remove deferred events

### DIFF
--- a/lib/cache/cacheKey.js
+++ b/lib/cache/cacheKey.js
@@ -48,9 +48,6 @@ api.genesis = ledgerNodeId => `g|${_lni(ledgerNodeId)}`;
 api.head = ({creatorId, ledgerNodeId}) =>
   `h|${_lni(ledgerNodeId)}|${_ci(creatorId)}`;
 
-api.headGeneration = ({eventHash, ledgerNodeId}) =>
-  `hg|${_lni(ledgerNodeId)}|${eventHash}`;
-
 // hash portion of the voterId
 api.gossipNotification = ledgerNodeId => `gn|${_lni(ledgerNodeId)}`;
 

--- a/lib/cache/events.js
+++ b/lib/cache/events.js
@@ -102,6 +102,7 @@ exports.addLocalMergeEvent = async ({event, meta, ledgerNodeId}) => {
   const outstandingMergeKey = _cacheKey.outstandingMerge(ledgerNodeId);
   const {parentHash, treeHash, type} = event;
   const parentHashes = parentHash.filter(h => h !== treeHash);
+  // FIXME: do we need `headGeneration` at all anymore? remove it if not
   // no need to set a headGeneration key here, those are only used for
   // processing peer merge events
 
@@ -297,6 +298,7 @@ exports.setEventGossip = async (
     .exec();
 };
 
+// FIXME: is this function used any more? remove it if not
 /**
  * Gets the generation for a single event identified by the given event hash
  * and stored by the given ledger node. The generation indicates the order of

--- a/lib/cache/events.js
+++ b/lib/cache/events.js
@@ -47,8 +47,6 @@ exports.addPeerEvent = async ({event, meta, ledgerNodeId}) => {
   }
   if(type === 'm') {
     const {basisBlockHeight, mergeHeight} = event;
-    const headGenerationKey = _cacheKey.headGeneration(
-      {eventHash, ledgerNodeId});
     const latestPeerHeadKey = _cacheKey.latestPeerHead(
       {creatorId, ledgerNodeId});
     // expire the key in an hour, in case the peer/creator goes dark
@@ -60,8 +58,6 @@ exports.addPeerEvent = async ({event, meta, ledgerNodeId}) => {
       'mh', mergeHeight,
       'la', localAncestorGeneration);
     txn.expire(latestPeerHeadKey, 3600);
-    // this key is set to expire in the event-writer
-    txn.set(headGenerationKey, generation);
   }
   // add the hash to the set used to check for dups and ancestors
   txn.sadd(eventQueueSetKey, eventHash);
@@ -102,9 +98,6 @@ exports.addLocalMergeEvent = async ({event, meta, ledgerNodeId}) => {
   const outstandingMergeKey = _cacheKey.outstandingMerge(ledgerNodeId);
   const {parentHash, treeHash, type} = event;
   const parentHashes = parentHash.filter(h => h !== treeHash);
-  // FIXME: do we need `headGeneration` at all anymore? remove it if not
-  // no need to set a headGeneration key here, those are only used for
-  // processing peer merge events
 
   // full event without meta goes into cache for gossip purposes
   const fullEvent = JSON.stringify({event});
@@ -296,85 +289,6 @@ exports.setEventGossip = async (
     .hmset(eventKey, 'event', eventString, 'meta', metaString)
     .expire(eventKey, expire)
     .exec();
-};
-
-// FIXME: is this function used any more? remove it if not
-/**
- * Gets the generation for a single event identified by the given event hash
- * and stored by the given ledger node. The generation indicates the order of
- * an event relative to its creator node. A generation of `0` is the genesis
- * event and events count up from there, scoped to each node.
- *
- * @param eventHash {string} - The hash of the event.
- * @param ledgerNodeId {string} - The ID of the ledger node.
- *
- * @returns {Promise<Number|null>} The generation for the event.
- */
-exports.getGeneration = async ({eventHash, ledgerNodeId}) => {
-  // first check cache
-  const key = _cacheKey.headGeneration({eventHash, ledgerNodeId});
-  const generation = await cache.client.get(key);
-  if(generation !== null) {
-    return parseInt(generation, 10);
-  }
-  // no generation found for the eventHash
-  return null;
-};
-
-/**
- * Bulk sets the generation for every event in the given Map.
- *
- * @param generationMap {Map} - A Map of eventHash => generation to set.
- * @param ledgerNodeId {string} - The ID of the ledger node.
- *
- * @returns {Promise} resolves once the operation completes.
- */
-exports.setGenerations = async ({generationMap, ledgerNodeId}) => {
-  if(generationMap.size === 0) {
-    // nothing to do
-    return;
-  }
-  // use a single atomic transaction to set all generations
-  const txn = cache.client.multi();
-  for(const [eventHash, generation] of generationMap) {
-    const key = _cacheKey.headGeneration({eventHash, ledgerNodeId});
-    txn.set(key, generation, 'EX', 36000);
-  }
-  return txn.exec();
-};
-
-/**
- * Bulk gets the generations for all events identified by the given hashes.
- *
- * @param eventHashes {string[]} - The hashes of the events.
- * @param ledgerNodeId {string} - The ID of the ledger node.
- *
- * @returns {Promise<Object>} An object with:
- *         generationMap: a Map of eventHash => generation where the entries
- *           will preserve the order of `eventHashes`; any missing generation
- *           will be `null`.
- *         notFound: an array of eventHashes that were not found.
- */
-exports.getGenerations = async ({eventHashes, ledgerNodeId}) => {
-  // create keys in order (ensures event hash order is preserved)
-  const keys = eventHashes.map(eventHash =>
-    _cacheKey.headGeneration({eventHash, ledgerNodeId}));
-  const generations = await cache.client.mget(keys);
-
-  // insert entries into generation map in order
-  const generationMap = new Map();
-  const notFound = [];
-  let index = 0;
-  for(const eventHash in eventHashes) {
-    const generation = generations[index++];
-    if(generation === null) {
-      notFound.push(eventHash);
-      generationMap.set(eventHash, null);
-    } else {
-      generationMap.set(eventHash, parseInt(generation, 10));
-    }
-  }
-  return {generationMap, notFound};
 };
 
 /**

--- a/lib/peerEvents.js
+++ b/lib/peerEvents.js
@@ -48,43 +48,16 @@ api.addBatch = async ({blockHeight, events, ledgerNode, needed}) => {
     blockHeight, events, ledgerNode, needed
   });
 
-  const deferredEvents = [];
   for(const [eventHash, {event, meta, rawEvent, _temp}] of eventMap) {
-    const {valid, requiredBlockHeight} = _temp;
+    const {valid} = _temp;
     if(!valid) {
-      throw new BedrockError(
-        'An unrelated event was detected in the batch.', 'DataError', {
-          // eventRecord,
-          httpStatusCode: 400,
-          public: true,
-        });
-    }
-    if(requiredBlockHeight) {
-      deferredEvents.push({eventHash, requiredBlockHeight});
-      // remove this merge event from the eventMap
-      eventMap.delete(eventHash);
+      // FIXME: do we want to reject the whole batch here? note that what
+      // we have that is valid can be accepted due to new _validateGraph
+      // algorithm that ensures we depth-first validate
       continue;
     }
 
     if(meta.continuity2017.type === 'm') {
-      if(deferredEvents.length > 0 && _temp.insideBatch.length > 0) {
-        // if no events have been deferred, it is not necessasry to check the
-        // processedEventHashes against the insideBatch list. We know that the
-        // ancestors were ordered in the batch prior to this event. If none
-        // of those ancestors were deferred, it is safe to proceed without the
-        // additional check.
-
-        // ensure every event referenced inside the batch has been processed.
-        // Some of this merge event's ancestors inside this batch may have been
-        // deferred. If so, this event must be deferred as well.
-        if(!_temp.insideBatch.every(
-          eventHash => eventMap.has(eventHash))) {
-          // some ancestors were excluded from processing
-          // remove this merge event from the eventMap
-          eventMap.delete(eventHash);
-        }
-        continue;
-      }
       mergeEventsReceived++;
     }
 
@@ -98,7 +71,7 @@ api.addBatch = async ({blockHeight, events, ledgerNode, needed}) => {
     await _cache.events.addPeerEvent({event, ledgerNodeId, meta});
   }
 
-  return {deferredEvents, mergeEventsReceived};
+  return {mergeEventsReceived};
 };
 
 api.createPeerEventRecord = async function({event, eventMap, ledgerNode}) {
@@ -130,49 +103,70 @@ async function _validateEvents({blockHeight, events, ledgerNode, needed}) {
 
   // FIXME: use removeOnComplete when fixed
   // see: https://github.com/OptimalBits/bull/issues/1906
-  const jobDefinitions = events.map(event => ({
-    data: {blockHeight, event, ledgerNodeId},
-    // max time it should take to validate an event
-    opts: {timeout: 5000},
-  }));
-  const jobs = await jobQueue.addBulk(jobDefinitions);
+  const jobDefinitions = [];
+  for(const event of events) {
+    // event must have a valid `basisBlockHeight` that is not ahead of our
+    // current blockHeight, otherwise it gets dropped; note that the peer
+    // should not send us these events if it is following the gossip protocol
+    // but we have to account for such violations
+    const {basisBlockHeight} = event;
+    if(!(Number.isInteger(basisBlockHeight) &&
+      basisBlockHeight <= blockHeight)) {
+      // FIXME: keep track of the fact that the peer sent events it should
+      // not have sent; do we want to throw out the whole batch like we do
+      // with other unrequested events? (do we even want to do that?)
+      continue;
+    }
+    // push a job to handle basic event validation for this event
+    jobDefinitions.push({
+      data: {event, ledgerNodeId},
+      // max time it should take to validate an event
+      // FIXME: we need to ensure that if this spills over into the next work
+      // session that it cannot cause corruption
+      opts: {timeout: 5000}
+    });
+  }
 
   // job.finished() returns a promise that resolves when the job completes
-  const results = await Promise.all(jobs.map(job => job.finished()));
+  const jobs = await jobQueue.addBulk(jobDefinitions);
+  const promises = [];
+  for(const job of jobs) {
+    promises.push(job.finished());
+  }
+  const results = await Promise.all(promises);
 
+  // gather all of the validated events; at this point operations and
+  // configurations in events have been validated based on ledger validators,
+  // but DAG merge history has not yet been validated
+  const neededSet = new Set(needed);
   const eventMap = new Map();
   const eventHashes = [];
-  const neededSet = new Set(needed);
   let index = 0;
-  for(const {event, requiredBlockHeight, meta} of results) {
+  for(const {event, meta} of results) {
     const {eventHash} = meta;
+    // if any event in the batch was not requested, throw out entire batch
+    if(!neededSet.has(eventHash)) {
+      throw new BedrockError(
+        'The event supplied by the peer was not requested.',
+        'DataError', {event, eventHash, neededSet});
+    }
     eventHashes.push(eventHash);
-    const _temp = {valid: false, processed: false, requiredBlockHeight};
+    const _temp = {valid: false, processed: false};
     eventMap.set(eventHash, {
       event,
       meta,
       rawEvent: events[index++],
       _temp
     });
-
-    // populate `generation` for merge events, some merge events may have
-    // immediate ancestors inside the batch which are found in `eventMap`
-    if(meta.continuity2017.type === 'm') {
-      const parentGeneration = await _getGeneration(
-        {eventHash: event.treeHash, eventMap, ledgerNode});
-      meta.continuity2017.generation = parentGeneration + 1;
-    }
-
-    // if delete returns false, the eventHash was not present in the set
-    if(!neededSet.delete(meta.eventHash)) {
-      throw new BedrockError(
-        'The event supplied by the peer was not requested.',
-        'DataError', {event, eventHash, neededSet});
-    }
   }
 
   // ensure that all the needed events are included in the batch
-  if(neededSet.size !== 0) {
+  if(neededSet.size !== eventHashes.length) {
+    // FIXME: do we want to reject the whole batch on this basis or accept
+    // what we have and simply report we didn't get every thing we asked for?
+    // ... note that the new `_validateGraph` will ensure that we don't mark
+    // ... any events valid if their parents are missing/not valid
+    /*
     throw new BedrockError(
       'The batch does not include all the needed events.',
       'DataError', {
@@ -180,6 +174,7 @@ async function _validateEvents({blockHeight, events, ledgerNode, needed}) {
         missingEventHashes: [...neededSet],
         public: true,
       });
+    */
   }
 
   // inspect all the provided events; this will also set
@@ -190,20 +185,19 @@ async function _validateEvents({blockHeight, events, ledgerNode, needed}) {
 }
 
 // called by a bedrock-job, job contains `data` payload
-async function _validateEvent({data: {blockHeight, event, ledgerNodeId}}) {
+async function _validateEvent({data: {event, ledgerNodeId}}) {
   const ledgerNode = await brLedgerNode.get(null, ledgerNodeId);
 
+  // creating a peer event record also includes signature verification for
+  // merge events and hash generation for every event type
   const {event: processedEvent, meta} = await api.createPeerEventRecord(
     {event, ledgerNode});
 
   const {basisBlockHeight} = event;
-  // regular events and configuration events have basisBlockHeight
-  if(Number.isInteger(basisBlockHeight) && basisBlockHeight > blockHeight) {
-    // do not attempt to validate yet
-    return {event: processedEvent, requiredBlockHeight: basisBlockHeight, meta};
-  }
 
-  // events type could be regular 'r', configuration 'c' or merge events 'm'
+  // events type could be regular 'r', configuration 'c' or merge events 'm';
+  // there are no additional validation rules for merge events here, but others
+  // will be applied when validating the DAG shape later (outside this function)
   if(meta.continuity2017.type === 'r') {
     await _util.processChunked({
       tasks: processedEvent.operationRecords,
@@ -338,7 +332,7 @@ async function _hashOperation(operation) {
 // identify merge events, then validate their parents. ensure:
 // merge events are validated
 // merge event parents that are not merge events are validated
-// parents referenced outside the batch are merge events
+// parents referenced outside the batch already exist and have been validated
 async function _validateGraph({eventHashes, eventMap, ledgerNode}) {
   // get all parent merge events that exist outside of the batch that
   // will be needed to validate those inside the batch; previous checks
@@ -374,22 +368,6 @@ async function _validateGraph({eventHashes, eventMap, ledgerNode}) {
   const outsideBatchEvents = await _events.getEvents(
     {eventHash: outsideBatchHashes, ledgerNode});
   for(const parentRecord of outsideBatchEvents) {
-    const {meta: {continuity2017: {type: parentType}}} = parentRecord;
-    if(parentType !== 'm') {
-      // this should not be possible due to checks elsewhere; the batch must
-      // have all non-merge event parents
-      // FIXME: the previous docs indicated that this needed to be checked
-      // but it wasn't checked -- so this check was added but now causes
-      // some failures; commenting until we determine whether or not this
-      // check should be applied
-      /*throw new BedrockError(
-        'The peer event batch is missing a non-merge event parent.',
-        'DataError', {
-          parentRecord,
-          httpStatusCode: 400,
-          public: true
-        });*/
-    }
     outsideBatchMap.set(parentRecord.meta.eventHash, parentRecord);
   }
 
@@ -409,7 +387,6 @@ async function _validateGraph({eventHashes, eventMap, ledgerNode}) {
         const parentRecord = eventMap.get(parentHash);
         if(parentRecord && parentRecord.meta.continuity2017.type === 'm' &&
           !parentRecord._temp.processed) {
-          console.log('parent', parentRecord);
           defer = true;
           break;
         }
@@ -433,14 +410,23 @@ async function _validateGraph({eventHashes, eventMap, ledgerNode}) {
         if(!parentRecord) {
           outsideBatch = true;
           parentRecord = outsideBatchMap.get(parentHash);
+          if(!parentRecord) {
+            // event's parent is missing, consider the event invalid
+            _temp.processed = true;
+            break;
+          }
         }
 
         const {meta: {continuity2017: {
           type: parentType,
+          generation: parentGeneration,
           localAncestorGeneration: parentLocalAncestorGeneration = 0
         }}} = parentRecord;
 
         if(parentHash === event.treeHash) {
+          // set event's generation based on its tree parent's
+          eventRecord.meta.continuity2017.generation = parentGeneration + 1;
+
           // check tree-parent-specific validate rules
           await _validateTreeParent(
             {ledgerNode, eventRecord, parentRecord, genesisCreator});
@@ -468,11 +454,16 @@ async function _validateGraph({eventHashes, eventMap, ledgerNode}) {
         }
       }
 
-      // all parents referenced in the merge event are valid, so it is valid
-      _temp.valid = _temp.processed = true;
-      // ensure `localAncestorGeneration` is set for the merge event
-      eventRecord.meta.continuity2017.localAncestorGeneration =
-        localAncestorGeneration;
+      // if the event has not been marked as processed yet, then it is now
+      // fully processed and all parents referenced in the merge event are
+      // valid, so it is valid; otherwise, it is missing some parents and
+      // has already been marked processed and invalid
+      if(!_temp.processed) {
+        _temp.valid = _temp.processed = true;
+        // ensure `localAncestorGeneration` is set for the merge event
+        eventRecord.meta.continuity2017.localAncestorGeneration =
+          localAncestorGeneration;
+      }
     }
   }
 }
@@ -484,8 +475,7 @@ async function _validateTreeParent({
     creator: eventCreator, generation: eventGeneration
   }}} = eventRecord;
   const {meta: {continuity2017: {
-    creator: parentCreator, generation: parentGeneration,
-    type: parentType
+    creator: parentCreator, type: parentType
   }}} = parentRecord;
 
   // merge event tree parents must be merge events
@@ -495,21 +485,6 @@ async function _validateTreeParent({
       'DataError', {
         parentRecord,
         eventRecord,
-        httpStatusCode: 400,
-        public: true
-      });
-  }
-
-  // merge events must descend directly from the previous generation
-  const expectedGeneration = eventGeneration - 1;
-  if(parentGeneration !== expectedGeneration) {
-    throw new BedrockError(
-      'Merge events must descend directly from the previous generation.',
-      'DataError', {
-        parentRecord,
-        eventRecord,
-        parentGeneration,
-        expectedGeneration,
         httpStatusCode: 400,
         public: true
       });
@@ -686,27 +661,6 @@ async function _validateParentNonMergeEvent({
         });
     }
   }
-}
-
-// looks in cache and storage for an event's generation
-async function _getGeneration({eventHash, eventMap, ledgerNode}) {
-  // check the map
-  const event = eventMap.get(eventHash);
-  if(event) {
-    const {meta: {continuity2017: {generation}}} = event;
-    return generation;
-  }
-  // first check cache
-  const generation = await _cache.events.getGeneration(
-    {eventHash, ledgerNodeId: ledgerNode.id});
-  if(generation !== null) {
-    // cache hit
-    return generation;
-  }
-
-  // check storage
-  const {meta} = await ledgerNode.storage.events.get(eventHash);
-  return meta.continuity2017.generation;
 }
 
 async function _validateOperation(

--- a/lib/worker/EventWriter.js
+++ b/lib/worker/EventWriter.js
@@ -173,11 +173,6 @@ module.exports = class EventWriter {
         multi.rename(currentKeyForNewHead, newHeadKey);
         currentKeysForNewHeads.add(currentKeyForNewHead);
         newHeadKeys.add(newHeadKey);
-        const headGenerationKey = _cacheKey.headGeneration(
-          {eventHash, ledgerNodeId});
-        // these keys are mainly useful during gossip about recent events
-        // expire them after an hour
-        multi.expire(headGenerationKey, 3600);
       }
       // add new childless heads
       if(newHeads.length !== 0) {

--- a/lib/worker/gossip.js
+++ b/lib/worker/gossip.js
@@ -91,13 +91,12 @@ async function _gw({ledgerNode, creatorId, peer}) {
 
   // process any events acquired from peer
   let mergeEventsReceived = 0;
-  let deferredEvents = [];
   if(result && result.events) {
     const {events, needed} = result;
     try {
       const blockHeight = await _cache.blocks.blockHeight(ledgerNode.id);
 
-      ({deferredEvents, mergeEventsReceived} = await _peerEvents.addBatch({
+      ({mergeEventsReceived} = await _peerEvents.addBatch({
         blockHeight, events, ledgerNode, needed
       }));
     } catch(error) {
@@ -115,10 +114,9 @@ async function _gw({ledgerNode, creatorId, peer}) {
       const {coolDownPeriod} = config['ledger-consensus-continuity'].gossip;
       backoff = coolDownPeriod;
     }
-    let detectedBlockHeight = 0;
-    if(deferredEvents.length > 0) {
-      [{requiredBlockHeight: detectedBlockHeight}] = deferredEvents;
-    }
+    // FIXME: replace `detectedBlockHeight` with declared block height from
+    // the peer
+    const detectedBlockHeight = 0;
     await peer.success({backoff, detectedBlockHeight});
   }
 


### PR DESCRIPTION
@mattcollier -- let me know what you think about some of the changes and FIXMEs here, in particular, whether or not we should be dropping entire batches when only some of the events are problematic. Note that there have been changes to `_validateGraph` ensure that parents referenced by events are validated prior to the events themselves being validated (depth-first validation).

Also, it looks like the `headGeneration` cache/key/functions are no longer used and I've added a commit to remove them. Please let me know what you think.

Note that this PR does not add anything to send the known `blockHeight` during gossip to prevent (well-behaved) peers from sending us events we can't yet process. I'm doing this incrementally to ensure both that the tests keep passing and that we're handling what would be misbehaving peers along the way. Of course, we will eventually need dedicated tests with peers that send us things we can't yet process -- similar to how we need forking peer tests (cc: @gannan08).