### PR TITLE
Change witnesses to set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # bedrock-ledger-consensus-continuity ChangeLog
 
+## 8.0.2 - TBD
+
+### Changed
+- Changed `witnesses` from an `Array` to a `Set`.
+
 ## 8.0.1 - TBD
 
 ### Removed

--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -237,7 +237,7 @@ async function _setRequiredBlockHeight({ledgerNode, witnesses, blockHeight}) {
   // FIXME: make this a covered query
   const {collection} = ledgerNode.storage.events;
   const result = await collection.updateMany({
-    'meta.continuity2017.creator': {$in: witnesses},
+    'meta.continuity2017.creator': {$in: Array.from(witnesses)},
     'meta.continuity2017.requiredBlockHeight': -1
   }, {
     $set: {'meta.continuity2017.requiredBlockHeight': blockHeight}

--- a/lib/blocks.js
+++ b/lib/blocks.js
@@ -151,7 +151,8 @@ api.write = async ({worker, consensusResult}) => {
   const {witnesses} = consensusResult;
   await Promise.all([
     ledgerNode.storage.events.updateMany({events: eventUpdates}),
-    _setRequiredBlockHeight({ledgerNode, witnesses, blockHeight})
+    _setRequiredBlockHeight(
+      {ledgerNode, witnesses: [...witnesses], blockHeight})
   ]);
 
   // create new block ID
@@ -232,12 +233,22 @@ async function _markNewReplayers({ledgerNode, replayers, blockHeight}) {
   return result;
 }
 
+/**
+ * Sets the Required Block Height for a block.
+ *
+ * @param {object} options - Options to use.
+ * @param {object} options.ledgerNode - A ledger node.
+ * @param {Array<string>} options.witnesses - An array of witness ids.
+ * @param {number} options.blockHeight - A blockHeight to set.
+ *
+ * @returns {Promise<object>} The result of the operation.
+ */
 // FIXME: move to bedrock-ledger-consensus-continuity-storage
 async function _setRequiredBlockHeight({ledgerNode, witnesses, blockHeight}) {
   // FIXME: make this a covered query
   const {collection} = ledgerNode.storage.events;
   const result = await collection.updateMany({
-    'meta.continuity2017.creator': {$in: Array.from(witnesses)},
+    'meta.continuity2017.creator': {$in: witnesses},
     'meta.continuity2017.requiredBlockHeight': -1
   }, {
     $set: {'meta.continuity2017.requiredBlockHeight': blockHeight}

--- a/lib/continuity.js
+++ b/lib/continuity.js
@@ -184,7 +184,6 @@ function _getTails({history, witnesses, state = null}) {
   }
 
   const witnessTails = new Map();
-  const witnessSet = new Set(witnesses);
 
   // build history links
   const eventMap = new Map();
@@ -211,7 +210,7 @@ function _getTails({history, witnesses, state = null}) {
       proposalEndorsement: null,
       mostRecentWitnessAncestors: null,
       support: null,
-      witness: witnessSet.has(_getCreator(e)),
+      witness: witnesses.has(_getCreator(e)),
       y: false,
 
       // consensus order
@@ -280,7 +279,7 @@ function _getTails({history, witnesses, state = null}) {
         head = current;
       }
     }
-    if(witnessSet.has(creator)) {
+    if(witnesses.has(creator)) {
       witnessTails.set(creator, tail);
     }
     for(const e of tail) {
@@ -435,7 +434,7 @@ function _findConsensusSet({
     return {consensus: [], yCandidates: []};
   }
 
-  const supermajority = api.supermajority(witnesses.length);
+  const supermajority = api.supermajority(witnesses.size);
   return {
     // pair `y`s with `x`s
     consensus: _findConsensusMergeEventPairs({ys, supermajority}),
@@ -459,7 +458,7 @@ function _findConsensusSet({
 function _findConsensusCandidates({
   ledgerNodeId, witnessTails, blockHeight, witnesses, logger = noopLogger
 }) {
-  const supermajority = api.supermajority(witnesses.length);
+  const supermajority = api.supermajority(witnesses.size);
 
   //console.log('TAILS', util.inspect(tails, {depth:10}));
 
@@ -622,7 +621,7 @@ function _findConsensusMergeEvents({
     ledgerNodeId, {ledgerNode: ledgerNodeId});*/
 
   // if witnesses is 1, consensus is trivial
-  if(witnesses.length === 1) {
+  if(witnesses.size === 1) {
     return [].concat(...[...yByWitness.values()]);
   }
 
@@ -864,9 +863,9 @@ function _experiment({
   }
 
   // compute maximum failures `f` and supermajority `2f+1` thresholds
-  const f = api.maximumFailures(witnesses.length);
+  const f = api.maximumFailures(witnesses.size);
   const fPlusOne = f + 1;
-  const supermajority = api.supermajority(witnesses.length);
+  const supermajority = api.supermajority(witnesses.size);
 
   // tally support seen
   const {tally, fPlusOneSupport} = _tallySupport({event, f, fPlusOne});
@@ -1306,8 +1305,8 @@ function _getPriorityPeers({
 
   If creating a new merge event would be helpful, prioritize the witness.
   */
-  const supermajority = api.supermajority(witnesses.length);
-  const f = api.maximumFailures(witnesses.length);
+  const supermajority = api.supermajority(witnesses.size);
+  const f = api.maximumFailures(witnesses.size);
 
   // collect non-byzantine peers and their heads
   const nonByzantinePeers = [];

--- a/lib/continuity.js
+++ b/lib/continuity.js
@@ -166,10 +166,10 @@ api.maximumFailures = witnessCount => (witnessCount === 1) ?
  * perspective into the views for each of the nodes (including both
  * witnesses and non-witnesses).
  *
- * @param history recent history.
- * @param witnesses the current witnesses.
- * @param [state=null] an optional object for storing state information that
- *   can be reused for the same `blockHeight`.
+ * @param {object} history - Recent history.
+ * @param {Set<string>} witnesses - The current witnesses.
+ * @param {object} [state=null] - an optional object for storing state
+ *   information that can be reused for the same `blockHeight`.
  *
  * @return a map containing {tails, witnessTails} where each is a map with
  *   creator => an array containing the node's branch of history starting at

--- a/lib/events.js
+++ b/lib/events.js
@@ -663,7 +663,7 @@ async function _createLocalEventRecord({worker, event, eventHash}) {
   // merge event that merges this event reaches consensus or if the peer
   // becomes a witness on a subsequent block
   const {blockHeight, witnesses} = consensusState;
-  const requiredBlockHeight = witnesses.includes(localPeerId) ?
+  const requiredBlockHeight = witnesses.has(localPeerId) ?
     blockHeight : -1;
   const meta = {
     blockHeight: -1,

--- a/lib/history.js
+++ b/lib/history.js
@@ -440,7 +440,7 @@ async function _getAcceptableHistory({
         ({witnesses} = await _witnesses.getBlockWitnesses(
           {ledgerNode, blockHeight: localBlockHeight + 1}));
       }
-      if(witnesses.includes(creator)) {
+      if(witnesses.has(creator)) {
         acceptableCount++;
         continue;
       }

--- a/lib/peerEvents.js
+++ b/lib/peerEvents.js
@@ -1038,7 +1038,7 @@ async function _checkParentHashCommitments({
 
     // if creator is presently a witness
     // note: `consensusState.blockHeight >= `basisBlockHeight + 1`
-    if(consensusState.witnesses.includes(creator)) {
+    if(consensusState.witnesses.has(creator)) {
       // set `requiredBlockHeight` to `consensusState.blockHeight` and skip
       _setRequiredBlockHeight(
         {eventRecord, blockHeight: consensusState.blockHeight, eventMap});
@@ -1055,7 +1055,7 @@ async function _checkParentHashCommitments({
           {ledgerNode, blockHeight}));
         witnessesMap.set(blockHeight, witnesses);
       }
-      if(witnesses.includes(creator)) {
+      if(witnesses.has(creator)) {
         // set `requiredBlockHeight` to `basisBlockHeight` and skip
         _setRequiredBlockHeight(
           {eventRecord, blockHeight: basisBlockHeight, eventMap});
@@ -1167,7 +1167,7 @@ async function _checkPeerCommitments({
   const peerIds = [];
   for(const eventRecord of mergeEvents) {
     const {meta: {continuity2017: {creator, generation}}} = eventRecord;
-    if(generation === 1 && !witnesses.includes(creator)) {
+    if(generation === 1 && !witnesses.has(creator)) {
       firstGeneration.push(eventRecord);
       peerIds.push(creator);
     }

--- a/lib/peers.js
+++ b/lib/peers.js
@@ -299,7 +299,7 @@ api.getCommitmentToPeer = async ({
 };
 
 api.getPeerForCommitment = async ({
-  ledgerNode, localPeerId, witnesses = []
+  ledgerNode, localPeerId, witnesses = new Set()
 } = {}) => {
   const {records} = await api.getCached({ledgerNode});
   // find a peer to commit to
@@ -369,7 +369,7 @@ function _samplePeers({peers, start, end = peers.length - 1}) {
 // checks to see if a peer commitment is required for the given peer to enable
 // it to submit its own merge events
 async function _isPeerCommitmentRequired({
-  ledgerNode, peerId, localPeerId, witnesses = []
+  ledgerNode, peerId, localPeerId, witnesses = new Set()
 } = {}) {
   // if peer is presently a witness, then no commitment is required; note that
   // this only applies *at the block height* for the given witnesses, so only

--- a/lib/peers.js
+++ b/lib/peers.js
@@ -298,6 +298,16 @@ api.getCommitmentToPeer = async ({
   return cursor.toArray();
 };
 
+/**
+ * Checks and sets if commitment is required by a peer.
+ *
+ * @param {object} options - Options to use.
+ * @param {object} options.ledgerNode - A ledgerNode.
+ * @param {string} options.localPeerId - The local peer Id.
+ * @param {Set<string>} [witnesses = new Set()] - A set of witness ids.
+ *
+ * @returns {Promise<object|null>} - Either null or the peer.
+ */
 api.getPeerForCommitment = async ({
   ledgerNode, localPeerId, witnesses = new Set()
 } = {}) => {

--- a/lib/peers.js
+++ b/lib/peers.js
@@ -374,7 +374,7 @@ async function _isPeerCommitmentRequired({
   // if peer is presently a witness, then no commitment is required; note that
   // this only applies *at the block height* for the given witnesses, so only
   // pass `witnesses` with care
-  if(witnesses.includes(peerId)) {
+  if(witnesses.has(peerId)) {
     return false;
   }
   // optimistically assume it is uncommon to be checking for a witness

--- a/lib/witnesses.js
+++ b/lib/witnesses.js
@@ -43,6 +43,17 @@ api.getBlockWitnesses = async ({ledgerNode, blockHeight}) => {
   });
 };
 
+/**
+ * Gets all witnesses for events after a certain block height.
+ *
+ * @private
+ * @param {object} options - Options to use.
+ * @param {object} options.ledgerNode - a Ledger Node.
+ * @param {number|string} options.blockHeight - A block height.
+ *
+ * @returns {Promise<object<Array<string>>>} An object with a witnesses property
+ *   that is an array of ids.
+ */
 async function _getWitnesses({ledgerNode, blockHeight}) {
   // get config and latest summary
   // FIXME: remove passing latest block summary to block electors API and
@@ -76,8 +87,7 @@ async function _getWitnesses({ledgerNode, blockHeight}) {
         'Witnesses do not form a set of size "3f+1".', 'InvalidStateError');
     }
   }
-
-  return {witnesses};
+  return {witnesses: new Set(witnesses)};
 }
 
 async function _getLatestConfig(ledgerNode) {

--- a/lib/witnesses.js
+++ b/lib/witnesses.js
@@ -51,8 +51,8 @@ api.getBlockWitnesses = async ({ledgerNode, blockHeight}) => {
  * @param {object} options.ledgerNode - a Ledger Node.
  * @param {number|string} options.blockHeight - A block height.
  *
- * @returns {Promise<object<Array<string>>>} An object with a witnesses property
- *   that is an array of ids.
+ * @returns {Promise<object.<symbol, Set<string>>} An object with a witnesses
+ *   property that is a set of ids.
  */
 async function _getWitnesses({ledgerNode, blockHeight}) {
   // get config and latest summary

--- a/lib/worker/GossipPeer.js
+++ b/lib/worker/GossipPeer.js
@@ -106,7 +106,7 @@ module.exports = class GossipPeer {
     }
 
     if(_peer.reputation < 0) {
-      const isWitness = witnesses.some(id => id === _peer.id);
+      const isWitness = witnesses.has(_peer.id);
       if(!isWitness) {
         // peer has no reputation, remove it
         await this.delete();
@@ -142,7 +142,7 @@ module.exports = class GossipPeer {
       _peer,
       worker: {ledgerNode, consensusState: {blockHeight, witnesses}}
     } = this;
-    const isWitness = witnesses.some(id => id === _peer.id);
+    const isWitness = witnesses.has(_peer.id);
     // do not delete peer if they are presently a witness
     if(!isWitness && _peer.reputation === 0) {
       /* Note: We have a maximum number of 110 peers that can be stored in

--- a/lib/worker/Worker.js
+++ b/lib/worker/Worker.js
@@ -412,7 +412,7 @@ module.exports = class Worker {
   }
 
   // pick a withheld event to commit to
-  _selectWithheld({witnessSet} = {}) {
+  _selectWithheld({witnesses} = {}) {
     const {withheldCache} = this;
     if(withheldCache.itemCount === 0) {
       return null;
@@ -420,7 +420,7 @@ module.exports = class Worker {
     const keys = withheldCache.keys();
     for(const creator of keys) {
       // skip any current witnesses
-      if(witnessSet.has(creator)) {
+      if(witnesses.has(creator)) {
         continue;
       }
       return withheldCache.get(creator);

--- a/lib/worker/Worker.js
+++ b/lib/worker/Worker.js
@@ -159,7 +159,7 @@ module.exports = class Worker {
       if(blockHeight <= nextBlockHeight) {
         const {witnesses} = await _witnesses.getBlockWitnesses(
           {blockHeight, ledgerNode});
-        if(witnesses.includes(creator)) {
+        if(witnesses.has(creator)) {
           this.mergeCommitment = null;
           this._clearWithheld();
         }

--- a/lib/worker/merge.js
+++ b/lib/worker/merge.js
@@ -23,7 +23,6 @@ api.merge = async ({
   if(witnesses.size === 0) {
     throw new TypeError('"witnesses" must be a non-empty array.');
   }
-  const witnessSet = new Set(witnesses);
 
   if(peerWitnessParentThreshold === undefined) {
     // both the solo witness case and the first generation case have no
@@ -38,7 +37,7 @@ api.merge = async ({
   }
 
   const status = await _prepareNextMerge({
-    worker, priorityPeers, witnesses, witnessSet,
+    worker, priorityPeers, witnesses,
     basisBlockHeight, peerWitnessParentThreshold
   });
   if(!status.mergeable) {
@@ -117,7 +116,7 @@ api.merge = async ({
 };
 
 async function _prepareNextMerge({
-  worker, priorityPeers, witnesses, witnessSet,
+  worker, priorityPeers, witnesses,
   basisBlockHeight, peerWitnessParentThreshold
 }) {
   const {mergeEvents: {maxParents, maxNonMergeParents}} = _continuityConstants;
@@ -170,7 +169,7 @@ async function _prepareNextMerge({
     await hasOutstandingRegularEvents({basisBlockHeight});
 
   // determine if peer is a witness
-  const isWitness = witnessSet.has(localPeerId);
+  const isWitness = witnesses.has(localPeerId);
   if(isWitness) {
     // a merge event created by a witness requires only `basisBlockHeight`
     // block height for acceptance
@@ -440,7 +439,7 @@ async function _prepareNextMerge({
     heads. */
 
     // first try to get a withheld event to commit to
-    const withheld = worker._selectWithheld({witnessSet});
+    const withheld = worker._selectWithheld({witnesses});
     if(withheld) {
       status.peerHeadCommitment = {
         basisBlockHeight: withheld.mergeEvent.event.basisBlockHeight,
@@ -467,7 +466,7 @@ async function _prepareNextMerge({
     commitment slot not being used for the same creator twice in a row. */
     if(!status.peerHeadCommitment) {
       for(const peerHead of remainingChildlessPeerHeads) {
-        if(!witnessSet.has(peerHead.creator)) {
+        if(!witnesses.has(peerHead.creator)) {
           status.peerHeadCommitment = peerHead;
           break;
         }
@@ -512,7 +511,7 @@ async function _prepareNextMerge({
   // speed along consensus
   if(isWitness && remainingSlots > 0) {
     for(const peerHead of remainingChildlessPeerHeads) {
-      if(witnessSet.has(peerHead.creator) &&
+      if(witnesses.has(peerHead.creator) &&
         !peerCreatorSet.has(peerHead.creator)) {
         parentHashes.add(peerHead.eventHash);
         peerCreatorSet.add(peerHead.creator);

--- a/lib/worker/merge.js
+++ b/lib/worker/merge.js
@@ -21,7 +21,7 @@ api.merge = async ({
   basisBlockHeight, peerWitnessParentThreshold
 }) => {
   if(witnesses.size === 0) {
-    throw new TypeError('"witnesses" must be a non-empty array.');
+    throw new TypeError('"witnesses" must be a non-empty set.');
   }
 
   if(peerWitnessParentThreshold === undefined) {

--- a/lib/worker/merge.js
+++ b/lib/worker/merge.js
@@ -20,7 +20,7 @@ api.merge = async ({
   worker, priorityPeers = [], witnesses = worker.consensusState.witnesses,
   basisBlockHeight, peerWitnessParentThreshold
 }) => {
-  if(witnesses.length === 0) {
+  if(witnesses.size === 0) {
     throw new TypeError('"witnesses" must be a non-empty array.');
   }
   const witnessSet = new Set(witnesses);
@@ -28,11 +28,11 @@ api.merge = async ({
   if(peerWitnessParentThreshold === undefined) {
     // both the solo witness case and the first generation case have no
     // peer witness parent threshold
-    if(witnesses.length === 1 || worker.head.generation === 0) {
+    if(witnesses.size === 1 || worker.head.generation === 0) {
       peerWitnessParentThreshold = 0;
     } else {
       // `2f` is the default peer witness parent threshold
-      const f = Math.max(1, (witnesses.length - 1) / 3);
+      const f = Math.max(1, (witnesses.size - 1) / 3);
       peerWitnessParentThreshold = 2 * f;
     }
   }

--- a/test/mocha/066-continuity_findConsensusSet.js
+++ b/test/mocha/066-continuity_findConsensusSet.js
@@ -62,8 +62,8 @@ describe('Continuity API _findConsensusSet', () => {
   it('ledger history alpha', async function() {
     const report = {};
     // NOTE: for ledger history alpha, all nodes should have the same view
-    // all peers are witnesses
-    const witnesses = Object.values(peers);
+    // all peers are witnesses.
+    const witnesses = new Set(Object.values(peers));
     const build = await helpers.buildHistory(
       {historyId: 'alpha', mockData, nodes, witnesses});
     for(const key in nodes) {
@@ -94,7 +94,7 @@ describe('Continuity API _findConsensusSet', () => {
     const report = {};
     // NOTE: for ledger history beta, all nodes should have the same view
     // all peers are witnesses
-    const witnesses = Object.values(peers);
+    const witnesses = new Set(Object.values(peers));
     const build = await helpers.buildHistory(
       {historyId: 'beta', mockData, nodes, witnesses});
     for(const key in nodes) {
@@ -125,7 +125,7 @@ describe('Continuity API _findConsensusSet', () => {
     const report = {};
     // NOTE: for ledger history gamma, all nodes should have the same view
     // all peers are witnesses
-    const witnesses = Object.values(peers);
+    const witnesses = new Set(Object.values(peers));
     const build = await helpers.buildHistory(
       {historyId: 'gamma', mockData, nodes, witnesses});
     for(const key in nodes) {
@@ -157,7 +157,7 @@ describe('Continuity API _findConsensusSet', () => {
     this.timeout(120000);
     const report = {};
     // all peers except epsilon are witnesses (epsilon not added yet)
-    const witnesses = Object.values(peers);
+    const witnesses = new Set(Object.values(peers));
 
     try {
       // add node epsilon for this test and remove it afterwards
@@ -221,7 +221,7 @@ describe('Continuity API _findConsensusSet', () => {
     const report = {};
     // all peers are witnesses (epsilon is not a peer anymore here and
     // the peer name is only coincidentally the same as the history name)
-    const witnesses = Object.values(peers);
+    const witnesses = new Set(Object.values(peers));
     const build = await helpers.buildHistory(
       {historyId: 'epsilon', mockData, nodes, witnesses});
     for(const key in nodes) {
@@ -254,7 +254,7 @@ describe('Continuity API _findConsensusSet', () => {
     const eventTemplate = mockData.events.alpha;
     const opTemplate = mockData.operations.alpha;
     // all peers are witnesses
-    const witnesses = Object.values(peers);
+    const witnesses = new Set(Object.values(peers));
     const build = await helpers.buildHistory(
       {historyId: 'alpha', mockData, nodes, witnesses});
     const event = await helpers.addEvent(

--- a/test/mocha/066-continuity_findConsensusSet.js
+++ b/test/mocha/066-continuity_findConsensusSet.js
@@ -174,7 +174,7 @@ describe('Continuity API _findConsensusSet', () => {
       // epsilon must be treated as a witness for merging purposes since this
       // is legacy code and it would otherwise not be able to merge without
       // commitments
-      const mergeWitnesses = [...witnesses, id];
+      const mergeWitnesses = new Set([...witnesses, id]);
       const build = await helpers.buildHistory(
         {historyId: 'delta', mockData, nodes, witnesses: mergeWitnesses});
 

--- a/test/mocha/067-continuity_getTails.js
+++ b/test/mocha/067-continuity_getTails.js
@@ -148,7 +148,7 @@ describe.skip('Continuity API _getTails', () => {
       test1: ['addEvent1', (results, callback) => {
         // all peers are witnesses
         const addEvent = results.addEvent1;
-        const witnesses = Object.values(peers);
+        const witnesses = new Set(Object.values(peers));
         async.eachOfSeries(nodes, (n, i, callback) => {
           async.auto({
             history: callback =>
@@ -194,7 +194,7 @@ describe.skip('Continuity API _getTails', () => {
         // test beta
         const addEvent = results.addEvent1;
         const cp1 = results.cp1;
-        const witnesses = Object.values(peers);
+        const witnesses = new Set(Object.values(peers));
         const ledgerNode = nodes.beta;
         async.auto({
           history: callback =>
@@ -264,7 +264,7 @@ describe.skip('Continuity API _getTails', () => {
         // test gamma
         const addEvent = results.addEvent1;
         const cp2 = results.cp2;
-        const witnesses = Object.values(peers);
+        const witnesses = new Set(Object.values(peers));
         const ledgerNode = nodes.gamma;
         async.auto({
           history: callback =>
@@ -326,7 +326,7 @@ describe.skip('Continuity API _getTails', () => {
         const cp1 = results.cp1;
         const cp2 = results.cp2;
         const cp3 = results.cp3;
-        const witnesses = Object.values(peers);
+        const witnesses = new Set(Object.values(peers));
         const ledgerNode = nodes.gamma;
         async.auto({
           history: callback =>
@@ -340,7 +340,7 @@ describe.skip('Continuity API _getTails', () => {
             const peerId = witnesses;
             const keys = Object.keys(branches);
             keys.should.have.length(4);
-            keys.should.have.same.members(Object.values(peers));
+            keys.should.have.same.members(new Set(Object.values(peers)));
             // inspect gamma tail
             const tailGamma = branches[peers.gamma];
             tailGamma.should.have.length(1);
@@ -438,7 +438,7 @@ describe.skip('Continuity API _getTails', () => {
         const cp2 = results.cp2;
         const cp3 = results.cp3;
         const cp4 = results.cp4;
-        const witnesses = Object.values(peers);
+        const witnesses = new Set(Object.values(peers));
         const ledgerNode = nodes.beta;
         async.auto({
           history: callback =>
@@ -452,7 +452,7 @@ describe.skip('Continuity API _getTails', () => {
             const peerId = witnesses;
             const keys = Object.keys(branches);
             keys.should.have.length(4);
-            keys.should.have.same.members(Object.values(peers));
+            keys.should.have.same.members(new Set(Object.values(peers)));
             // inspect gamma tail
             const tailGamma = branches[peers.gamma];
             tailGamma.should.have.length(1);

--- a/test/mocha/068-history_addNonConsensusAncestorHashes.js
+++ b/test/mocha/068-history_addNonConsensusAncestorHashes.js
@@ -21,7 +21,7 @@ describe('History API _addNonConsensusAncestorHashes', () => {
   let Worker;
   const nodes = {};
   const peers = {};
-  const witnesses = [];
+  const witnesses = new Set();
   beforeEach(async function() {
     this.timeout(120000);
     const ledgerConfiguration = mockData.ledgerConfiguration;
@@ -48,7 +48,7 @@ describe('History API _addNonConsensusAncestorHashes', () => {
       ledgerNode.peerId = await consensusApi._localPeers.getPeerId(
         {ledgerNodeId});
       peers[key] = ledgerNode.peerId;
-      witnesses.push(ledgerNode.peerId);
+      witnesses.add(ledgerNode.peerId);
       ledgerNode.worker.consensusState.witnesses = witnesses;
     }
     genesisMerge = nodes.alpha.worker.head.eventHash;

--- a/test/mocha/069-consensus-find.js
+++ b/test/mocha/069-consensus-find.js
@@ -60,7 +60,7 @@ describe('Consensus API find', () => {
     // the genesisMerge already has consensus
     const ledgerNode = nodes.alpha;
     const {peerId} = ledgerNode;
-    ledgerNode.worker.consensusState.witnesses = [peers.alpha];
+    ledgerNode.worker.consensusState.witnesses = new Set([peers.alpha]);
     const eventTemplate = mockData.events.alpha;
     const opTemplate = mockData.operations.alpha;
     async.auto({
@@ -85,7 +85,8 @@ describe('Consensus API find', () => {
   it('properly does not reach consensus with four witnesses', done => {
     const ledgerNode = nodes.alpha;
     const {peerId} = ledgerNode;
-    const witnesses = [peers.alpha, peers.beta, peers.gamma, peers.delta];
+    const witnesses = new Set(
+      [peers.alpha, peers.beta, peers.gamma, peers.delta]);
     ledgerNode.worker.consensusState.witnesses = witnesses;
     const eventTemplate = mockData.events.alpha;
     const opTemplate = mockData.operations.alpha;
@@ -104,7 +105,7 @@ describe('Consensus API find', () => {
   it.skip('add regular event with no merge before findConsensus', done => {
     const findConsensus = callbackify(consensusApi._worker._findConsensus);
     const ledgerNode = nodes.alpha;
-    const witnesses = Object.values(peers);
+    const witnesses = new Set(Object.values(peers));
     const eventTemplate = mockData.events.alpha;
     const opTemplate = mockData.operations.alpha;
     async.auto({

--- a/test/mocha/076-worker-merge-api.js
+++ b/test/mocha/076-worker-merge-api.js
@@ -33,7 +33,7 @@ describe('events.mergeBranches API', () => {
     nodes.beta = await brLedgerNode.add(null, {genesisBlock});
     nodes.gamma = await brLedgerNode.add(null, {genesisBlock});
     nodes.delta = await brLedgerNode.add(null, {genesisBlock});
-    const witnesses = [];
+    const witnesses = new Set();
     for(const key in nodes) {
       const ledgerNode = nodes[key];
       // attach worker to the node to emulate a work session used by `helpers`
@@ -43,7 +43,7 @@ describe('events.mergeBranches API', () => {
       const peerId = await consensusApi._localPeers.getPeerId({ledgerNodeId});
       ledgerNode.peerId = peerId;
       peers[key] = peerId;
-      witnesses.push(peerId);
+      witnesses.add(peerId);
       ledgerNode.worker.consensusState.witnesses = witnesses;
     }
     // NOTE: if nodeEpsilon is enabled, be sure to add to `creator` deps

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -166,7 +166,6 @@ api.buildHistory = async ({historyId, mockData, nodes, witnesses} = {}) => {
   // set workers to use passed witnesses when merging
   for(const key in nodes) {
     const ledgerNode = nodes[key];
-    // double check to ensure witnesses is a Set
     ledgerNode.worker.consensusState.witnesses = witnesses;
   }
   const results = await ledgerHistory[historyId]({

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -167,7 +167,7 @@ api.buildHistory = async ({historyId, mockData, nodes, witnesses} = {}) => {
   for(const key in nodes) {
     const ledgerNode = nodes[key];
     // double check to ensure witnesses is a Set
-    ledgerNode.worker.consensusState.witnesses = new Set(witnesses);
+    ledgerNode.worker.consensusState.witnesses = witnesses;
   }
   const results = await ledgerHistory[historyId]({
     api, eventTemplate, nodes, opTemplate

--- a/test/mocha/helpers.js
+++ b/test/mocha/helpers.js
@@ -166,7 +166,8 @@ api.buildHistory = async ({historyId, mockData, nodes, witnesses} = {}) => {
   // set workers to use passed witnesses when merging
   for(const key in nodes) {
     const ledgerNode = nodes[key];
-    ledgerNode.worker.consensusState.witnesses = witnesses;
+    // double check to ensure witnesses is a Set
+    ledgerNode.worker.consensusState.witnesses = new Set(witnesses);
   }
   const results = await ledgerHistory[historyId]({
     api, eventTemplate, nodes, opTemplate

--- a/test/mocha/tools/Graph.js
+++ b/test/mocha/tools/Graph.js
@@ -150,7 +150,8 @@ class Graph {
   getWitnesses() {
     const witnesses = [];
     this.nodes.forEach(node => witnesses.push(node));
-    return witnesses.filter(({isWitness}) => isWitness).map(({id}) => id);
+    return new Set(
+      witnesses.filter(({isWitness}) => isWitness).map(({id}) => id));
   }
 
   debug() {


### PR DESCRIPTION
- [x] clean up jsdoc
- [x] remove witnessSet
- [x] grep for all Array only methods
- [x] change all `includes` to `has`
- [x] change `some` to `has`
- [x] remove all `witness =` that are not defaults in destructuring
- [x] change all defaults in destructuring to `new Set()`
- [x] remove previous witness sets
- [x] ensure no set is used with a mongodb query
- [x] change test data to use `Set` over `Array`
- [x] replace all instances of `length` with `size`
- [x] All tests passing

Gist with test results before and after changes and also relevant code snippets before and after:
https://gist.github.com/aljones15/68b64c86c23ec9d5fffe0473583db193