### PR TITLE
Use did:key DIDs as peer IDs.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,8 +3,14 @@
 ## 9.0.0 - TBD
 
 ### Changed
-- Changed `witnesses` from an `Array` to a `Set`.
 - **BREAKING**: Renamed `voters` to `peers` in various routes.
+- **BREAKING**: Converted peer IDs into `did:key` DIDs. While peer IDs and
+  peer service URLs had already been functionally separated in a previous
+  release, this may impact bootstrapping code that inserted the same value
+  for both a remote peer's ID and its service URL to peer databases. Ensure
+  that peer IDs (now did:key DIDs) and their service URLs (HTTPS) use
+  separate values.
+- Changed `witnesses` from an `Array` to a `Set`.
 - Move some internal functions to bedrock-ledger-consensus-continuity-storage.
 
 ### Removed

--- a/lib/client.js
+++ b/lib/client.js
@@ -9,6 +9,7 @@ const {httpClient} = require('@digitalbazaar/http-client');
 const https = require('https');
 const bedrock = require('bedrock');
 const {config, util: {BedrockError}} = bedrock;
+const {getLocalPeerUrl} = require('./localPeers');
 const LRU = require('lru-cache');
 const {pipeline} = require('stream');
 const split2 = require('split2');
@@ -106,7 +107,7 @@ exports.getHistory = async ({
     const {cause, httpStatusCode} = _processHTTPError(error);
     throw new BedrockError(
       'Could not get peer history.', 'NetworkError',
-      {httpStatusCode, localPeerId, remotePeerId}, cause);
+      {httpStatusCode, localPeerId, remotePeerId, url}, cause);
   }
   if(!res.data) {
     throw new BedrockError(
@@ -114,6 +115,7 @@ exports.getHistory = async ({
         httpStatusCode: res.status,
         localPeerId,
         remotePeerId,
+        url,
         public: true
       });
   }
@@ -126,9 +128,14 @@ exports.notifyPeer = async ({ledgerNodeId, remotePeer}) => {
   const url = `${remotePeer.url}/notify`;
   const {'ledger-consensus-continuity': {client: {timeout}}} = config;
   const key = await getKeyPair({ledgerNodeId});
+  const localPeerId = key.id.substr(0, key.id.indexOf('#'));
   // the peerId sent to the remote peer is the peerId of the local peer
-  // FIXME: send actual gossip URL instead of `localPeerId` twice
-  const json = {peer: {id: key.id, url: key.id}};
+  const json = {
+    peer: {
+      id: localPeerId,
+      url: getLocalPeerUrl({peerId: localPeerId})
+    }
+  };
   try {
     const headers = await signRequest({url, json, signer: key.signer()});
     await httpClient.post(url, {
@@ -141,7 +148,7 @@ exports.notifyPeer = async ({ledgerNodeId, remotePeer}) => {
     const {cause, httpStatusCode} = _processHTTPError(error);
     throw new BedrockError(
       'Could not send peer notification.', 'NetworkError',
-      {localPeerId: key.id, httpStatusCode, remotePeerId}, cause);
+      {localPeerId, httpStatusCode, remotePeerId}, cause);
   }
 };
 
@@ -216,19 +223,21 @@ exports.getValidationServiceUrl = ({localPeerId}) => {
     gossip: {eventsValidation}
   }} = config;
 
+  const localPeerUrl = getLocalPeerUrl({peerId: localPeerId});
+
   // events validation url is not set, use the node's localPeerId
   if(!eventsValidation.baseUrl) {
-    return localPeerId + '/events-validation';
+    return localPeerUrl + '/events-validation';
   }
 
-  const key = `${localPeerId}${eventsValidation.baseUrl}`;
+  const key = `${localPeerUrl}${eventsValidation.baseUrl}`;
 
   let eventsValidationUrl = EVENTS_VALIDATION_URL_CACHE.get(key);
   if(eventsValidationUrl) {
     return eventsValidationUrl;
   }
 
-  const url = new URL(localPeerId);
+  const url = new URL(localPeerUrl);
   eventsValidationUrl = eventsValidation.baseUrl +
     `${url.pathname}/events-validation`;
 

--- a/lib/localPeers.js
+++ b/lib/localPeers.js
@@ -12,7 +12,6 @@ const multibase = require('multibase');
 const {Ed25519VerificationKey2020} =
   require('@digitalbazaar/ed25519-verification-key-2020');
 const {LruCache} = require('@digitalbazaar/lru-memoize');
-const URL = require('url');
 
 require('./config');
 
@@ -108,6 +107,11 @@ api.getKeyPair = async ({ledgerNodeId}) => {
   return keyPair;
 };
 
+api.getLocalPeerUrl = ({peerId}) => {
+  return config.server.baseUri +
+    `/consensus/continuity2017/peers/${encodeURIComponent(peerId)}`;
+};
+
 api.getLedgerNodeId = async ({peerId}) => {
   return LOCAL_PEER_ID_CACHE.memoize({
     key: peerId,
@@ -123,12 +127,10 @@ api.getLedgerNodeId = async ({peerId}) => {
  * @return the base58-encoded public key.
  */
 api.getPublicKeyFromId = ({peerId}) => {
-  // FIXME: this is to be replaced by `did:key`
-  const parsed = URL.parse(peerId);
-  const last = parsed.pathname.split('/').pop();
+  // FIXME: use did-key driver instead or not worth it?
 
   // the public key is expected to be a multibase encoded multicodec value
-  const mbPubkey = last;
+  const mbPubkey = peerId.substr('did:key:'.length);
   const mcPubkeyBytes = multibase.decode(mbPubkey);
   const mcType = multicodec.getCodec(mcPubkeyBytes);
   if(mcType !== 'ed25519-pub') {
@@ -242,8 +244,7 @@ api.storage.get = async ({ledgerNodeId, peerId, keyPair = false}) => {
 
 async function _generateLocalPeer({ledgerNodeId}) {
   const kp = await Ed25519VerificationKey2020.generate();
-  const peerId = config.server.baseUri +
-    '/consensus/continuity2017/peers/' + encodeURIComponent(kp.fingerprint());
+  const peerId = `did:key:${kp.fingerprint()}`;
   const localPeer = {
     peerId,
     ledgerNodeId,

--- a/lib/server.js
+++ b/lib/server.js
@@ -41,10 +41,8 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
   app.post(
     routes.eventsQuery, validate('continuity-server.getEvents'),
     asyncHandler(async (req, res) => {
-      const localPeerId = `${config.server.baseUri}/consensus/continuity2017/` +
-        `peers/${encodeURIComponent(req.params.peerId)}`;
       const ledgerNodeId = await _localPeers.getLedgerNodeId(
-        {peerId: localPeerId});
+        {peerId: req.params.peerId});
       const {eventHash} = req.body;
       const events = await _events.getEventsForGossip(
         {eventHashes: eventHash, ledgerNodeId});
@@ -84,8 +82,6 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
     routes.gossip,
     validate('continuity-server.gossip'),
     asyncHandler(async (req, res) => {
-      const localPeerId = `${config.server.baseUri}/consensus/` +
-        `continuity2017/peers/${encodeURIComponent(req.params.peerId)}`;
       // `basisBlockHeight` is the last block that has reached consensus
       //   on the client
       // `localEventNumber` is optional, only present if the client knows
@@ -96,7 +92,7 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
       const {body: remoteInfo} = req;
       // return a partition of the DAG history appropriate for the request
       const ledgerNodeId = await _localPeers.getLedgerNodeId(
-        {peerId: localPeerId});
+        {peerId: req.params.peerId});
       const ledgerNode = await brLedgerNode.get(null, ledgerNodeId);
       const [result, samplePeers] = await Promise.all([
         _history.partition({ledgerNode, remoteInfo}),
@@ -115,8 +111,8 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
     routes.notify,
     validate('continuity-server.notification'),
     asyncHandler(async (req, res) => {
-      const {verified, keyId} = await _signature.verifyRequest({req});
-      if(!(verified && req.body.peer.id === keyId)) {
+      const {verified, peerId} = await _signature.verifyRequest({req});
+      if(!(verified && req.body.peer.id === peerId)) {
         return res.status(403).end();
       }
       // queue handling notification and immediately send response, do not
@@ -128,10 +124,8 @@ bedrock.events.on('bedrock-express.configure.routes', app => {
 
 async function _handleNotification({req}) {
   const {peer} = req.body;
-  const localPeerId = `${config.server.baseUri}/consensus/continuity2017/` +
-    `peers/${encodeURIComponent(req.params.peerId)}`;
-  const ledgerNodeId = await _localPeers.getLedgerNodeId(
-    {peerId: localPeerId});
+  const {peerId: localPeerId} = req.params;
+  const ledgerNodeId = await _localPeers.getLedgerNodeId({peerId: localPeerId});
   const ledgerNode = await brLedgerNode.get(null, ledgerNodeId);
   await _peers.addNotifier({ledgerNode, remotePeer: peer, localPeerId});
 }

--- a/lib/signature.js
+++ b/lib/signature.js
@@ -6,7 +6,7 @@
 const _ = require('lodash');
 const _localPeers = require('./localPeers');
 const bedrock = require('bedrock');
-const {config: {constants}, util: {BedrockError}} = bedrock;
+const {util: {BedrockError}} = bedrock;
 const jsigs = require('jsonld-signatures');
 const {
   parseRequest,
@@ -21,17 +21,14 @@ const {Ed25519VerificationKey2020} =
 const MergeEventEd25519Signature2020 = require(
   './MergeEventEd25519Signature2020');
 
-const {
-  // TODO: remove once tests are written
-  //suites: {Ed25519Signature2020},
-  purposes: {AssertionProofPurpose}
-} = jsigs;
+const {purposes: {AssertionProofPurpose}} = jsigs;
 
 exports.getKeyPair = async ({ledgerNodeId}) => {
   const localPeer = await _localPeers.getKeyPair({ledgerNodeId});
+  const fingerprint = localPeer.peerId.substr('did:key:'.length);
 
   return new Ed25519VerificationKey2020({
-    id: localPeer.peerId,
+    id: `${localPeer.peerId}#${fingerprint}`,
     publicKeyMultibase: localPeer.keyPair.publicKeyMultibase,
     privateKeyMultibase: localPeer.keyPair.privateKeyMultibase
   });
@@ -57,7 +54,8 @@ exports.sign = async ({event, ledgerNodeId}) => {
     suite: new MergeEventEd25519Signature2020({key}),
     purpose: new AssertionProofPurpose()
   });
-  return {signed, peerId: key.id};
+  const peerId = key.id.substr(0, key.id.indexOf('#'));
+  return {signed, peerId};
 };
 
 const COVERED_CONTENT = [
@@ -134,12 +132,16 @@ exports.signRequest = async ({
  */
 exports.verify = async ({event}) => {
   const {proof: {verificationMethod: publicKeyId}} = event;
+  const key = new Ed25519VerificationKey2020(_getPublicKey(publicKeyId));
   const controller = {
-    '@context': constants.SECURITY_CONTEXT_URL,
-    id: publicKeyId,
+    '@context': [
+      // FIXME: get did context URL from a constant
+      'https://www.w3.org/ns/did/v1',
+      Ed25519VerificationKey2020.SUITE_CONTEXT,
+    ],
+    id: key.controller,
     assertionMethod: publicKeyId,
   };
-  const key = new Ed25519VerificationKey2020(_getPublicKey(publicKeyId));
   const result = await jsigs.verify(event, {
     compactProof: false,
     documentLoader,
@@ -162,7 +164,7 @@ exports.verify = async ({event}) => {
       });
   }
 
-  return {controller: publicKeyId};
+  return {controller: key.controller};
 };
 
 /**
@@ -190,7 +192,10 @@ exports.verifyRequest = async ({req, expectedHeaders = COVERED_CONTENT}) => {
     const signature = Buffer.from(b64Signature, 'base64');
     // verify HTTP signature
     const verified = await verifier.verify({data, signature});
-    return {verified, keyId};
+    // Note: a proof purpose of `assertionMethod` is not checked here because
+    // the key is a did:key DID; which must support `assertionMethod` and
+    // use the same key for it
+    return {verified, keyId, peerId: key.controller};
   } catch(e) {
     throw new BedrockError(
       'Signature verification failed.', 'DataError',
@@ -199,12 +204,17 @@ exports.verifyRequest = async ({req, expectedHeaders = COVERED_CONTENT}) => {
 };
 
 function _getPublicKey(publicKeyId) {
-  const publicKeyMultibase = _localPeers.getPublicKeyFromId(
-    {peerId: publicKeyId});
+  // FIXME: use did-key resolver
+  const fragmentIdx = publicKeyId.indexOf('#');
+  if(!(publicKeyId.startsWith('did:key:') && fragmentIdx !== -1)) {
+    throw new Error('Public key must be a did:key key.');
+  }
+  const peerId = publicKeyId.substr(0, fragmentIdx);
+  const publicKeyMultibase = publicKeyId.substr(fragmentIdx + 1);
   return {
     id: publicKeyId,
     type: 'Ed25519VerificationKey2020',
-    controller: publicKeyId,
+    controller: peerId,
     publicKeyMultibase
   };
 }

--- a/test/mocha/050-client-api.js
+++ b/test/mocha/050-client-api.js
@@ -10,13 +10,16 @@ describe('Client API', () => {
   describe('notifyPeer', () => {
     let peerId = null;
     const ledgerNodeId = 'foo';
+    const remotePeerId =
+      'did:key:z6MkikAFvQGvzvunQcSma5jvUY41FkLJxrBomQPKPSWWX7kU';
     before(async () => {
       ({peerId} = await _localPeers.generate({ledgerNodeId}));
     });
     it('throws a NotFoundError if ledgerNodeId is not found', async () => {
       const remotePeer = {
-        id: 'https://127.0.0.1',
-        url: 'https://127.0.0.1'
+        id: remotePeerId,
+        url: 'https://127.0.0.1/consensus/continuity2017/peers/' +
+          encodeURIComponent(remotePeerId)
       };
       let err;
       try {
@@ -30,8 +33,9 @@ describe('Client API', () => {
 
     it('throws a NetworkError on connection refused', async () => {
       const remotePeer = {
-        id: 'https://127.0.0.1',
-        url: 'https://127.0.0.1'
+        id: remotePeerId,
+        url: 'https://127.0.0.1/consensus/continuity2017/peers/' +
+          encodeURIComponent(remotePeerId)
       };
       let err;
       try {
@@ -55,7 +59,7 @@ describe('Client API', () => {
     it('should notify peer', async () => {
       const remotePeer = {
         id: peerId,
-        url: peerId
+        url: _localPeers.getLocalPeerUrl(peerId)
       };
       let err;
       try {
@@ -71,12 +75,15 @@ describe('Client API', () => {
   });
 
   describe('getEvents', () => {
+    const remotePeerId =
+      'did:key:z6MkikAFvQGvzvunQcSma5jvUY41FkLJxrBomQPKPSWWX7kU';
     it('properly handles ECONNREFUSED', async () => {
       let error;
       try {
         const remotePeer = {
-          id: 'https://127.0.0.1:3333',
-          url: 'https://127.0.0.1:3333'
+          id: remotePeerId,
+          url: 'https://127.0.0.1:3333/consensus/continuity2017/peers/' +
+            encodeURIComponent(remotePeerId)
         };
         await _client.getEvents({eventHashes: ['abc'], remotePeer});
       } catch(e) {
@@ -91,8 +98,9 @@ describe('Client API', () => {
       let error;
       try {
         const remotePeer = {
-          id: config.server.baseUri,
-          url: config.server.baseUri
+          id: remotePeerId,
+          url: config.server.baseUri + '/consensus/continuity2017/peers/' +
+            encodeURIComponent(remotePeerId)
         };
         await _client.getEvents({eventHashes: ['abc'], remotePeer});
       } catch(e) {

--- a/test/mocha/090-multinode.js
+++ b/test/mocha/090-multinode.js
@@ -72,18 +72,21 @@ describe('Multinode', () => {
           continue;
         }
         // add genesis peer to the peer's peers collection
-        // FIXME: use proper URL do not just repeat ID
         const remotePeer = {
           id: genesisLedgerNode._peerId,
-          url: genesisLedgerNode._peerId
+          url: consensusApi._localPeers.getLocalPeerUrl(
+            {peerId: genesisLedgerNode._peerId})
         };
         await consensusApi._peers.optionallyAdd(
           {ledgerNode, remotePeer});
         // add new peer to genesis node
         await consensusApi._peers.optionallyAdd({
           ledgerNode: genesisLedgerNode,
-          // FIXME: use proper URL do not just repeat ID
-          remotePeer: {id: ledgerNode._peerId, url: ledgerNode._peerId}
+          remotePeer: {
+            id: ledgerNode._peerId,
+            url: consensusApi._localPeers.getLocalPeerUrl(
+              {peerId: ledgerNode._peerId})
+          }
         });
       }
     });
@@ -353,10 +356,10 @@ describe('Multinode', () => {
         });
         peers.push(ledgerNode);
         // add genesis peer to the peer's peers collection
-        // FIXME: use proper URL do not just repeat ID
         const remotePeer = {
           id: genesisLedgerNode._peerId,
-          url: genesisLedgerNode._peerId
+          url: consensusApi._localPeers.getLocalPeerUrl(
+            {peerId: genesisLedgerNode._peerId})
         };
         await consensusApi._peers.optionallyAdd(
           {ledgerNode, remotePeer});

--- a/test/mocha/091-basic-multinode.js
+++ b/test/mocha/091-basic-multinode.js
@@ -89,8 +89,11 @@ describe.skip('Multinode Basics', () => {
           continue;
         }
         // add genesis peer to the peer's peers collection
-        // FIXME: use proper URL do not just repeat ID
-        const remotePeer = {id: peers[0], url: peers[0]};
+        const remotePeer = {
+          id: peers[0],
+          url: consensusApi._localPeers.getLocalPeerUrl(
+            {peerId: peers[0]})
+        };
         await consensusApi._peers.optionallyAdd(
           {ledgerNode, remotePeer});
         i++;

--- a/test/mocha/092-xblock-multinode.js
+++ b/test/mocha/092-xblock-multinode.js
@@ -100,15 +100,21 @@ describe('X Block Test', () => {
           continue;
         }
         // add genesis peer to the peer's peers collection
-        // FIXME: use proper URL do not just repeat ID
-        const remotePeer = {id: peers.alpha, url: peers.alpha};
+        const remotePeer = {
+          id: peers.alpha,
+          url: consensusApi._localPeers.getLocalPeerUrl(
+            {peerId: peers.alpha})
+        };
         await consensusApi._peers.optionallyAdd(
           {ledgerNode, remotePeer});
         // add new peer to genesis node
         await consensusApi._peers.optionallyAdd({
           ledgerNode: nodes.alpha,
-          // FIXME: use proper URL do not just repeat ID
-          remotePeer: {id: ledgerNode._peerId, url: ledgerNode._peerId}
+          remotePeer: {
+            id: ledgerNode._peerId,
+            url: consensusApi._localPeers.getLocalPeerUrl(
+              {peerId: ledgerNode._peerId})
+          }
         });
       }
     });

--- a/test/mocha/093-xblock-nw-multinode.js
+++ b/test/mocha/093-xblock-nw-multinode.js
@@ -105,15 +105,21 @@ describe('X Block Test with non-witnesses', () => {
           continue;
         }
         // add genesis peer to the peer's peers collection
-        // FIXME: use proper URL do not just repeat ID
-        const remotePeer = {id: peers.alpha, url: peers.alpha};
+        const remotePeer = {
+          id: peers.alpha,
+          url: consensusApi._localPeers.getLocalPeerUrl(
+            {peerId: peers.alpha})
+        };
         await consensusApi._peers.optionallyAdd(
           {ledgerNode, remotePeer});
         // add new peer to genesis node
         await consensusApi._peers.optionallyAdd({
           ledgerNode: nodes.alpha,
-          // FIXME: use proper URL do not just repeat ID
-          remotePeer: {id: ledgerNode._peerId, url: ledgerNode._peerId}
+          remotePeer: {
+            id: ledgerNode._peerId,
+            url: consensusApi._localPeers.getLocalPeerUrl(
+              {peerId: ledgerNode._peerId})
+          }
         });
       }
     });

--- a/test/mocha/094-xblock-multinode-multiops.js
+++ b/test/mocha/094-xblock-multinode-multiops.js
@@ -100,15 +100,21 @@ describe('X Block Test multiple operations', () => {
           continue;
         }
         // add genesis peer to the peer's peers collection
-        // FIXME: use proper URL do not just repeat ID
-        const remotePeer = {id: peers.alpha, url: peers.alpha};
+        const remotePeer = {
+          id: peers.alpha,
+          url: consensusApi._localPeers.getLocalPeerUrl(
+            {peerId: peers.alpha})
+        };
         await consensusApi._peers.optionallyAdd(
           {ledgerNode, remotePeer});
         // add new peer to genesis node
         await consensusApi._peers.optionallyAdd({
           ledgerNode: nodes.alpha,
-          // FIXME: use proper URL do not just repeat ID
-          remotePeer: {id: ledgerNode._peerId, url: ledgerNode._peerId}
+          remotePeer: {
+            id: ledgerNode._peerId,
+            url: consensusApi._localPeers.getLocalPeerUrl(
+              {peerId: ledgerNode._peerId})
+          }
         });
       }
     });

--- a/test/mocha/095-xblock-ws-wp.js
+++ b/test/mocha/095-xblock-ws-wp.js
@@ -77,15 +77,21 @@ describe('X Block Test with witness pool and non-witnesses', () => {
           continue;
         }
         // add genesis peer to the peer's peers collection
-        // FIXME: use proper URL do not just repeat ID
-        const remotePeer = {id: peers.alpha, url: peers.alpha};
+        const remotePeer = {
+          id: peers.alpha,
+          url: consensusApi._localPeers.getLocalPeerUrl(
+            {peerId: peers.alpha})
+        };
         await consensusApi._peers.optionallyAdd(
           {ledgerNode, remotePeer});
         // add new peer to genesis node
         await consensusApi._peers.optionallyAdd({
           ledgerNode: nodes.alpha,
-          // FIXME: use proper URL do not just repeat ID
-          remotePeer: {id: ledgerNode._peerId, url: ledgerNode._peerId}
+          remotePeer: {
+            id: ledgerNode._peerId,
+            url: consensusApi._localPeers.getLocalPeerUrl(
+              {peerId: ledgerNode._peerId})
+          }
         });
       }
     });


### PR DESCRIPTION
This PR builds on top of PR #266.

It moves all peer IDs to did:key DIDs but does so with the simplest internal changes. Now peer IDs appear as did:key DIDs properly when presenting them to other peers and the internal implementation can be tightened up as needed. This includes improving validation for incoming peer IDs and potentially using a did key resolver library (or, if this is unnecessary, at least adding tests to confirm the current code behaves the same way as a did:key resolver).