### PR TITLE
Only ignore duplicate event error when inserting genesis event.

### DIFF
--- a/lib/events.js
+++ b/lib/events.js
@@ -595,7 +595,6 @@ async function _writeEvent({event, eventHash, genesis, ledgerNode, worker}) {
       'must not be added outside of a work session.');
   }
 
-  const ledgerNodeId = ledgerNode.id;
   const {storage} = ledgerNode;
 
   // process event (create `meta`, do any extra validation, etc.)
@@ -624,8 +623,9 @@ async function _writeEvent({event, eventHash, genesis, ledgerNode, worker}) {
   try {
     eventRecord = await storage.events.add(eventRecord);
   } catch(e) {
-    // ignore duplicates, may be recovering from a failed create operation
-    if(e.name !== 'DuplicateError') {
+    // ignore duplicates when creating the event; we may be recovering from a
+    // previous failed attempt to initialize the ledger node
+    if(!(genesis && e.name === 'DuplicateError')) {
       throw e;
     }
   }
@@ -636,22 +636,14 @@ async function _writeEvent({event, eventHash, genesis, ledgerNode, worker}) {
   }
 
   /* Note: The worker state needs to be updated here as a local event was
-  committed to storage and it now needs to be merged; if the worker state is
+  committed to storage and it now needs to be merged. If the worker state is
   not updated, then a merge event could be created that excludes it, causing
   all operations in the regular event to be lost or causing a subsequent merge
-  event to be invalid by merging in a regular event that is not its sibling; if
+  event to be invalid by merging in a regular event that is not its sibling. If
   this update fails, the work session should exit and it will be corrected when
   the new work session begins. Every new work session creates a new worker
   state that is in sync the database. */
   worker.pendingLocalRegularEventHashes.add(eventHash);
-  const isConfig = hasValue(event, 'type', 'WebLedgerConfigurationEvent');
-  if(isConfig) {
-    // FIXME: notify worker to wake up using in-memory call ... or rely
-    // on pushing to a new cache-based configuration queue to wake it up
-    // must notify that a config needs merging
-    await cache.client.publish(
-      `continuity2017|needsMerge|${ledgerNodeId}`, 'config');
-  }
 
   return eventRecord;
 }

--- a/lib/events.js
+++ b/lib/events.js
@@ -11,7 +11,6 @@ const _signature = require('./signature');
 const _util = require('./util');
 const bedrock = require('bedrock');
 const brLedgerNode = require('bedrock-ledger-node');
-const cache = require('bedrock-redis');
 const {util: {hasValue, BedrockError}} = bedrock;
 const {config} = bedrock;
 const database = require('bedrock-mongodb');


### PR DESCRIPTION
I was looking around for the source of an off-by-one error and this came up as a possible problem since worker state is modified (`nextLocalEventNumber` is incremented) for an event that may then be considered a duplicate. However, this doesn't actually ever happen (AFAICT) in practice when adding an event via a worker (the same function is used to add the genesis event without a worker), and if you force it to happen, it happily carries on without a problem. So this fix did not the solve the problem I was looking into.

Regardless, I think we should only be ignoring the duplicate when it is for the genesis event (a failed ledger node creation attempt occurred and we can try again later). I don't see any reason for a duplicate error to occur on an up and running node and we should throw if this happens instead of allowing potentially bad state (even if it doesn't seem fatal) to get into the system.