### PR TITLE
Update params to getHead to match next release of continuity-storage.

### DIFF
--- a/lib/worker/Worker.js
+++ b/lib/worker/Worker.js
@@ -488,7 +488,7 @@ module.exports = class Worker {
     const {ledgerNode} = this;
     const {getHead} = ledgerNode.storage.events.plugins['continuity-storage'];
     // FIXME: how to handle forks?
-    const records = await getHead({creatorId: peerId});
+    const records = await getHead({peerId});
     if(records.length > 0) {
       const [{
         event: {basisBlockHeight, mergeHeight, parentHashCommitment},

--- a/test/package.json
+++ b/test/package.json
@@ -20,7 +20,7 @@
     "bedrock-ledger-agent": "^4.0.0",
     "bedrock-ledger-consensus-continuity": "file:..",
     "bedrock-ledger-consensus-continuity-es-most-recent-participants": "^2.0.0",
-    "bedrock-ledger-consensus-continuity-storage": "^4.0.0",
+    "bedrock-ledger-consensus-continuity-storage": "digitalbazaar/bedrock-ledger-consensus-continuity-storage#update-event-summary-index",
     "bedrock-ledger-context": "^18.1.0",
     "bedrock-ledger-node": "^12.0.0",
     "bedrock-ledger-storage-mongodb": "^5.0.0",


### PR DESCRIPTION
- [x] tests are succeeding locally (62 passing 27 pending) running locally.


PR should be merged after changes on continuity-storage have been merged: https://github.com/digitalbazaar/bedrock-ledger-consensus-continuity-storage/pull/15