### PR TITLE
Swap out axios for @digitalbazaar/http-client.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # bedrock-ledger-consensus-continuity ChangeLog
 
+## 8.0.1 - TBD
+
+### Removed
+- `axios` was removed from `lib/client.js` in order to move away from axios.
+- `axios` was removed from `package.json`
+
+### Added
+- `@digitalbazaar/http-client` was added to the project.
+
+### Changed
+- `lib/client.js` now uses `@digitalbazaar/http-client`.
+
 ## 8.0.0 - 2021-04-29
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `@digitalbazaar/http-client` was added to the project.
 
 ### Changed
+- Replaced `axios` with `@digitalbazaar/http-client`
 - `lib/client.js` now uses `@digitalbazaar/http-client`.
 
 ## 8.0.0 - 2021-04-29

--- a/lib/client.js
+++ b/lib/client.js
@@ -4,7 +4,6 @@
 'use strict';
 
 const _ = require('lodash');
-const axios = require('axios');
 const brHttpsAgent = require('bedrock-https-agent');
 const {httpClient} = require('@digitalbazaar/http-client');
 const https = require('https');
@@ -99,15 +98,13 @@ exports.getHistory = async ({
   const {httpsAgent} = brHttpsAgent;
   let res;
   try {
-    res = await axios({
-      httpsAgent,
-      method: 'POST',
-      url,
-      data,
+    res = await httpClient.post(url, {
+      json: data,
       timeout,
+      agent: httpsAgent
     });
   } catch(error) {
-    const {cause, httpStatusCode} = _processAxiosError(error);
+    const {cause, httpStatusCode} = _processHTTPError(error);
     throw new BedrockError(
       'Could not get peer history.', 'NetworkError',
       {httpStatusCode, localPeerId, remotePeerId}, cause);
@@ -132,17 +129,15 @@ exports.notifyPeer = async ({localPeerId, remotePeer}) => {
   const {httpsAgent} = brHttpsAgent;
   // FIXME: use http-signature to authenticate
   try {
-    await axios({
-      httpsAgent,
-      method: 'POST',
-      url,
+    await httpClient.post(url, {
+      agent: httpsAgent,
       // the peerId sent to the remote peer is the peerId of the local peer
       // FIXME: send actual gossip URL instead of `localPeerId` twice
-      data: {peer: {id: localPeerId, url: localPeerId}},
-      timeout,
+      json: {peer: {id: localPeerId, url: localPeerId}},
+      timeout
     });
   } catch(error) {
-    const {cause, httpStatusCode} = _processAxiosError(error);
+    const {cause, httpStatusCode} = _processHTTPError(error);
     throw new BedrockError(
       'Could not send peer notification.', 'NetworkError',
       {localPeerId, httpStatusCode, remotePeerId}, cause);
@@ -245,22 +240,23 @@ function _pipelineComplete(/* err */) {
   // error is handled before this handler is called, this is a no-op
 }
 
-function _processAxiosError(error) {
-  const {request, response} = error;
+function _processHTTPError(error) {
+  const {response} = error;
+  const data = error.data || (response && response.data);
   let cause;
   let httpStatusCode;
-  if(response && response.data && response.data.details) {
+  if(response && data && data.details) {
     // it's BedrockError
     httpStatusCode = response.status;
     cause = new BedrockError(
-      response.data.message, response.data.type, response.data.details);
+      data.message, data.type, data.details);
   } else if(response) {
     httpStatusCode = response.status;
     cause = new BedrockError('An HTTP error occurred.', 'NetworkError', {
-      data: response.data,
+      data,
       httpStatusCode,
     });
-  } else if(request) {
+  } else if(!response) {
     // no status code available
     const {address, code, errno, port} = error;
     cause = new BedrockError(error.message, 'NetworkError', {

--- a/lib/client.js
+++ b/lib/client.js
@@ -1,10 +1,10 @@
 /*!
- * Copyright (c) 2017-2020 Digital Bazaar, Inc. All rights reserved.
+ * Copyright (c) 2017-2021 Digital Bazaar, Inc. All rights reserved.
  */
 'use strict';
 
 const _ = require('lodash');
-const brHttpsAgent = require('bedrock-https-agent');
+const {httpsAgent} = require('bedrock-https-agent');
 const {httpClient} = require('@digitalbazaar/http-client');
 const https = require('https');
 const bedrock = require('bedrock');
@@ -27,7 +27,7 @@ bedrock.events.on('bedrock.ready', async () => {
   if(httpsAgentOpts) {
     EVENTS_VALIDATION_HTTPS_AGENT = new https.Agent(httpsAgentOpts);
   } else {
-    EVENTS_VALIDATION_HTTPS_AGENT = brHttpsAgent.httpsAgent;
+    EVENTS_VALIDATION_HTTPS_AGENT = httpsAgent;
   }
 });
 
@@ -36,7 +36,6 @@ exports.getEventStream = async ({eventHash, remotePeer}) => {
   const url = remotePeer.url + '/events-query';
   const data = {eventHash};
   const {'ledger-consensus-continuity': {client: {timeout}}} = config;
-  const {httpsAgent} = brHttpsAgent;
   const response = await httpClient.post(url, {
     agent: httpsAgent,
     json: data,
@@ -95,7 +94,6 @@ exports.getHistory = async ({
     data.localEventNumber = localEventNumber;
   }
   const {'ledger-consensus-continuity': {client: {timeout}}} = config;
-  const {httpsAgent} = brHttpsAgent;
   let res;
   try {
     res = await httpClient.post(url, {
@@ -126,7 +124,6 @@ exports.notifyPeer = async ({localPeerId, remotePeer}) => {
   const {id: remotePeerId} = remotePeer;
   const url = `${remotePeer.url}/notify`;
   const {'ledger-consensus-continuity': {client: {timeout}}} = config;
-  const {httpsAgent} = brHttpsAgent;
   // FIXME: use http-signature to authenticate
   try {
     await httpClient.post(url, {

--- a/lib/client.js
+++ b/lib/client.js
@@ -258,6 +258,7 @@ function _processHTTPError(error) {
     });
   } else if(!response) {
     // no status code available
+    // NOTE: have not seen a ky error with port or address
     const {address, code, errno, port} = error;
     cause = new BedrockError(error.message, 'NetworkError', {
       address, code, errno, port

--- a/package.json
+++ b/package.json
@@ -23,9 +23,8 @@
   "dependencies": {
     "@digitalbazaar/ed25519-signature-2018": "^1.0.0",
     "@digitalbazaar/ed25519-verification-key-2018": "^3.0.0",
-    "@digitalbazaar/http-client": "^1.0.0",
+    "@digitalbazaar/http-client": "^1.1.0",
     "@digitalbazaar/lru-memoize": "^1.1.0",
-    "axios": "^0.21.1",
     "body-parser": "^1.18.2",
     "bs58": "^4.0.1",
     "canonicalize": "^1.0.4",


### PR DESCRIPTION
Patches the intermittent release in master with the removal of axios.

1. Replaces axios in `getEventStream` API
2. Replaces axios in `getHistory` API
3. Replaces axios in `notifyPeer` API
4. All methods are called by the existing tests
5. All methods have tests for success in the tests.
6. Streams from `getEventStream` are being read.
5. `getHistory` & `notifyPeer` both have negative tests which hit the new error handler.
6. `getEventStream` returns a `ReadableStream` which is in a readable state (has not been used yet)
7. `getEventStream` does not have a test testing failure, but `response.ok` is on the ky response object.